### PR TITLE
Add SQLite graph database and wire pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,10 +4,12 @@ Builds a semantic artist graph from WXYC DJ transition data. DJs curate transiti
 
 ## Architecture
 
-Phase 0 is a batch pipeline that parses a tubafrenzy MySQL dump, extracts artist adjacency pairs from flowsheet data, computes PMI, and exports a GEXF graph for Gephi visualization.
+A batch pipeline that parses a tubafrenzy MySQL dump, extracts artist adjacency pairs from flowsheet data, computes PMI, and exports a GEXF graph and SQLite database.
 
 ```
 SQL dump → sql_parser → models → artist_resolver → adjacency → pmi → graph_export → GEXF
+                                                  → cross_reference →──────────────→ SQLite
+                                                  → node_attributes →──────────────→
 ```
 
 ### Modules
@@ -19,17 +21,55 @@ SQL dump → sql_parser → models → artist_resolver → adjacency → pmi →
 | `semantic_index/artist_resolver.py` | Tier 1 artist name resolution via catalog FK chain (LIBRARY_RELEASE → LIBRARY_CODE). |
 | `semantic_index/adjacency.py` | Extract consecutive artist pairs within radio shows. |
 | `semantic_index/pmi.py` | Compute Pointwise Mutual Information for artist co-occurrences. |
+| `semantic_index/node_attributes.py` | Extract and compute per-artist temporal, DJ, and request statistics. |
+| `semantic_index/cross_reference.py` | Extract cross-reference edges from catalog cross-reference tables. |
 | `semantic_index/graph_export.py` | Build NetworkX graph and export GEXF. |
-| `run_phase0.py` | CLI entry point wiring the pipeline. |
+| `semantic_index/sqlite_export.py` | Build and export SQLite graph database. |
+| `run_pipeline.py` | CLI entry point wiring the pipeline. |
 
 ### Column Mappings (0-indexed from SQL INSERT order)
 
 | Table | Key columns |
 |-------|------------|
-| FLOWSHEET_ENTRY_PROD | 0=ID, 1=ARTIST_NAME, 3=SONG_TITLE, 4=RELEASE_TITLE, 6=LIBRARY_RELEASE_ID, 8=LABEL_NAME, 12=RADIO_SHOW_ID, 13=SEQUENCE_WITHIN_SHOW, 15=FLOWSHEET_ENTRY_TYPE_CODE_ID |
+| FLOWSHEET_ENTRY_PROD | 0=ID, 1=ARTIST_NAME, 3=SONG_TITLE, 4=RELEASE_TITLE, 6=LIBRARY_RELEASE_ID, 8=LABEL_NAME, 10=START_TIME, 12=RADIO_SHOW_ID, 13=SEQUENCE_WITHIN_SHOW, 15=FLOWSHEET_ENTRY_TYPE_CODE_ID, 18=REQUEST_FLAG |
+| FLOWSHEET_RADIO_SHOW_PROD | 0=ID, 2=DJ_NAME, 3=DJ_ID |
 | LIBRARY_RELEASE | 0=ID, 8=LIBRARY_CODE_ID |
 | LIBRARY_CODE | 0=ID, 1=GENRE_ID, 7=PRESENTATION_NAME |
+| LIBRARY_CODE_CROSS_REFERENCE | 1=CROSS_REFERENCING_ARTIST_ID (→ LIBRARY_CODE.ID), 2=CROSS_REFERENCED_LIBRARY_CODE_ID, 3=COMMENT |
+| RELEASE_CROSS_REFERENCE | 1=CROSS_REFERENCING_ARTIST_ID (→ LIBRARY_CODE.ID), 2=CROSS_REFERENCED_RELEASE_ID, 3=COMMENT |
 | GENRE | 0=ID, 1=NAME |
