### PR TITLE
Add Discogs enrichment module

### DIFF
--- a/semantic_index/discogs_client.py
+++ b/semantic_index/discogs_client.py
@@ -95,6 +95,34 @@ class DiscogsClient:
         # Try API
         return self._get_release_api(release_id)
 
+    def get_releases_for_artist(self, artist_name: str) -> list[int]:
+        """Get release IDs for an artist from the cache.
+
+        Args:
+            artist_name: The artist name to search for (case-insensitive).
+
+        Returns:
+            List of distinct release IDs where this artist is a primary credit.
+        """
+        conn = self._get_cache_conn()
+        if conn is None:
+            return []
+        try:
+            rows = conn.execute(
+                """
+                SELECT DISTINCT release_id
+                FROM release_artist
+                WHERE lower(artist_name) = lower(%s) AND extra = 0
+                """,
+                (artist_name,),
+            ).fetchall()
+            return [row[0] for row in rows]
+        except Exception:
+            logger.warning(
+                "Cache get_releases_for_artist failed for %r", artist_name, exc_info=True
+            )
+            return []
+
     def _search_artist_cache(self, name: str) -> DiscogsSearchResult | None:
         """Search for an artist in the discogs-cache PostgreSQL."""
         conn = self._get_cache_conn()
@@ -185,10 +213,10 @@ class DiscogsClient:
                 (release_id,),
             ).fetchall()
 
-            conn.execute(
-                "SELECT artist_name FROM release_track_artist WHERE release_id = %s",
+            track_artist_rows = conn.execute(
+                "SELECT release_id, artist_name FROM release_track_artist WHERE release_id = %s",
                 (release_id,),
-            ).fetchall()  # TODO: use for compilation track artists in PR 3
+            ).fetchall()
 
             # Build model
             main_artists = [
@@ -201,6 +229,12 @@ class DiscogsClient:
             ]
             labels = [DiscogsLabel(name=r[1], label_id=r[0], catno=r[2]) for r in label_rows]
             tracks = [DiscogsTrack(position=r[0] or "", title=r[1] or "") for r in track_rows]
+
+            # Attach per-track artists for compilation detection
+            track_artists_set = {r[1] for r in track_artist_rows}
+            if track_artists_set:
+                for track in tracks:
+                    track.artists = list(track_artists_set)
 
             artist_name = main_artists[0].name if main_artists else ""
             artist_id = main_artists[0].artist_id if main_artists else None

