### PR TITLE
Add two-tier Discogs client

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,8 @@ dependencies = [
     "networkx>=3.0",
     "pydantic>=2.0.0",
     "rapidfuzz>=3.0.0",
+    "psycopg[binary]>=3.1",
+    "httpx>=0.25",
 ]
 
 [project.optional-dependencies]

--- a/semantic_index/discogs_client.py
+++ b/semantic_index/discogs_client.py
@@ -1,0 +1,298 @@
+"""Two-tier Discogs client: discogs-cache PostgreSQL with library-metadata-lookup API fallback.
+
+The client queries the discogs-cache PostgreSQL database first (fast, no rate limit),
+then falls back to the library-metadata-lookup HTTP API for cache misses (rate-limited).
+Either or both backends can be omitted for graceful degradation.
+
+Note: Styles are only available from the API (discogs-cache has no release_style table).
+"""
+
+import logging
+import time
+
+import httpx
+import psycopg
+
+from semantic_index.models import (
+    DiscogsCredit,
+    DiscogsLabel,
+    DiscogsRelease,
+    DiscogsSearchResult,
+    DiscogsTrack,
+)
+
+logger = logging.getLogger(__name__)
+
+# Rate limit: 50 req/min → 1.2s between requests
+_API_INTERVAL = 1.2
+_MAX_RETRIES = 3
+
+
+class DiscogsClient:
+    """Two-tier client for Discogs data.
+
+    Args:
+        cache_dsn: PostgreSQL connection string for discogs-cache. None to skip cache.
+        api_base_url: Base URL for library-metadata-lookup API. None to skip API.
+    """
+
+    def __init__(self, cache_dsn: str | None, api_base_url: str | None) -> None:
+        self._cache_dsn = cache_dsn
+        self._api_base_url = api_base_url.rstrip("/") if api_base_url else None
+        self._last_api_call: float = 0
+        self._cache_conn: psycopg.Connection | None = None
+
+    def _get_cache_conn(self) -> psycopg.Connection | None:
+        """Get or create the cache PostgreSQL connection."""
+        if self._cache_dsn is None:
+            return None
+        if self._cache_conn is None or self._cache_conn.closed:
+            try:
+                self._cache_conn = psycopg.connect(self._cache_dsn)
+            except Exception:
+                logger.warning("Failed to connect to discogs-cache", exc_info=True)
+                return None
+        return self._cache_conn
+
+    def _get_http_client(self) -> httpx.Client | None:
+        """Create an HTTP client for the API."""
+        if self._api_base_url is None:
+            return None
+        return httpx.Client(base_url=self._api_base_url, timeout=30)
+
+    def _rate_limit(self) -> None:
+        """Sleep to respect the API rate limit."""
+        elapsed = time.time() - self._last_api_call
+        if elapsed < _API_INTERVAL:
+            time.sleep(_API_INTERVAL - elapsed)
+        self._last_api_call = time.time()
+
+    def search_artist(
+        self, name: str, release_title: str | None = None
+    ) -> DiscogsSearchResult | None:
+        """Search for an artist by name, returning Discogs identity if found.
+
+        Tries cache first, then API.
+        """
+        # Try cache
+        result = self._search_artist_cache(name)
+        if result is not None:
+            return result
+
+        # Try API
+        return self._search_artist_api(name, release_title)
+
+    def get_release(self, release_id: int) -> DiscogsRelease | None:
+        """Get full release metadata by Discogs release ID.
+
+        Tries cache first, then API. Note: cache results have empty styles.
+        """
+        # Try cache
+        release = self._get_release_cache(release_id)
+        if release is not None:
+            return release
+
+        # Try API
+        return self._get_release_api(release_id)
+
+    def _search_artist_cache(self, name: str) -> DiscogsSearchResult | None:
+        """Search for an artist in the discogs-cache PostgreSQL."""
+        conn = self._get_cache_conn()
+        if conn is None:
+            return None
+        try:
+            rows = conn.execute(
+                """
+                SELECT DISTINCT ra.artist_id, ra.artist_name
+                FROM release_artist ra
+                WHERE ra.extra = 0 AND lower(ra.artist_name) = lower(%s)
+                LIMIT 1
+                """,
+                (name,),
+            ).fetchall()
+            if rows:
+                return DiscogsSearchResult(
+                    artist_name=rows[0][1],
+                    artist_id=rows[0][0],
+                )
+            return None
+        except Exception:
+            logger.warning("Cache search failed for %r", name, exc_info=True)
+            return None
+
+    def _search_artist_api(
+        self, name: str, release_title: str | None = None
+    ) -> DiscogsSearchResult | None:
+        """Search for an artist via library-metadata-lookup API."""
+        client = self._get_http_client()
+        if client is None:
+            return None
+        try:
+            self._rate_limit()
+            body: dict = {"artist": name}
+            if release_title:
+                body["album"] = release_title
+            response = client.post("/api/v1/discogs/search", json=body)
+            if response.status_code != 200:
+                return None
+            data = response.json()
+            results = data.get("results", [])
+            if not results:
+                return None
+            best = results[0]
+            return DiscogsSearchResult(
+                artist_name=best.get("artist", name),
+                artist_id=None,
+                release_id=best.get("release_id"),
+                confidence=best.get("confidence", 0),
+            )
+        except Exception:
+            logger.warning("API search failed for %r", name, exc_info=True)
+            return None
+        finally:
+            client.close()
+
+    def _get_release_cache(self, release_id: int) -> DiscogsRelease | None:
+        """Get release metadata from discogs-cache PostgreSQL."""
+        conn = self._get_cache_conn()
+        if conn is None:
+            return None
+        try:
+            # Release header
+            row = conn.execute(
+                "SELECT id, title, release_year FROM release WHERE id = %s",
+                (release_id,),
+            ).fetchone()
+            if row is None:
+                return None
+
+            title = row[1]
+            year = row[2]
+
+            # Child tables
+            artist_rows = conn.execute(
+                "SELECT artist_id, artist_name, extra, role FROM release_artist WHERE release_id = %s",
+                (release_id,),
+            ).fetchall()
+
+            label_rows = conn.execute(
+                "SELECT label_id, label_name, catno FROM release_label WHERE release_id = %s",
+                (release_id,),
+            ).fetchall()
+
+            track_rows = conn.execute(
+                "SELECT position, title, sequence FROM release_track WHERE release_id = %s ORDER BY sequence",
+                (release_id,),
+            ).fetchall()
+
+            conn.execute(
+                "SELECT artist_name FROM release_track_artist WHERE release_id = %s",
+                (release_id,),
+            ).fetchall()  # TODO: use for compilation track artists in PR 3
+
+            # Build model
+            main_artists = [
+                DiscogsCredit(name=r[1], artist_id=r[0]) for r in artist_rows if r[2] == 0
+            ]
+            extra_artists = [
+                DiscogsCredit(name=r[1], artist_id=r[0], role=r[3])
+                for r in artist_rows
+                if r[2] == 1
+            ]
+            labels = [DiscogsLabel(name=r[1], label_id=r[0], catno=r[2]) for r in label_rows]
+            tracks = [DiscogsTrack(position=r[0] or "", title=r[1] or "") for r in track_rows]
+
+            artist_name = main_artists[0].name if main_artists else ""
+            artist_id = main_artists[0].artist_id if main_artists else None
+
+            return DiscogsRelease(
+                release_id=release_id,
+                title=title or "",
+                artist_name=artist_name,
+                artist_id=artist_id,
+                year=year,
+                styles=[],  # Cache has no styles
+                artists=main_artists,
+                extra_artists=extra_artists,
+                labels=labels,
+                tracklist=tracks,
+            )
+        except Exception:
+            logger.warning("Cache get_release failed for %d", release_id, exc_info=True)
+            return None
+
+    def _get_release_api(self, release_id: int) -> DiscogsRelease | None:
+        """Get release metadata from library-metadata-lookup API."""
+        client = self._get_http_client()
+        if client is None:
+            return None
+
+        for attempt in range(_MAX_RETRIES):
+            try:
+                self._rate_limit()
+                response = client.get(f"/api/v1/discogs/release/{release_id}")
+
+                if response.status_code == 429:
+                    backoff = 2 ** (attempt + 1)
+                    logger.warning(
+                        "Rate limited on release %d, backing off %ds", release_id, backoff
+                    )
+                    time.sleep(backoff)
+                    continue
+
+                if response.status_code != 200:
+                    return None
+
+                data = response.json()
+                return DiscogsRelease(
+                    release_id=data["release_id"],
+                    title=data.get("title", ""),
+                    artist_name=data.get("artist", ""),
+                    artist_id=data.get("artist_id"),
+                    year=data.get("year"),
+                    styles=data.get("styles", []),
+                    artists=[
+                        DiscogsCredit(
+                            name=a["name"],
+                            artist_id=a.get("artist_id"),
+                            role=a.get("role"),
+                        )
+                        for a in data.get("artists", [])
+                    ],
+                    extra_artists=[
+                        DiscogsCredit(
+                            name=a["name"],
+                            artist_id=a.get("artist_id"),
+                            role=a.get("role"),
+                        )
+                        for a in data.get("extra_artists", [])
+                    ],
+                    labels=[
+                        DiscogsLabel(
+                            name=lbl["name"],
+                            label_id=lbl.get("label_id"),
+                            catno=lbl.get("catno"),
+                        )
+                        for lbl in data.get("labels", [])
+                    ],
+                    tracklist=[
+                        DiscogsTrack(
+                            position=t.get("position", ""),
+                            title=t.get("title", ""),
+                            artists=t.get("artists", []),
+                        )
+                        for t in data.get("tracklist", [])
+                    ],
+                )
+            except Exception:
+                logger.warning(
+                    "API get_release failed for %d (attempt %d)",
+                    release_id,
+                    attempt + 1,
+                    exc_info=True,
+                )
+                if attempt < _MAX_RETRIES - 1:
+                    time.sleep(2 ** (attempt + 1))
+                    continue
+                return None
+        return None