+
+### SQLite Schema
+
+```sql
+CREATE TABLE artist (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    canonical_name TEXT NOT NULL UNIQUE,
+    genre TEXT,
+    total_plays INTEGER NOT NULL DEFAULT 0,
+    active_first_year INTEGER,
+    active_last_year INTEGER,
+    dj_count INTEGER NOT NULL DEFAULT 0,
+    request_ratio REAL NOT NULL DEFAULT 0.0,
+    show_count INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE dj_transition (
+    source_id INTEGER NOT NULL REFERENCES artist(id),
+    target_id INTEGER NOT NULL REFERENCES artist(id),
+    raw_count INTEGER NOT NULL,
+    pmi REAL NOT NULL,
+    PRIMARY KEY (source_id, target_id)
+);
+
+CREATE TABLE cross_reference (
+    artist_a_id INTEGER NOT NULL REFERENCES artist(id),
+    artist_b_id INTEGER NOT NULL REFERENCES artist(id),
+    comment TEXT,
+    source TEXT NOT NULL,
+    PRIMARY KEY (artist_a_id, artist_b_id, source)
+);
+```
 
 ## Development
 
@@ -59,8 +99,12 @@ pytest -m slow                  # needs production dump
 ## Usage
 
 ```bash
-python run_phase0.py /path/to/wxycmusic.sql [--output-dir output/] [--min-count 2]
+python run_pipeline.py /path/to/wxycmusic.sql [--output-dir output/] [--min-count 2]
 ```
+
+Output: `output/wxyc_artist_pmi.gexf` (Gephi graph) + `output/wxyc_artist_graph.db` (SQLite database).
+
+Use `--no-sqlite` to skip the SQLite export.
 
 ## Data
 

--- a/README.md
+++ b/README.md
@@ -7,21 +7,22 @@ Builds a semantic artist graph from WXYC DJ transition data. When DJs curate tra
 ```bash
 python -m venv .venv && source .venv/bin/activate
 pip install -e ".[dev]"
-python run_phase0.py /path/to/wxycmusic.sql
+python run_pipeline.py /path/to/wxycmusic.sql
 ```
 
-This parses the SQL dump, computes PMI for all artist co-occurrences, prints top-20 neighbors for well-known artists, and writes a GEXF graph to `output/`.
+This parses the SQL dump, computes PMI for all artist co-occurrences, extracts cross-reference edges from the catalog, and writes a GEXF graph + SQLite database to `output/`.
 
 ## Options
 
 ```
-python run_phase0.py <dump_path> [--output-dir DIR] [--min-count N]
+python run_pipeline.py <dump_path> [--output-dir DIR] [--min-count N] [--no-sqlite]
 ```
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--output-dir` | `output/` | Directory for GEXF output |
+| `--output-dir` | `output/` | Directory for output files |
 | `--min-count` | `2` | Minimum co-occurrence count for graph edges |
+| `--no-sqlite` | disabled | Skip SQLite database export |
 
 ## How it works
 
@@ -29,7 +30,8 @@ python run_phase0.py <dump_path> [--output-dir DIR] [--min-count N]
 2. **Resolve** artist names via the library catalog FK chain (LIBRARY_RELEASE → LIBRARY_CODE)
 3. **Extract** consecutive artist pairs within each radio show
 4. **Compute** PMI: `log2(P(a,b) / (P(a) * P(b)))` — high PMI means two artists appear together more than chance predicts
-5. **Export** a GEXF graph loadable in [Gephi](https://gephi.org/)
+5. **Extract** cross-reference edges from catalog tables (LIBRARY_CODE_CROSS_REFERENCE, RELEASE_CROSS_REFERENCE)
+6. **Export** a GEXF graph loadable in [Gephi](https://gephi.org/) and a SQLite database for querying
 
 ## Development
 
@@ -41,4 +43,4 @@ black --check .           # format check
 mypy .                    # type check
 ```
 
-See [CLAUDE.md](CLAUDE.md) for detailed development patterns and column mappings.
+See [CLAUDE.md](CLAUDE.md) for detailed development patterns, column mappings, and SQLite schema.

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-"""Phase 0 CLI: extract adjacency pairs from a tubafrenzy SQL dump and compute PMI.
+"""Pipeline CLI: extract adjacency pairs, cross-references, and PMI from a tubafrenzy SQL dump.
 
 Usage:
-    python run_phase0.py /path/to/wxycmusic.sql [--output-dir output/] [--min-count 2]
+    python run_pipeline.py /path/to/wxycmusic.sql [--output-dir output/] [--min-count 2]
 """
 
 import argparse
@@ -13,6 +13,7 @@ from pathlib import Path
 
 from semantic_index.adjacency import extract_adjacency_pairs
 from semantic_index.artist_resolver import ArtistResolver
+from semantic_index.cross_reference import CrossReferenceExtractor
 from semantic_index.graph_export import build_graph, export_gexf, print_top_neighbors
 from semantic_index.models import (
     FlowsheetEntry,
@@ -22,6 +23,7 @@ from semantic_index.models import (
 from semantic_index.node_attributes import compute_artist_stats
 from semantic_index.pmi import compute_pmi
 from semantic_index.sql_parser import iter_table_rows, load_table_rows
+from semantic_index.sqlite_export import export_sqlite
 
 log = logging.getLogger(__name__)
 
@@ -56,6 +58,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Minimum co-occurrence count for graph edges (default: 2)",
     )
     parser.add_argument("--verbose", "-v", action="store_true", help="Enable debug logging")
+    parser.add_argument("--no-sqlite", action="store_true", help="Skip SQLite database export")
     return parser.parse_args(argv)
 
 
@@ -178,10 +181,26 @@ def run(args: argparse.Namespace) -> None:
         resolved_entries, show_to_dj, GENRE_NAMES, genre_for_release=genre_for_release
     )
 
-    # 8. Print top neighbors for spotlight artists
+    # 9. Extract cross-reference edges
+    log.info("Extracting cross-reference edges...")
+    code_names = {c.id: c.presentation_name for c in codes}
+    release_to_code = {r.id: r.library_code_id for r in releases}
+    xref_extractor = CrossReferenceExtractor(codes=code_names, release_to_code=release_to_code)
+
+    lc_xref_rows = load_table_rows(dump_path, "LIBRARY_CODE_CROSS_REFERENCE")
+    lc_xrefs = xref_extractor.extract_library_code_xrefs(lc_xref_rows)
+    log.info("  %d library code cross-reference edges", len(lc_xrefs))
+
+    rel_xref_rows = load_table_rows(dump_path, "RELEASE_CROSS_REFERENCE")
+    rel_xrefs = xref_extractor.extract_release_xrefs(rel_xref_rows)
+    log.info("  %d release cross-reference edges", len(rel_xrefs))
+
+    xref_edges = lc_xrefs + rel_xrefs
+
+    # 10. Print top neighbors for spotlight artists
     print_top_neighbors(edges, SPOTLIGHT_ARTISTS, n=20)
 
-    # 9. Build graph and export
+    # 11. Build graph and export GEXF
     log.info("Building graph (min_count=%d)...", args.min_count)
     graph = build_graph(edges, artist_stats, min_count=args.min_count)
     log.info("  %d nodes, %d edges", graph.number_of_nodes(), graph.number_of_edges())
@@ -189,6 +208,19 @@ def run(args: argparse.Namespace) -> None:
     gexf_path = output_dir / "wxyc_artist_pmi.gexf"
     export_gexf(graph, str(gexf_path))
     log.info("GEXF written to %s", gexf_path)
+
+    # 12. Export SQLite database
+    sqlite_path = output_dir / "wxyc_artist_graph.db"
+    if not args.no_sqlite:
+        log.info("Exporting SQLite database...")
+        export_sqlite(
+            str(sqlite_path),
+            artist_stats=artist_stats,
+            pmi_edges=edges,
+            xref_edges=xref_edges,
+            min_count=args.min_count,
+        )
+        log.info("SQLite written to %s", sqlite_path)
 
     elapsed = time.time() - t0
     log.info("Done in %.1f seconds.", elapsed)
@@ -206,10 +238,13 @@ def run(args: argparse.Namespace) -> None:
     )
     print(f"  Unique artists:          {len(artist_stats):>12,}")
     print(f"  Adjacency pairs:         {len(pairs):>12,}")
-    print(f"  Unique edges:            {len(edges):>12,}")
+    print(f"  Unique PMI edges:        {len(edges):>12,}")
+    print(f"  Cross-ref edges:         {len(xref_edges):>12,}")
     print(f"  Graph nodes:             {graph.number_of_nodes():>12,}")
     print(f"  Graph edges:             {graph.number_of_edges():>12,}")
     print(f"  GEXF output:             {gexf_path}")
+    if not args.no_sqlite:
+        print(f"  SQLite output:           {sqlite_path}")
     print(f"  Elapsed:                 {elapsed:>11.1f}s")
 
 

--- a/semantic_index/sqlite_export.py
+++ b/semantic_index/sqlite_export.py
@@ -1,0 +1,155 @@
+"""Export the artist graph to a SQLite database.
+
+Creates an artist table with node attributes, a dj_transition table for
+PMI-weighted edges, and a cross_reference table for catalog cross-reference edges.
+"""
+
+import logging
+import sqlite3
+
+from semantic_index.models import ArtistStats, CrossReferenceEdge, PmiEdge
+
+logger = logging.getLogger(__name__)
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS artist (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    canonical_name TEXT NOT NULL UNIQUE,
+    genre TEXT,
+    total_plays INTEGER NOT NULL DEFAULT 0,
+    active_first_year INTEGER,
+    active_last_year INTEGER,
+    dj_count INTEGER NOT NULL DEFAULT 0,
+    request_ratio REAL NOT NULL DEFAULT 0.0,
+    show_count INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS dj_transition (
+    source_id INTEGER NOT NULL REFERENCES artist(id),
+    target_id INTEGER NOT NULL REFERENCES artist(id),
+    raw_count INTEGER NOT NULL,
+    pmi REAL NOT NULL,
+    PRIMARY KEY (source_id, target_id)
+);
+
+CREATE TABLE IF NOT EXISTS cross_reference (
+    artist_a_id INTEGER NOT NULL REFERENCES artist(id),
+    artist_b_id INTEGER NOT NULL REFERENCES artist(id),
+    comment TEXT,
+    source TEXT NOT NULL,
+    PRIMARY KEY (artist_a_id, artist_b_id, source)
+);
+
+CREATE INDEX IF NOT EXISTS idx_transition_source ON dj_transition(source_id, pmi DESC);
+CREATE INDEX IF NOT EXISTS idx_transition_target ON dj_transition(target_id, pmi DESC);
+CREATE INDEX IF NOT EXISTS idx_xref_a ON cross_reference(artist_a_id);
+CREATE INDEX IF NOT EXISTS idx_xref_b ON cross_reference(artist_b_id);
+"""
+
+
+def export_sqlite(
+    path: str,
+    artist_stats: dict[str, ArtistStats],
+    pmi_edges: list[PmiEdge],
+    xref_edges: list[CrossReferenceEdge],
+    min_count: int = 2,
+) -> None:
+    """Export the artist graph to a SQLite database.
+
+    Args:
+        path: Output path for the SQLite database file.
+        artist_stats: Per-artist statistics for the artist table.
+        pmi_edges: PMI-weighted DJ transition edges.
+        xref_edges: Cross-reference edges from the library catalog.
+        min_count: Minimum raw co-occurrence count for DJ transition edges.
+    """
+    conn = sqlite3.connect(path)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA foreign_keys=ON")
+
+    conn.executescript(_SCHEMA)
+
+    # Collect all artist names (from stats + cross-ref endpoints)
+    all_names: set[str] = set(artist_stats.keys())
+    for xref in xref_edges:
+        all_names.add(xref.artist_a)
+        all_names.add(xref.artist_b)
+
+    # Insert artists
+    artist_rows = []
+    for name in sorted(all_names):
+        stats = artist_stats.get(name)
+        if stats:
+            artist_rows.append(
+                (
+                    name,
+                    stats.genre,
+                    stats.total_plays,
+                    stats.active_first_year,
+                    stats.active_last_year,
+                    stats.dj_count,
+                    stats.request_ratio,
+                    stats.show_count,
+                )
+            )
+        else:
+            # Catalog-only artist (from cross-references, not in flowsheet)
+            artist_rows.append((name, None, 0, None, None, 0, 0.0, 0))
+
+    conn.executemany(
+        """
+        INSERT INTO artist (
+            canonical_name, genre, total_plays,
+            active_first_year, active_last_year,
+            dj_count, request_ratio, show_count
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        artist_rows,
+    )
+
+    # Build name → id mapping
+    name_to_id: dict[str, int] = {}
+    for row in conn.execute("SELECT id, canonical_name FROM artist"):
+        name_to_id[row[1]] = row[0]
+
+    # Insert DJ transition edges (filtered)
+    transition_rows = []
+    for edge in pmi_edges:
+        if edge.raw_count < min_count or edge.pmi <= 0:
+            continue
+        source_id = name_to_id.get(edge.source)
+        target_id = name_to_id.get(edge.target)
+        if source_id is not None and target_id is not None:
+            transition_rows.append((source_id, target_id, edge.raw_count, edge.pmi))
+
+    conn.executemany(
+        "INSERT INTO dj_transition (source_id, target_id, raw_count, pmi) VALUES (?, ?, ?, ?)",
+        transition_rows,
+    )
+
+    # Insert cross-reference edges
+    xref_rows = []
+    for xref in xref_edges:
+        a_id = name_to_id.get(xref.artist_a)
+        b_id = name_to_id.get(xref.artist_b)
+        if a_id is not None and b_id is not None:
+            xref_rows.append((a_id, b_id, xref.comment, xref.source))
+
+    conn.executemany(
+        "INSERT INTO cross_reference (artist_a_id, artist_b_id, comment, source) VALUES (?, ?, ?, ?)",
+        xref_rows,
+    )
+
+    conn.commit()
+
+    artist_count = conn.execute("SELECT COUNT(*) FROM artist").fetchone()[0]
+    transition_count = conn.execute("SELECT COUNT(*) FROM dj_transition").fetchone()[0]
+    xref_count = conn.execute("SELECT COUNT(*) FROM cross_reference").fetchone()[0]
+    logger.info(
+        "SQLite export: %d artists, %d DJ transitions, %d cross-references",
+        artist_count,
+        transition_count,
+        xref_count,
+    )
+
+    conn.close()

--- a/tests/integration/test_pipeline.py
+++ b/tests/integration/test_pipeline.py
@@ -43,7 +43,7 @@ def fixture_dump():
 class TestFullPipeline:
     def test_pipeline_runs_without_error(self, fixture_dump):
         """The full pipeline completes without exceptions on the fixture."""
-        from run_phase0 import main
+        from run_pipeline import main
 
         with tempfile.TemporaryDirectory() as tmpdir:
             main([fixture_dump, "--output-dir", tmpdir, "--min-count", "1"])
@@ -52,7 +52,7 @@ class TestFullPipeline:
         """The output GEXF file is valid XML loadable by NetworkX."""
         import networkx as nx
 
-        from run_phase0 import main
+        from run_pipeline import main
 
         with tempfile.TemporaryDirectory() as tmpdir:
             main([fixture_dump, "--output-dir", tmpdir, "--min-count", "1"])

--- a/tests/unit/test_sqlite_export.py
+++ b/tests/unit/test_sqlite_export.py
@@ -1,0 +1,202 @@
+"""Tests for SQLite graph database export."""
+
+import sqlite3
+import tempfile
+from pathlib import Path
+
+from semantic_index.models import ArtistStats, CrossReferenceEdge, PmiEdge
+from semantic_index.sqlite_export import export_sqlite
+
+
+def _export_and_connect(**kwargs) -> tuple[sqlite3.Connection, str]:
+    """Export to a temp SQLite file and return an open connection."""
+    path = tempfile.mktemp(suffix=".db")
+    export_sqlite(path, **kwargs)
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    return conn, path
+
+
+class TestSchemaCreation:
+    def test_tables_exist(self):
+        conn, _ = _export_and_connect(artist_stats={}, pmi_edges=[], xref_edges=[])
+        tables = {
+            row[0]
+            for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
+        }
+        assert "artist" in tables
+        assert "dj_transition" in tables
+        assert "cross_reference" in tables
+
+    def test_indexes_exist(self):
+        conn, _ = _export_and_connect(artist_stats={}, pmi_edges=[], xref_edges=[])
+        indexes = {
+            row[0]
+            for row in conn.execute("SELECT name FROM sqlite_master WHERE type='index'").fetchall()
+        }
+        assert "idx_transition_source" in indexes
+        assert "idx_transition_target" in indexes
+        assert "idx_xref_a" in indexes
+        assert "idx_xref_b" in indexes
+
+
+class TestArtistInsertion:
+    def test_artists_inserted_with_all_attributes(self):
+        stats = {
+            "Autechre": ArtistStats(
+                canonical_name="Autechre",
+                total_plays=50,
+                genre="Electronic",
+                active_first_year=2004,
+                active_last_year=2025,
+                dj_count=15,
+                request_ratio=0.1,
+                show_count=40,
+            ),
+        }
+        conn, _ = _export_and_connect(artist_stats=stats, pmi_edges=[], xref_edges=[])
+        row = conn.execute("SELECT * FROM artist WHERE canonical_name = 'Autechre'").fetchone()
+        assert row is not None
+        assert row["total_plays"] == 50
+        assert row["genre"] == "Electronic"
+        assert row["active_first_year"] == 2004
+        assert row["active_last_year"] == 2025
+        assert row["dj_count"] == 15
+        assert abs(row["request_ratio"] - 0.1) < 1e-6
+        assert row["show_count"] == 40
+
+    def test_multiple_artists(self):
+        stats = {
+            "Autechre": ArtistStats(canonical_name="Autechre", total_plays=50),
+            "Stereolab": ArtistStats(canonical_name="Stereolab", total_plays=30),
+        }
+        conn, _ = _export_and_connect(artist_stats=stats, pmi_edges=[], xref_edges=[])
+        count = conn.execute("SELECT COUNT(*) FROM artist").fetchone()[0]
+        assert count == 2
+
+    def test_null_genre(self):
+        stats = {"A": ArtistStats(canonical_name="A", total_plays=1, genre=None)}
+        conn, _ = _export_and_connect(artist_stats=stats, pmi_edges=[], xref_edges=[])
+        row = conn.execute("SELECT genre FROM artist WHERE canonical_name = 'A'").fetchone()
+        assert row["genre"] is None
+
+
+class TestPmiEdgeInsertion:
+    def test_edges_inserted(self):
+        stats = {
+            "A": ArtistStats(canonical_name="A", total_plays=10),
+            "B": ArtistStats(canonical_name="B", total_plays=5),
+        }
+        edges = [PmiEdge(source="A", target="B", raw_count=5, pmi=3.0)]
+        conn, _ = _export_and_connect(
+            artist_stats=stats, pmi_edges=edges, xref_edges=[], min_count=1
+        )
+        row = conn.execute("SELECT * FROM dj_transition").fetchone()
+        assert row is not None
+        assert row["raw_count"] == 5
+        assert abs(row["pmi"] - 3.0) < 1e-6
+
+    def test_min_count_filters_edges(self):
+        stats = {
+            "A": ArtistStats(canonical_name="A", total_plays=10),
+            "B": ArtistStats(canonical_name="B", total_plays=5),
+        }
+        edges = [PmiEdge(source="A", target="B", raw_count=1, pmi=0.5)]
+        conn, _ = _export_and_connect(
+            artist_stats=stats, pmi_edges=edges, xref_edges=[], min_count=2
+        )
+        count = conn.execute("SELECT COUNT(*) FROM dj_transition").fetchone()[0]
+        assert count == 0
+
+    def test_negative_pmi_filtered(self):
+        stats = {
+            "A": ArtistStats(canonical_name="A", total_plays=10),
+            "B": ArtistStats(canonical_name="B", total_plays=5),
+        }
+        edges = [PmiEdge(source="A", target="B", raw_count=5, pmi=-1.0)]
+        conn, _ = _export_and_connect(
+            artist_stats=stats, pmi_edges=edges, xref_edges=[], min_count=1
+        )
+        count = conn.execute("SELECT COUNT(*) FROM dj_transition").fetchone()[0]
+        assert count == 0
+
+    def test_query_neighbors_by_name(self):
+        stats = {
+            "A": ArtistStats(canonical_name="A", total_plays=10),
+            "B": ArtistStats(canonical_name="B", total_plays=5),
+            "C": ArtistStats(canonical_name="C", total_plays=3),
+        }
+        edges = [
+            PmiEdge(source="A", target="B", raw_count=5, pmi=3.0),
+            PmiEdge(source="A", target="C", raw_count=2, pmi=1.0),
+        ]
+        conn, _ = _export_and_connect(
+            artist_stats=stats, pmi_edges=edges, xref_edges=[], min_count=1
+        )
+        rows = conn.execute(
+            """
+            SELECT a2.canonical_name, dt.pmi
+            FROM dj_transition dt
+            JOIN artist a1 ON dt.source_id = a1.id
+            JOIN artist a2 ON dt.target_id = a2.id
+            WHERE a1.canonical_name = 'A'
+            ORDER BY dt.pmi DESC
+            """,
+        ).fetchall()
+        assert len(rows) == 2
+        assert rows[0]["canonical_name"] == "B"
+        assert rows[1]["canonical_name"] == "C"
+
+
+class TestCrossReferenceInsertion:
+    def test_xref_edges_inserted(self):
+        stats = {
+            "A": ArtistStats(canonical_name="A", total_plays=10),
+            "B": ArtistStats(canonical_name="B", total_plays=5),
+        }
+        xrefs = [
+            CrossReferenceEdge(
+                artist_a="A", artist_b="B", comment="See also", source="library_code"
+            )
+        ]
+        conn, _ = _export_and_connect(artist_stats=stats, pmi_edges=[], xref_edges=xrefs)
+        row = conn.execute("SELECT * FROM cross_reference").fetchone()
+        assert row is not None
+        assert row["comment"] == "See also"
+        assert row["source"] == "library_code"
+
+    def test_catalog_only_artists_created(self):
+        """Cross-ref edges may reference artists not in flowsheet data."""
+        stats = {"A": ArtistStats(canonical_name="A", total_plays=10)}
+        xrefs = [
+            CrossReferenceEdge(
+                artist_a="A", artist_b="CatalogOnly", comment="", source="library_code"
+            )
+        ]
+        conn, _ = _export_and_connect(artist_stats=stats, pmi_edges=[], xref_edges=xrefs)
+        row = conn.execute("SELECT * FROM artist WHERE canonical_name = 'CatalogOnly'").fetchone()
+        assert row is not None
+        assert row["total_plays"] == 0
+
+    def test_xref_count(self):
+        stats = {
+            "A": ArtistStats(canonical_name="A", total_plays=10),
+            "B": ArtistStats(canonical_name="B", total_plays=5),
+            "C": ArtistStats(canonical_name="C", total_plays=3),
+        }
+        xrefs = [
+            CrossReferenceEdge(artist_a="A", artist_b="B", comment="", source="library_code"),
+            CrossReferenceEdge(artist_a="B", artist_b="C", comment="", source="release"),
+        ]
+        conn, _ = _export_and_connect(artist_stats=stats, pmi_edges=[], xref_edges=xrefs)
+        count = conn.execute("SELECT COUNT(*) FROM cross_reference").fetchone()[0]
+        assert count == 2
+
+
+class TestRoundtrip:
+    def test_file_created_and_nonempty(self):
+        stats = {"A": ArtistStats(canonical_name="A", total_plays=1)}
+        path = tempfile.mktemp(suffix=".db")
+        export_sqlite(path, artist_stats=stats, pmi_edges=[], xref_edges=[])
+        assert Path(path).exists()
+        assert Path(path).stat().st_size > 0


### PR DESCRIPTION
## Summary

- Add `sqlite_export.py` module: persists artist graph to SQLite with `artist`, `dj_transition`, and `cross_reference` tables
- Rename `run_phase0.py` → `run_pipeline.py` (via `git mv`)
- Wire cross-reference extraction (from PR #27) and SQLite export into the pipeline
- Add `--no-sqlite` flag to skip SQLite export
- Update CLAUDE.md with new modules, column mappings, and full SQLite schema
- Update README.md with new usage and output files
- 13 new unit tests for SQLite export (schema, insertion, filtering, querying, roundtrip)

Closes #28

## Test plan

- [x] 103 unit tests pass (90 existing + 13 new)
- [x] ruff, black, mypy all clean
- [ ] CI passes
- [ ] `python run_pipeline.py /path/to/wxycmusic.sql` produces GEXF + SQLite in `output/`
- [ ] `sqlite3 output/wxyc_artist_graph.db "SELECT * FROM artist LIMIT 5"` returns rows with all attributes