--- a/semantic_index/discogs_enrichment.py
+++ b/semantic_index/discogs_enrichment.py
@@ -1,0 +1,146 @@
+"""Discogs enrichment module for artist metadata aggregation.
+
+Enriches canonical artists with Discogs metadata: styles, personnel credits,
+labels, and compilation appearances. Uses the DiscogsClient to fetch release
+data and aggregates across all releases per artist.
+"""
+
+import logging
+
+from semantic_index.discogs_client import DiscogsClient
+from semantic_index.models import (
+    ArtistEnrichment,
+    CompilationAppearance,
+    DiscogsRelease,
+    LabelInfo,
+    PersonnelCredit,
+)
+
+logger = logging.getLogger(__name__)
+
+_PROGRESS_INTERVAL = 500
+
+
+class DiscogsEnricher:
+    """Enriches canonical artists with Discogs metadata."""
+
+    def __init__(self, client: DiscogsClient) -> None:
+        self._client = client
+
+    def enrich_artist(
+        self, canonical_name: str, discogs_artist_id: int | None = None
+    ) -> ArtistEnrichment | None:
+        """Fetch and aggregate Discogs metadata for a canonical artist.
+
+        1. Search for artist in Discogs (by name or ID)
+        2. Get all releases for that artist
+        3. Aggregate: styles (union), personnel (extra_artists with roles), labels, compilations
+
+        Args:
+            canonical_name: The canonical artist name to enrich.
+            discogs_artist_id: Known Discogs artist ID, if available. Skips search when provided.
+
+        Returns:
+            ArtistEnrichment with aggregated metadata, or None if artist not found in Discogs.
+        """
+        # Step 1: Resolve Discogs identity
+        if discogs_artist_id is None:
+            search_result = self._client.search_artist(canonical_name)
+            if search_result is None:
+                return None
+            discogs_artist_id = search_result.artist_id
+
+        # Step 2: Get all release IDs for this artist
+        release_ids = self._client.get_releases_for_artist(canonical_name)
+
+        # Step 3: Fetch each release and aggregate
+        all_styles: set[str] = set()
+        personnel_map: dict[str, set[str]] = {}  # name -> set of roles
+        labels_seen: dict[str, LabelInfo] = {}  # name -> LabelInfo
+        compilations: list[CompilationAppearance] = []
+
+        for release_id in release_ids:
+            release = self._client.get_release(release_id)
+            if release is None:
+                continue
+            self._aggregate_release(
+                release, canonical_name, all_styles, personnel_map, labels_seen, compilations
+            )
+
+        return ArtistEnrichment(
+            canonical_name=canonical_name,
+            discogs_artist_id=discogs_artist_id,
+            styles=sorted(all_styles),
+            personnel=[
+                PersonnelCredit(name=name, roles=sorted(roles))
+                for name, roles in sorted(personnel_map.items())
+            ],
+            labels=[labels_seen[name] for name in sorted(labels_seen)],
+            compilation_appearances=compilations,
+        )
+
+    def enrich_batch(self, artists: dict[str, int | None]) -> dict[str, ArtistEnrichment]:
+        """Enrich a batch of artists.
+
+        Args:
+            artists: Mapping of canonical_name to discogs_artist_id (or None if unknown).
+
+        Returns:
+            Dict of canonical_name to ArtistEnrichment (only for successfully enriched artists).
+        """
+        results: dict[str, ArtistEnrichment] = {}
+        total = len(artists)
+
+        for i, (name, artist_id) in enumerate(artists.items(), start=1):
+            enrichment = self.enrich_artist(name, discogs_artist_id=artist_id)
+            if enrichment is not None:
+                results[name] = enrichment
+
+            if i % _PROGRESS_INTERVAL == 0:
+                logger.info("Enriched %d / %d artists (%d successful)", i, total, len(results))
+
+        logger.info(
+            "Enrichment complete: %d / %d artists enriched successfully", len(results), total
+        )
+        return results
+
+    @staticmethod
+    def _aggregate_release(
+        release: DiscogsRelease,
+        canonical_name: str,
+        all_styles: set[str],
+        personnel_map: dict[str, set[str]],
+        labels_seen: dict[str, LabelInfo],
+        compilations: list[CompilationAppearance],
+    ) -> None:
+        """Aggregate data from a single release into the running accumulators."""
+        # Styles
+        all_styles.update(release.styles)
+
+        # Personnel from extra_artists
+        for credit in release.extra_artists:
+            if credit.name not in personnel_map:
+                personnel_map[credit.name] = set()
+            if credit.role is not None:
+                personnel_map[credit.name].add(credit.role)
+
+        # Labels
+        for label in release.labels:
+            if label.name not in labels_seen:
+                labels_seen[label.name] = LabelInfo(name=label.name, label_id=label.label_id)
+
+        # Compilation detection: tracks with per-track artist credits
+        has_track_artists = any(len(track.artists) > 0 for track in release.tracklist)
+        if has_track_artists:
+            other_artists: list[str] = []
+            for track in release.tracklist:
+                for artist in track.artists:
+                    if artist != canonical_name and artist not in other_artists:
+                        other_artists.append(artist)
+            compilations.append(
+                CompilationAppearance(
+                    release_id=release.release_id,
+                    release_title=release.title,
+                    other_artists=other_artists,
+                )
+            )

--- a/semantic_index/models.py
+++ b/semantic_index/models.py
@@ -138,3 +138,39 @@ class DiscogsSearchResult(BaseModel):
     artist_id: int | None = None
     release_id: int | None = None
     confidence: float = 0.0