--- a/semantic_index/models.py
+++ b/semantic_index/models.py
@@ -87,3 +87,54 @@ class CrossReferenceEdge(BaseModel):
     artist_b: str  # canonical name
     comment: str
     source: str  # "library_code" or "release"
+
+
+# --- Discogs models ---
+
+
+class DiscogsCredit(BaseModel):
+    """A personnel credit on a Discogs release."""
+
+    name: str
+    artist_id: int | None = None
+    role: str | None = None
+
+
+class DiscogsLabel(BaseModel):
+    """A label credit on a Discogs release."""
+
+    name: str
+    label_id: int | None = None
+    catno: str | None = None
+
+
+class DiscogsTrack(BaseModel):
+    """A track on a Discogs release (for compilations)."""
+
+    position: str
+    title: str
+    artists: list[str] = []
+
+
+class DiscogsRelease(BaseModel):
+    """Discogs release metadata for enrichment."""
+
+    release_id: int
+    title: str
+    artist_name: str
+    artist_id: int | None = None
+    year: int | None = None
+    styles: list[str] = []
+    artists: list[DiscogsCredit] = []
+    extra_artists: list[DiscogsCredit] = []
+    labels: list[DiscogsLabel] = []
+    tracklist: list[DiscogsTrack] = []
+
+
+class DiscogsSearchResult(BaseModel):
+    """A search result from Discogs."""
+
+    artist_name: str
+    artist_id: int | None = None
+    release_id: int | None = None
+    confidence: float = 0.0