+
+
+# --- Enrichment models ---
+
+
+class PersonnelCredit(BaseModel):
+    """A credited musician across an artist's releases."""
+
+    name: str
+    roles: list[str] = []
+
+
+class LabelInfo(BaseModel):
+    """A label an artist has released on."""
+
+    name: str
+    label_id: int | None = None
+
+
+class CompilationAppearance(BaseModel):
+    """An artist's appearance on a compilation release."""
+
+    release_id: int
+    release_title: str
+    other_artists: list[str] = []
+
+
+class ArtistEnrichment(BaseModel):
+    """Discogs enrichment data for a single canonical artist."""
+
+    canonical_name: str
+    discogs_artist_id: int | None = None
+    styles: list[str] = []
+    personnel: list[PersonnelCredit] = []
+    labels: list[LabelInfo] = []
+    compilation_appearances: list[CompilationAppearance] = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,10 +5,18 @@ Uses WXYC example artists from the canonical data in wxyc-shared.
 
 from semantic_index.models import (
     AdjacencyPair,
+    ArtistEnrichment,
+    CompilationAppearance,
     CrossReferenceEdge,
+    DiscogsCredit,
+    DiscogsLabel,
+    DiscogsRelease,
+    DiscogsTrack,
     FlowsheetEntry,
+    LabelInfo,
     LibraryCode,
     LibraryRelease,
+    PersonnelCredit,
     ResolvedEntry,
 )
 
@@ -87,4 +95,66 @@ def make_cross_reference_edge(
         artist_b=artist_b,
         comment=comment,
         source=source,
+    )
+
+
+def make_discogs_release(
+    release_id: int = 12345,
+    title: str = "Confield",
+    artist_name: str = "Autechre",
+    artist_id: int | None = 42,
+    year: int | None = 2001,
+    styles: list[str] | None = None,
+    artists: list[DiscogsCredit] | None = None,
+    extra_artists: list[DiscogsCredit] | None = None,
+    labels: list[DiscogsLabel] | None = None,
+    tracklist: list[DiscogsTrack] | None = None,
+) -> DiscogsRelease:
+    return DiscogsRelease(
+        release_id=release_id,
+        title=title,
+        artist_name=artist_name,
+        artist_id=artist_id,
+        year=year,
+        styles=styles if styles is not None else ["IDM", "Abstract"],
+        artists=artists
+        if artists is not None
+        else [DiscogsCredit(name=artist_name, artist_id=artist_id)],
+        extra_artists=extra_artists if extra_artists is not None else [],
+        labels=labels
+        if labels is not None
+        else [DiscogsLabel(name="Warp Records", label_id=100, catno="WARPCD85")],
+        tracklist=tracklist
+        if tracklist is not None
+        else [DiscogsTrack(position="1", title="VI Scose Poise")],
+    )
+
+
+def make_artist_enrichment(
+    canonical_name: str = "Autechre",
+    discogs_artist_id: int | None = 42,
+    styles: list[str] | None = None,
+    personnel: list[PersonnelCredit] | None = None,
+    labels: list[LabelInfo] | None = None,
+    compilation_appearances: list[CompilationAppearance] | None = None,
+) -> ArtistEnrichment:
+    return ArtistEnrichment(
+        canonical_name=canonical_name,
+        discogs_artist_id=discogs_artist_id,
+        styles=styles if styles is not None else ["IDM", "Abstract"],
+        personnel=personnel if personnel is not None else [],
+        labels=labels if labels is not None else [LabelInfo(name="Warp Records", label_id=100)],
+        compilation_appearances=compilation_appearances
+        if compilation_appearances is not None
+        else [],
+    )
+
+
+def make_personnel_credit(
+    name: str = "Rob Brown",
+    roles: list[str] | None = None,
+) -> PersonnelCredit:
+    return PersonnelCredit(
+        name=name,
+        roles=roles if roles is not None else ["Written-By"],
     )