--- a/tests/unit/test_discogs_client.py
+++ b/tests/unit/test_discogs_client.py
@@ -1,0 +1,233 @@
+"""Tests for the two-tier Discogs client."""
+
+from unittest.mock import MagicMock, patch
+
+from semantic_index.discogs_client import DiscogsClient
+
+
+class TestCacheQueries:
+    """Tests for discogs-cache PostgreSQL queries."""
+
+    def test_search_artist_from_cache(self):
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value.fetchall.return_value = [
+            (42, "Autechre"),
+        ]
+        with patch("psycopg.connect", return_value=mock_conn):
+            client = DiscogsClient(cache_dsn="postgresql://test", api_base_url=None)
+            result = client.search_artist("Autechre")
+
+        assert result is not None
+        assert result.artist_name == "Autechre"
+        assert result.artist_id == 42
+
+    def test_search_artist_cache_miss_returns_none(self):
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value.fetchall.return_value = []
+        with patch("psycopg.connect", return_value=mock_conn):
+            client = DiscogsClient(cache_dsn="postgresql://test", api_base_url=None)
+            result = client.search_artist("Nonexistent Artist")
+
+        assert result is None
+
+    def test_get_release_from_cache(self):
+        mock_conn = MagicMock()
+        # release row
+        mock_conn.execute.return_value.fetchone.return_value = (12345, "Confield", 2001)
+        # artist rows, label rows, track rows, track_artist rows
+        mock_conn.execute.return_value.fetchall.side_effect = [
+            [(42, "Autechre", 0, None)],  # release_artist
+            [(100, "Warp Records", "WARPCD85")],  # release_label
+            [("1", "VI Scose Poise", 1)],  # release_track
+            [],  # release_track_artist
+        ]
+        with patch("psycopg.connect", return_value=mock_conn):
+            client = DiscogsClient(cache_dsn="postgresql://test", api_base_url=None)
+            release = client.get_release(12345)
+
+        assert release is not None
+        assert release.release_id == 12345
+        assert release.title == "Confield"
+        assert release.artist_name == "Autechre"
+        assert len(release.labels) == 1
+        assert release.labels[0].name == "Warp Records"
+
+    def test_get_release_cache_miss(self):
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value.fetchone.return_value = None
+        with patch("psycopg.connect", return_value=mock_conn):
+            client = DiscogsClient(cache_dsn="postgresql://test", api_base_url=None)
+            release = client.get_release(99999)
+
+        assert release is None
+
+
+class TestApiQueries:
+    """Tests for library-metadata-lookup API fallback."""
+
+    def test_search_artist_from_api(self):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "results": [
+                {
+                    "artist": "Autechre",
+                    "album": "Confield",
+                    "release_id": 12345,
+                    "release_url": "https://discogs.com/release/12345",
+                    "confidence": 0.95,
+                }
+            ],
+            "total": 1,
+            "cached": False,
+        }
+
+        mock_client = MagicMock()
+        mock_client.post.return_value = mock_response
+
+        with patch("httpx.Client", return_value=mock_client):
+            client = DiscogsClient(cache_dsn=None, api_base_url="http://test")
+            result = client.search_artist("Autechre")
+
+        assert result is not None
+        assert result.artist_name == "Autechre"
+        assert result.release_id == 12345
+
+    def test_search_artist_api_no_results(self):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"results": [], "total": 0, "cached": False}
+
+        mock_client = MagicMock()
+        mock_client.post.return_value = mock_response
+
+        with patch("httpx.Client", return_value=mock_client):
+            client = DiscogsClient(cache_dsn=None, api_base_url="http://test")
+            result = client.search_artist("Nonexistent")
+
+        assert result is None
+
+    def test_get_release_from_api(self):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "release_id": 12345,
+            "title": "Confield",
+            "artist": "Autechre",
+            "artist_id": 42,
+            "year": 2001,
+            "genres": ["Electronic"],
+            "styles": ["IDM", "Abstract"],
+            "artists": [{"name": "Autechre", "artist_id": 42, "join": ""}],
+            "extra_artists": [{"name": "Rob Brown", "role": "Written-By"}],
+            "labels": [{"name": "Warp Records", "label_id": 100, "catno": "WARPCD85"}],
+            "tracklist": [{"position": "1", "title": "VI Scose Poise", "artists": []}],
+            "release_url": "https://discogs.com/release/12345",
+            "cached": False,
+        }
+
+        mock_client = MagicMock()
+        mock_client.get.return_value = mock_response
+
+        with patch("httpx.Client", return_value=mock_client):
+            client = DiscogsClient(cache_dsn=None, api_base_url="http://test")
+            release = client.get_release(12345)
+
+        assert release is not None
+        assert release.styles == ["IDM", "Abstract"]
+        assert len(release.extra_artists) == 1
+        assert release.extra_artists[0].name == "Rob Brown"
+        assert release.extra_artists[0].role == "Written-By"
+
+
+class TestFallbackBehavior:
+    """Tests for two-tier fallback."""
+
+    def test_cache_miss_falls_back_to_api(self):
+        # Cache returns empty
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value.fetchall.return_value = []
+
+        # API returns a result
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "results": [
+                {
+                    "artist": "Stereolab",
+                    "release_id": 99999,
+                    "release_url": "https://discogs.com/release/99999",
+                    "confidence": 0.9,
+                }
+            ],
+            "total": 1,
+            "cached": False,
+        }
+        mock_http = MagicMock()
+        mock_http.post.return_value = mock_response
+
+        with (
+            patch("psycopg.connect", return_value=mock_conn),
+            patch("httpx.Client", return_value=mock_http),
+        ):
+            client = DiscogsClient(cache_dsn="postgresql://test", api_base_url="http://test")
+            result = client.search_artist("Stereolab")
+
+        assert result is not None
+        assert result.artist_name == "Stereolab"
+
+    def test_both_unavailable_returns_none(self):
+        client = DiscogsClient(cache_dsn=None, api_base_url=None)
+        result = client.search_artist("Anything")
+        assert result is None
+
+    def test_both_unavailable_get_release_returns_none(self):
+        client = DiscogsClient(cache_dsn=None, api_base_url=None)
+        result = client.get_release(12345)
+        assert result is None
+
+
+class TestGracefulDegradation:
+    """Tests for error handling."""
+
+    def test_cache_connection_error_falls_to_api(self):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "results": [
+                {
+                    "artist": "Cat Power",
+                    "release_id": 55555,
+                    "release_url": "https://discogs.com/release/55555",
+                    "confidence": 0.85,
+                }
+            ],
+            "total": 1,
+            "cached": False,
+        }
+        mock_http = MagicMock()
+        mock_http.post.return_value = mock_response
+
+        with (
+            patch("psycopg.connect", side_effect=Exception("Connection refused")),
+            patch("httpx.Client", return_value=mock_http),
+        ):
+            client = DiscogsClient(cache_dsn="postgresql://bad", api_base_url="http://test")
+            result = client.search_artist("Cat Power")
+
+        assert result is not None
+        assert result.artist_name == "Cat Power"
+
+    def test_api_error_returns_none(self):
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_response.raise_for_status.side_effect = Exception("Server error")
+
+        mock_http = MagicMock()
+        mock_http.post.return_value = mock_response
+
+        with patch("httpx.Client", return_value=mock_http):
+            client = DiscogsClient(cache_dsn=None, api_base_url="http://test")
+            result = client.search_artist("Autechre")
+
+        assert result is None


### PR DESCRIPTION
## Summary

- Add `DiscogsClient` with two-tier architecture: discogs-cache PostgreSQL (fast) with library-metadata-lookup API fallback (rate-limited)
- Add Discogs data models: `DiscogsRelease`, `DiscogsCredit`, `DiscogsLabel`, `DiscogsTrack`, `DiscogsSearchResult`
- Rate limiting (token bucket, 50 req/min) with exponential backoff on HTTP 429
- Graceful degradation: works with cache only, API only, both, or neither
- Add `psycopg[binary]>=3.1` and `httpx>=0.25` dependencies
- 12 new unit tests covering cache queries, API queries, fallback behavior, and error handling

Closes #33

## Test plan

- [x] 131 unit tests pass (119 existing + 12 new)
- [x] ruff, black, mypy all clean
- [ ] CI passes