--- a/tests/unit/test_discogs_enrichment.py
+++ b/tests/unit/test_discogs_enrichment.py
@@ -1,0 +1,431 @@
+"""Tests for the Discogs enrichment module."""
+
+import logging
+from unittest.mock import MagicMock
+
+from semantic_index.discogs_client import DiscogsClient
+from semantic_index.discogs_enrichment import DiscogsEnricher
+from semantic_index.models import (
+    DiscogsCredit,
+    DiscogsLabel,
+    DiscogsSearchResult,
+    DiscogsTrack,
+)
+from tests.conftest import make_discogs_release
+
+
+class TestSingleReleaseStyles:
+    """Test style aggregation from a single release."""
+
+    def test_styles_from_single_release(self):
+        client = MagicMock(spec=DiscogsClient)
+        client.search_artist.return_value = DiscogsSearchResult(
+            artist_name="Autechre", artist_id=42
+        )
+        client.get_releases_for_artist.return_value = [12345]
+        client.get_release.return_value = make_discogs_release(
+            styles=["IDM", "Abstract"],
+        )
+
+        enricher = DiscogsEnricher(client)
+        result = enricher.enrich_artist("Autechre")
+
+        assert result is not None
+        assert sorted(result.styles) == ["Abstract", "IDM"]
+
+    def test_styles_deduplicated_across_releases(self):
+        client = MagicMock(spec=DiscogsClient)
+        client.search_artist.return_value = DiscogsSearchResult(
+            artist_name="Autechre", artist_id=42
+        )
+        client.get_releases_for_artist.return_value = [12345, 67890]
+        client.get_release.side_effect = [
+            make_discogs_release(release_id=12345, styles=["IDM", "Abstract"]),
+            make_discogs_release(
+                release_id=67890,
+                title="Amber",
+                year=1994,
+                styles=["IDM", "Ambient"],
+            ),
+        ]
+
+        enricher = DiscogsEnricher(client)
+        result = enricher.enrich_artist("Autechre")
+
+        assert result is not None
+        assert sorted(result.styles) == ["Abstract", "Ambient", "IDM"]
+
+
+class TestMultiReleaseAggregation:
+    """Test aggregation across multiple releases."""
+
+    def test_labels_deduplicated_by_name(self):
+        client = MagicMock(spec=DiscogsClient)
+        client.search_artist.return_value = DiscogsSearchResult(
+            artist_name="Autechre", artist_id=42
+        )
+        client.get_releases_for_artist.return_value = [12345, 67890]
+        client.get_release.side_effect = [
+            make_discogs_release(
+                release_id=12345,
+                labels=[DiscogsLabel(name="Warp Records", label_id=100, catno="WARPCD85")],
+            ),
+            make_discogs_release(
+                release_id=67890,
+                title="Amber",
+                labels=[
+                    DiscogsLabel(name="Warp Records", label_id=100, catno="WARPCD34"),
+                    DiscogsLabel(name="Skam", label_id=200, catno="SKA001"),
+                ],
+            ),
+        ]
+
+        enricher = DiscogsEnricher(client)
+        result = enricher.enrich_artist("Autechre")
+
+        assert result is not None
+        label_names = [lbl.name for lbl in result.labels]
+        assert sorted(label_names) == ["Skam", "Warp Records"]
+
+    def test_personnel_deduplicated_with_roles_merged(self):
+        client = MagicMock(spec=DiscogsClient)
+        client.search_artist.return_value = DiscogsSearchResult(
+            artist_name="Autechre", artist_id=42
+        )
+        client.get_releases_for_artist.return_value = [12345, 67890]
+        client.get_release.side_effect = [
+            make_discogs_release(
+                release_id=12345,
+                extra_artists=[
+                    DiscogsCredit(name="Rob Brown", role="Written-By"),
+                ],
+            ),
+            make_discogs_release(
+                release_id=67890,
+                title="Amber",
+                extra_artists=[
+                    DiscogsCredit(name="Rob Brown", role="Producer"),
+                    DiscogsCredit(name="Sean Booth", role="Written-By"),
+                ],
+            ),
+        ]
+
+        enricher = DiscogsEnricher(client)
+        result = enricher.enrich_artist("Autechre")
+
+        assert result is not None
+        personnel_by_name = {p.name: p for p in result.personnel}
+        assert "Rob Brown" in personnel_by_name
+        assert "Sean Booth" in personnel_by_name
+        assert sorted(personnel_by_name["Rob Brown"].roles) == ["Producer", "Written-By"]
+        assert personnel_by_name["Sean Booth"].roles == ["Written-By"]
+
+
+class TestExtraArtists:
+    """Test personnel credit extraction from extra_artists."""
+
+    def test_extra_artists_become_personnel(self):
+        client = MagicMock(spec=DiscogsClient)
+        client.search_artist.return_value = DiscogsSearchResult(
+            artist_name="Father John Misty", artist_id=99
+        )
+        client.get_releases_for_artist.return_value = [55555]
+        client.get_release.return_value = make_discogs_release(
+            release_id=55555,
+            title="I Love You, Honeybear",
+            artist_name="Father John Misty",
+            artist_id=99,
+            styles=["Folk Rock", "Baroque Pop"],
+            labels=[DiscogsLabel(name="Sub Pop", label_id=300)],
+            extra_artists=[
+                DiscogsCredit(name="Jonathan Wilson", role="Producer"),
+                DiscogsCredit(name="Drew Erickson", role="Piano"),
+            ],
+        )
+
+        enricher = DiscogsEnricher(client)
+        result = enricher.enrich_artist("Father John Misty")
+
+        assert result is not None
+        assert len(result.personnel) == 2
+        personnel_names = {p.name for p in result.personnel}
+        assert personnel_names == {"Jonathan Wilson", "Drew Erickson"}
+
+    def test_extra_artist_with_no_role(self):
+        client = MagicMock(spec=DiscogsClient)
+        client.search_artist.return_value = DiscogsSearchResult(
+            artist_name="Stereolab", artist_id=55
+        )
+        client.get_releases_for_artist.return_value = [11111]
+        client.get_release.return_value = make_discogs_release(
+            release_id=11111,
+            title="Aluminum Tunes",
+            artist_name="Stereolab",
+            artist_id=55,
+            styles=["Post-Rock", "Krautrock"],
+            labels=[DiscogsLabel(name="Duophonic", label_id=400)],
+            extra_artists=[
+                DiscogsCredit(name="John McEntire", role=None),
+            ],
+        )
+
+        enricher = DiscogsEnricher(client)
+        result = enricher.enrich_artist("Stereolab")
+
+        assert result is not None
+        assert len(result.personnel) == 1
+        assert result.personnel[0].name == "John McEntire"
+        assert result.personnel[0].roles == []
+
+
+class TestCompilationDetection:
+    """Test compilation appearance detection from per-track artists."""
+
+    def test_tracks_with_per_track_artists_detected_as_compilation(self):
+        client = MagicMock(spec=DiscogsClient)
+        client.search_artist.return_value = DiscogsSearchResult(
+            artist_name="Chuquimamani-Condori", artist_id=77
+        )
+        client.get_releases_for_artist.return_value = [33333]
+        client.get_release.return_value = make_discogs_release(
+            release_id=33333,
+            title="SOÑAR Compilation Vol. 1",
+            artist_name="Various",
+            artist_id=None,
+            styles=["Electronic"],
+            labels=[DiscogsLabel(name="SOÑAR", label_id=500)],
+            tracklist=[
+                DiscogsTrack(
+                    position="1",
+                    title="Call Your Name",
+                    artists=["Chuquimamani-Condori"],
+                ),
+                DiscogsTrack(
+                    position="2",
+                    title="Night Vision",
+                    artists=["Nourished by Time"],
+                ),
+                DiscogsTrack(
+                    position="3",
+                    title="Drift",
+                    artists=["Rochelle Jordan"],
+                ),
+            ],
+        )
+
+        enricher = DiscogsEnricher(client)
+        result = enricher.enrich_artist("Chuquimamani-Condori")
+
+        assert result is not None
+        assert len(result.compilation_appearances) == 1
+        comp = result.compilation_appearances[0]
+        assert comp.release_id == 33333
+        assert comp.release_title == "SOÑAR Compilation Vol. 1"
+        assert "Nourished by Time" in comp.other_artists
+        assert "Rochelle Jordan" in comp.other_artists
+
+    def test_regular_album_not_detected_as_compilation(self):
+        client = MagicMock(spec=DiscogsClient)
+        client.search_artist.return_value = DiscogsSearchResult(
+            artist_name="Jessica Pratt", artist_id=88
+        )
+        client.get_releases_for_artist.return_value = [44444]
+        client.get_release.return_value = make_discogs_release(
+            release_id=44444,
+            title="On Your Own Love Again",
+            artist_name="Jessica Pratt",
+            artist_id=88,
+            styles=["Folk"],
+            labels=[DiscogsLabel(name="Drag City", label_id=600)],
+            tracklist=[
+                DiscogsTrack(position="1", title="Back, Baby"),
+                DiscogsTrack(position="2", title="Greyclouds"),
+            ],
+        )
+
+        enricher = DiscogsEnricher(client)
+        result = enricher.enrich_artist("Jessica Pratt")
+
+        assert result is not None
+        assert result.compilation_appearances == []
+
+
+class TestNoMatch:
+    """Test behavior when no Discogs match is found."""
+
+    def test_no_search_result_returns_none(self):
+        client = MagicMock(spec=DiscogsClient)
+        client.search_artist.return_value = None
+
+        enricher = DiscogsEnricher(client)
+        result = enricher.enrich_artist("Obscure Unknown Artist")
+
+        assert result is None
+
+    def test_search_found_but_no_releases_returns_empty_enrichment(self):
+        client = MagicMock(spec=DiscogsClient)
+        client.search_artist.return_value = DiscogsSearchResult(
+            artist_name="Anne Gillis", artist_id=66
+        )
+        client.get_releases_for_artist.return_value = []
+
+        enricher = DiscogsEnricher(client)
+        result = enricher.enrich_artist("Anne Gillis")
+
+        assert result is not None
+        assert result.canonical_name == "Anne Gillis"
+        assert result.discogs_artist_id == 66
+        assert result.styles == []
+        assert result.personnel == []
+        assert result.labels == []
+        assert result.compilation_appearances == []
+
+    def test_release_fetch_returns_none_skipped(self):
+        client = MagicMock(spec=DiscogsClient)
+        client.search_artist.return_value = DiscogsSearchResult(artist_name="Sessa", artist_id=111)
+        client.get_releases_for_artist.return_value = [99999]
+        client.get_release.return_value = None
+
+        enricher = DiscogsEnricher(client)
+        result = enricher.enrich_artist("Sessa")
+
+        assert result is not None
+        assert result.canonical_name == "Sessa"
+        assert result.styles == []
+
+
+class TestEnrichWithKnownId:
+    """Test enrichment when discogs_artist_id is already known."""
+
+    def test_known_id_skips_search(self):
+        client = MagicMock(spec=DiscogsClient)
+        client.get_releases_for_artist.return_value = [12345]
+        client.get_release.return_value = make_discogs_release()
+
+        enricher = DiscogsEnricher(client)
+        result = enricher.enrich_artist("Autechre", discogs_artist_id=42)
+
+        assert result is not None
+        assert result.discogs_artist_id == 42
+        client.search_artist.assert_not_called()
+
+
+class TestBatchEnrichment:
+    """Test batch enrichment across multiple artists."""
+
+    def test_batch_enriches_multiple_artists(self):
+        client = MagicMock(spec=DiscogsClient)
+
+        def search_side_effect(name, release_title=None):
+            results = {
+                "Autechre": DiscogsSearchResult(artist_name="Autechre", artist_id=42),
+                "Stereolab": DiscogsSearchResult(artist_name="Stereolab", artist_id=55),
+            }
+            return results.get(name)
+
+        def releases_side_effect(name):
+            data = {
+                "Autechre": [12345],
+                "Stereolab": [67890],
+            }
+            return data.get(name, [])
+
+        def release_side_effect(release_id):
+            releases = {
+                12345: make_discogs_release(
+                    release_id=12345,
+                    styles=["IDM"],
+                    labels=[DiscogsLabel(name="Warp Records", label_id=100)],
+                ),
+                67890: make_discogs_release(
+                    release_id=67890,
+                    title="Aluminum Tunes",
+                    artist_name="Stereolab",
+                    artist_id=55,
+                    styles=["Post-Rock"],
+                    labels=[DiscogsLabel(name="Duophonic", label_id=400)],
+                ),
+            }
+            return releases.get(release_id)
+
+        client.search_artist.side_effect = search_side_effect
+        client.get_releases_for_artist.side_effect = releases_side_effect
+        client.get_release.side_effect = release_side_effect
+
+        enricher = DiscogsEnricher(client)
+        results = enricher.enrich_batch({"Autechre": None, "Stereolab": None})
+
+        assert len(results) == 2
+        assert "Autechre" in results
+        assert "Stereolab" in results
+        assert "IDM" in results["Autechre"].styles
+        assert "Post-Rock" in results["Stereolab"].styles
+
+    def test_batch_skips_failed_artists(self):
+        client = MagicMock(spec=DiscogsClient)
+        client.search_artist.side_effect = [
+            DiscogsSearchResult(artist_name="Cat Power", artist_id=33),
+            None,  # Buck Meek not found
+        ]
+        client.get_releases_for_artist.return_value = [22222]
+        client.get_release.return_value = make_discogs_release(
+            release_id=22222,
+            title="Moon Pix",
+            artist_name="Cat Power",
+            artist_id=33,
+            styles=["Indie Rock"],
+            labels=[DiscogsLabel(name="Matador Records", label_id=700)],
+        )
+
+        enricher = DiscogsEnricher(client)
+        results = enricher.enrich_batch({"Cat Power": None, "Buck Meek": None})
+
+        assert len(results) == 1
+        assert "Cat Power" in results
+        assert "Buck Meek" not in results
+
+    def test_batch_uses_known_ids(self):
+        client = MagicMock(spec=DiscogsClient)
+        client.get_releases_for_artist.return_value = [12345]
+        client.get_release.return_value = make_discogs_release()
+
+        enricher = DiscogsEnricher(client)
+        results = enricher.enrich_batch({"Autechre": 42})
+
+        assert len(results) == 1
+        assert results["Autechre"].discogs_artist_id == 42
+        client.search_artist.assert_not_called()
+
+
+class TestProgressLogging:
+    """Test that batch enrichment logs progress."""
+
+    def test_logs_progress_at_intervals(self, caplog):
+        client = MagicMock(spec=DiscogsClient)
+        client.search_artist.return_value = None
+
+        artists = {f"Artist {i}": None for i in range(1050)}
+
+        enricher = DiscogsEnricher(client)
+        with caplog.at_level(logging.INFO, logger="semantic_index.discogs_enrichment"):
+            enricher.enrich_batch(artists)
+
+        progress_messages = [r.message for r in caplog.records if "Enriched" in r.message]
+        assert len(progress_messages) >= 2  # at 500, 1000
+        assert any("500" in msg for msg in progress_messages)
+        assert any("1000" in msg for msg in progress_messages)
+
+    def test_logs_final_summary(self, caplog):
+        client = MagicMock(spec=DiscogsClient)
+        client.search_artist.return_value = DiscogsSearchResult(
+            artist_name="Autechre", artist_id=42
+        )
+        client.get_releases_for_artist.return_value = [12345]
+        client.get_release.return_value = make_discogs_release()
+
+        enricher = DiscogsEnricher(client)
+        with caplog.at_level(logging.INFO, logger="semantic_index.discogs_enrichment"):
+            enricher.enrich_batch({"Autechre": None})
+
+        summary_messages = [r.message for r in caplog.records if "complete" in r.message.lower()]
+        assert len(summary_messages) >= 1


### PR DESCRIPTION
## Summary

- Add `DiscogsEnricher` class with `enrich_artist()` and `enrich_batch()` methods
- Aggregates styles, personnel credits (with role merging), labels (deduplicated), and compilation appearances across all Discogs releases per artist
- Add `get_releases_for_artist()` method to `DiscogsClient`
- Add enrichment models: `ArtistEnrichment`, `PersonnelCredit`, `LabelInfo`, `CompilationAppearance`
- Add factory functions for Discogs models in conftest.py
- 17 new unit tests (style aggregation, personnel dedup, compilation detection, batch processing, progress logging)

Closes #37

## Test plan

- [x] 136 unit tests pass (119 existing + 17 new)
- [x] ruff, black, mypy all clean
- [ ] CI passes