### PR TITLE
Add Discogs-derived edge extraction

### DIFF
--- a/semantic_index/discogs_edges.py
+++ b/semantic_index/discogs_edges.py
@@ -1,0 +1,226 @@
+"""Discogs-derived edge extraction from ArtistEnrichment data.
+
+Four pure functions that compute edges between artists based on shared personnel,
+overlapping style tags, shared record labels, and co-appearance on compilations.
+All functions use inverted indexes for efficient pair generation.
+"""
+
+import logging
+from collections import defaultdict
+from itertools import combinations
+
+from semantic_index.models import (
+    ArtistEnrichment,
+    CompilationEdge,
+    LabelFamilyEdge,
+    SharedPersonnelEdge,
+    SharedStyleEdge,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def extract_shared_personnel(
+    enrichments: dict[str, ArtistEnrichment],
+    min_shared: int = 1,
+) -> list[SharedPersonnelEdge]:
+    """Build edges between artists who share credited musicians.
+
+    Builds an inverted index from personnel name to set of artists, then emits
+    edges for all pairs of artists sharing at least ``min_shared`` personnel.
+
+    Args:
+        enrichments: Mapping of canonical artist name to enrichment data.
+        min_shared: Minimum number of shared personnel to emit an edge.
+
+    Returns:
+        Deterministically sorted list of SharedPersonnelEdge.
+    """
+    # Inverted index: personnel_name -> set of artist names
+    personnel_to_artists: dict[str, set[str]] = defaultdict(set)
+    for artist_name, enrichment in enrichments.items():
+        for credit in enrichment.personnel:
+            personnel_to_artists[credit.name].add(artist_name)
+
+    # For each pair of artists, count shared personnel
+    pair_shared: dict[tuple[str, str], set[str]] = defaultdict(set)
+    for personnel_name, artists in personnel_to_artists.items():
+        if len(artists) < 2:
+            continue
+        for a, b in combinations(sorted(artists), 2):
+            pair_shared[(a, b)].add(personnel_name)
+
+    # Build edges, filtering by min_shared
+    edges: list[SharedPersonnelEdge] = []
+    for (a, b), shared_names in sorted(pair_shared.items()):
+        if len(shared_names) >= min_shared:
+            edges.append(
+                SharedPersonnelEdge(
+                    artist_a=a,
+                    artist_b=b,
+                    shared_count=len(shared_names),
+                    shared_names=sorted(shared_names),
+                )
+            )
+
+    logger.info("Extracted %d shared-personnel edges", len(edges))
+    return edges
+
+
+def extract_shared_styles(
+    enrichments: dict[str, ArtistEnrichment],
+    min_jaccard: float = 0.1,
+) -> list[SharedStyleEdge]:
+    """Build edges between artists with overlapping Discogs style tags.
+
+    Uses an inverted index (style tag -> artists) to avoid O(n^2) pairwise
+    comparison. Only pairs sharing at least one tag are considered, then Jaccard
+    similarity is computed: ``|intersection| / |union|``.
+
+    Args:
+        enrichments: Mapping of canonical artist name to enrichment data.
+        min_jaccard: Minimum Jaccard similarity to emit an edge.
+
+    Returns:
+        Deterministically sorted list of SharedStyleEdge.
+    """
+    # Build style sets per artist
+    artist_styles: dict[str, set[str]] = {}
+    for artist_name, enrichment in enrichments.items():
+        if enrichment.styles:
+            artist_styles[artist_name] = set(enrichment.styles)
+
+    # Inverted index: style -> set of artists (only artists with non-empty styles)
+    style_to_artists: dict[str, set[str]] = defaultdict(set)
+    for artist_name, styles in artist_styles.items():
+        for style in styles:
+            style_to_artists[style].add(artist_name)
+
+    # Collect candidate pairs (those sharing at least one tag)
+    candidate_pairs: set[tuple[str, str]] = set()
+    for artists in style_to_artists.values():
+        if len(artists) < 2:
+            continue
+        for a, b in combinations(sorted(artists), 2):
+            candidate_pairs.add((a, b))
+
+    # Compute Jaccard for each candidate pair
+    edges: list[SharedStyleEdge] = []
+    for a, b in sorted(candidate_pairs):
+        styles_a = artist_styles[a]
+        styles_b = artist_styles[b]
+        intersection = styles_a & styles_b
+        union = styles_a | styles_b
+        jaccard = len(intersection) / len(union)
+
+        if jaccard >= min_jaccard:
+            edges.append(
+                SharedStyleEdge(
+                    artist_a=a,
+                    artist_b=b,
+                    jaccard=jaccard,
+                    shared_tags=sorted(intersection),
+                )
+            )
+
+    logger.info("Extracted %d shared-style edges", len(edges))
+    return edges
+
+
+def extract_label_family(
+    enrichments: dict[str, ArtistEnrichment],
+    max_label_artists: int = 500,
+) -> list[LabelFamilyEdge]:
+    """Build edges between artists who share a record label.
+
+    Builds an inverted index from label name to set of artists, then emits
+    edges for all pairs. Labels with more than ``max_label_artists`` are excluded
+    to avoid noise from mega-labels.
+
+    Args:
+        enrichments: Mapping of canonical artist name to enrichment data.
+        max_label_artists: Maximum number of artists on a label before it is excluded.
+
+    Returns:
+        Deterministically sorted list of LabelFamilyEdge.
+    """
+    # Inverted index: label_name -> set of artist names
+    label_to_artists: dict[str, set[str]] = defaultdict(set)
+    for artist_name, enrichment in enrichments.items():
+        for label in enrichment.labels:
+            label_to_artists[label.name].add(artist_name)
+
+    # For each pair of artists, collect shared labels
+    pair_labels: dict[tuple[str, str], list[str]] = defaultdict(list)
+    for label_name, artists in label_to_artists.items():
+        if len(artists) < 2 or len(artists) > max_label_artists:
+            continue
+        for a, b in combinations(sorted(artists), 2):
+            pair_labels[(a, b)].append(label_name)
+
+    # Build edges
+    edges: list[LabelFamilyEdge] = []
+    for (a, b), labels in sorted(pair_labels.items()):
+        edges.append(
+            LabelFamilyEdge(
+                artist_a=a,
+                artist_b=b,
+                shared_labels=sorted(labels),
+            )
+        )
+
+    logger.info("Extracted %d label-family edges", len(edges))
+    return edges
+
+
+def extract_compilation_coappearance(
+    enrichments: dict[str, ArtistEnrichment],
+) -> list[CompilationEdge]:
+    """Build edges between artists who appear on the same compilation.
+
+    Builds an inverted index from compilation release_id to the set of graph
+    artists appearing on it (only artists present in ``enrichments``). Emits
+    edges for all pairs on compilations with 2+ graph artists.
+
+    Args:
+        enrichments: Mapping of canonical artist name to enrichment data.
+
+    Returns:
+        Deterministically sorted list of CompilationEdge.
+    """
+    graph_artists = set(enrichments.keys())
+
+    # Inverted index: release_id -> (release_title, set of graph artists)
+    comp_index: dict[int, tuple[str, set[str]]] = {}
+    for artist_name, enrichment in enrichments.items():
+        for comp in enrichment.compilation_appearances:
+            if comp.release_id not in comp_index:
+                comp_index[comp.release_id] = (comp.release_title, set())
+            comp_index[comp.release_id][1].add(artist_name)
+            # Also add other_artists that are in the graph
+            for other in comp.other_artists:
+                if other in graph_artists:
+                    comp_index[comp.release_id][1].add(other)
+
+    # For each pair of artists, collect shared compilations
+    pair_comps: dict[tuple[str, str], list[str]] = defaultdict(list)
+    for _release_id, (title, artists) in comp_index.items():
+        if len(artists) < 2:
+            continue
+        for a, b in combinations(sorted(artists), 2):
+            pair_comps[(a, b)].append(title)
+
+    # Build edges
+    edges: list[CompilationEdge] = []
+    for (a, b), titles in sorted(pair_comps.items()):
+        edges.append(
+            CompilationEdge(
+                artist_a=a,
+                artist_b=b,
+                compilation_count=len(titles),
+                compilation_titles=sorted(titles),
+            )
+        )
+
+    logger.info("Extracted %d compilation-coappearance edges", len(edges))
+    return edges

--- a/semantic_index/models.py
+++ b/semantic_index/models.py
@@ -174,3 +174,41 @@ class ArtistEnrichment(BaseModel):
     personnel: list[PersonnelCredit] = []
     labels: list[LabelInfo] = []
     compilation_appearances: list[CompilationAppearance] = []
+
+
+# --- Discogs-derived edge models ---
+
+
+class SharedPersonnelEdge(BaseModel):
+    """Edge between two artists who share credited musicians."""
+
+    artist_a: str
+    artist_b: str
+    shared_count: int
+    shared_names: list[str]
+
+
+class SharedStyleEdge(BaseModel):
+    """Edge between two artists with overlapping Discogs style tags."""
+
+    artist_a: str
+    artist_b: str
+    jaccard: float
+    shared_tags: list[str]
+
+
+class LabelFamilyEdge(BaseModel):
+    """Edge between two artists who share a record label."""
+
+    artist_a: str
+    artist_b: str
+    shared_labels: list[str]
+
+
+class CompilationEdge(BaseModel):
+    """Edge between two artists who appear on the same compilation."""
+
+    artist_a: str
+    artist_b: str
+    compilation_count: int
+    compilation_titles: list[str]

--- a/tests/unit/test_discogs_edges.py
+++ b/tests/unit/test_discogs_edges.py
@@ -1,0 +1,508 @@
+"""Tests for Discogs-derived edge extraction functions."""
+
+from semantic_index.discogs_edges import (
+    extract_compilation_coappearance,
+    extract_label_family,
+    extract_shared_personnel,
+    extract_shared_styles,
+)
+from semantic_index.models import CompilationAppearance, LabelInfo
+from tests.conftest import make_artist_enrichment, make_personnel_credit
+
+
+class TestExtractSharedPersonnel:
+    """Tests for extract_shared_personnel."""
+
+    def test_two_artists_sharing_one_person(self):
+        enrichments = {
+            "Autechre": make_artist_enrichment(
+                canonical_name="Autechre",
+                personnel=[make_personnel_credit(name="Rob Brown")],
+            ),
+            "Stereolab": make_artist_enrichment(
+                canonical_name="Stereolab",
+                personnel=[make_personnel_credit(name="Rob Brown")],
+            ),
+        }
+
+        edges = extract_shared_personnel(enrichments)
+
+        assert len(edges) == 1
+        assert edges[0].artist_a == "Autechre"
+        assert edges[0].artist_b == "Stereolab"
+        assert edges[0].shared_count == 1
+        assert edges[0].shared_names == ["Rob Brown"]
+
+    def test_two_artists_sharing_two_people(self):
+        enrichments = {
+            "Autechre": make_artist_enrichment(
+                canonical_name="Autechre",
+                personnel=[
+                    make_personnel_credit(name="Rob Brown"),
+                    make_personnel_credit(name="Sean Booth"),
+                ],
+            ),
+            "Stereolab": make_artist_enrichment(
+                canonical_name="Stereolab",
+                personnel=[
+                    make_personnel_credit(name="Rob Brown"),
+                    make_personnel_credit(name="Sean Booth"),
+                ],
+            ),
+        }
+
+        edges = extract_shared_personnel(enrichments)
+
+        assert len(edges) == 1
+        assert edges[0].shared_count == 2
+        assert edges[0].shared_names == ["Rob Brown", "Sean Booth"]
+
+    def test_three_artists_sharing_one_person(self):
+        enrichments = {
+            "Autechre": make_artist_enrichment(
+                canonical_name="Autechre",
+                personnel=[make_personnel_credit(name="Rob Brown")],
+            ),
+            "Cat Power": make_artist_enrichment(
+                canonical_name="Cat Power",
+                personnel=[make_personnel_credit(name="Rob Brown")],
+            ),
+            "Stereolab": make_artist_enrichment(
+                canonical_name="Stereolab",
+                personnel=[make_personnel_credit(name="Rob Brown")],
+            ),
+        }
+
+        edges = extract_shared_personnel(enrichments)
+
+        assert len(edges) == 3
+        pairs = [(e.artist_a, e.artist_b) for e in edges]
+        assert ("Autechre", "Cat Power") in pairs
+        assert ("Autechre", "Stereolab") in pairs
+        assert ("Cat Power", "Stereolab") in pairs
+
+    def test_no_shared_personnel(self):
+        enrichments = {
+            "Autechre": make_artist_enrichment(
+                canonical_name="Autechre",
+                personnel=[make_personnel_credit(name="Rob Brown")],
+            ),
+            "Stereolab": make_artist_enrichment(
+                canonical_name="Stereolab",
+                personnel=[make_personnel_credit(name="Tim Gane")],
+            ),
+        }
+
+        edges = extract_shared_personnel(enrichments)
+
+        assert len(edges) == 0
+
+    def test_min_shared_filter(self):
+        enrichments = {
+            "Autechre": make_artist_enrichment(
+                canonical_name="Autechre",
+                personnel=[
+                    make_personnel_credit(name="Rob Brown"),
+                    make_personnel_credit(name="Sean Booth"),
+                ],
+            ),
+            "Stereolab": make_artist_enrichment(
+                canonical_name="Stereolab",
+                personnel=[
+                    make_personnel_credit(name="Rob Brown"),
+                ],
+            ),
+            "Cat Power": make_artist_enrichment(
+                canonical_name="Cat Power",
+                personnel=[
+                    make_personnel_credit(name="Rob Brown"),
+                    make_personnel_credit(name="Sean Booth"),
+                ],
+            ),
+        }
+
+        edges = extract_shared_personnel(enrichments, min_shared=2)
+
+        assert len(edges) == 1
+        assert edges[0].artist_a == "Autechre"
+        assert edges[0].artist_b == "Cat Power"
+        assert edges[0].shared_count == 2
+
+    def test_empty_personnel(self):
+        enrichments = {
+            "Autechre": make_artist_enrichment(
+                canonical_name="Autechre",
+                personnel=[],
+            ),
+            "Stereolab": make_artist_enrichment(
+                canonical_name="Stereolab",
+                personnel=[],
+            ),
+        }
+
+        edges = extract_shared_personnel(enrichments)
+
+        assert len(edges) == 0
+
+
+class TestExtractSharedStyles:
+    """Tests for extract_shared_styles."""
+
+    def test_identical_styles_full_jaccard(self):
+        enrichments = {
+            "Autechre": make_artist_enrichment(
+                canonical_name="Autechre",
+                styles=["IDM", "Abstract"],
+            ),
+            "Stereolab": make_artist_enrichment(
+                canonical_name="Stereolab",
+                styles=["IDM", "Abstract"],
+            ),
+        }
+
+        edges = extract_shared_styles(enrichments)
+
+        assert len(edges) == 1
+        assert edges[0].jaccard == 1.0
+        assert edges[0].shared_tags == ["Abstract", "IDM"]
+
+    def test_fifty_percent_overlap(self):
+        enrichments = {
+            "Autechre": make_artist_enrichment(
+                canonical_name="Autechre",
+                styles=["IDM", "Abstract"],
+            ),
+            "Stereolab": make_artist_enrichment(
+                canonical_name="Stereolab",
+                styles=["IDM", "Krautrock"],
+            ),
+        }
+
+        edges = extract_shared_styles(enrichments, min_jaccard=0.0)
+
+        assert len(edges) == 1
+        # intersection = {"IDM"}, union = {"IDM", "Abstract", "Krautrock"} -> 1/3
+        expected_jaccard = 1.0 / 3.0
+        assert abs(edges[0].jaccard - expected_jaccard) < 1e-9
+        assert edges[0].shared_tags == ["IDM"]
+
+    def test_zero_overlap_no_edge(self):
+        enrichments = {
+            "Autechre": make_artist_enrichment(
+                canonical_name="Autechre",
+                styles=["IDM", "Abstract"],
+            ),
+            "Father John Misty": make_artist_enrichment(
+                canonical_name="Father John Misty",
+                styles=["Folk", "Indie Rock"],
+            ),
+        }
+
+        edges = extract_shared_styles(enrichments, min_jaccard=0.0)
+
+        assert len(edges) == 0
+
+    def test_empty_styles_no_edge(self):
+        enrichments = {
+            "Autechre": make_artist_enrichment(
+                canonical_name="Autechre",
+                styles=[],
+            ),
+            "Stereolab": make_artist_enrichment(
+                canonical_name="Stereolab",
+                styles=["IDM"],
+            ),
+        }
+
+        edges = extract_shared_styles(enrichments, min_jaccard=0.0)
+
+        assert len(edges) == 0
+
+    def test_min_jaccard_filter(self):
+        enrichments = {
+            "Autechre": make_artist_enrichment(
+                canonical_name="Autechre",
+                styles=["IDM", "Abstract", "Ambient", "Experimental"],
+            ),
+            "Stereolab": make_artist_enrichment(
+                canonical_name="Stereolab",
+                styles=["IDM", "Krautrock", "Post-Rock", "Space Rock"],
+            ),
+        }
+
+        # intersection = {"IDM"}, union has 7 items -> jaccard = 1/7 ≈ 0.143
+        edges_low = extract_shared_styles(enrichments, min_jaccard=0.1)
+        assert len(edges_low) == 1
+
+        edges_high = extract_shared_styles(enrichments, min_jaccard=0.5)
+        assert len(edges_high) == 0
+
+    def test_inverted_index_optimization_only_considers_pairs_with_shared_tags(self):
+        """Artists with no overlapping tags should never be compared."""
+        enrichments = {
+            "Autechre": make_artist_enrichment(
+                canonical_name="Autechre",
+                styles=["IDM"],
+            ),
+            "Stereolab": make_artist_enrichment(
+                canonical_name="Stereolab",
+                styles=["IDM"],
+            ),
+            "Father John Misty": make_artist_enrichment(
+                canonical_name="Father John Misty",
+                styles=["Folk"],
+            ),
+        }
+
+        edges = extract_shared_styles(enrichments, min_jaccard=0.0)
+
+        # Only Autechre-Stereolab should appear, not any pair with Father John Misty
+        assert len(edges) == 1
+        assert edges[0].artist_a == "Autechre"
+        assert edges[0].artist_b == "Stereolab"
+
+
+class TestExtractLabelFamily:
+    """Tests for extract_label_family."""
+
+    def test_two_artists_on_same_label(self):
+        enrichments = {
+            "Autechre": make_artist_enrichment(
+                canonical_name="Autechre",
+                labels=[LabelInfo(name="Warp Records", label_id=100)],
+            ),
+            "Stereolab": make_artist_enrichment(
+                canonical_name="Stereolab",
+                labels=[LabelInfo(name="Warp Records", label_id=100)],
+            ),
+        }
+
+        edges = extract_label_family(enrichments)
+
+        assert len(edges) == 1
+        assert edges[0].artist_a == "Autechre"
+        assert edges[0].artist_b == "Stereolab"
+        assert edges[0].shared_labels == ["Warp Records"]
+
+    def test_mega_label_excluded(self):
+        # Build a mega-label with more than max_label_artists artists
+        enrichments = {}
+        for i in range(501):
+            name = f"Artist {i:03d}"
+            enrichments[name] = make_artist_enrichment(
+                canonical_name=name,
+                labels=[LabelInfo(name="Not On Label", label_id=None)],
+            )
+
+        edges = extract_label_family(enrichments, max_label_artists=500)
+
+        assert len(edges) == 0
+
+    def test_multiple_shared_labels(self):
+        enrichments = {
+            "Autechre": make_artist_enrichment(
+                canonical_name="Autechre",
+                labels=[
+                    LabelInfo(name="Warp Records", label_id=100),
+                    LabelInfo(name="Skam", label_id=200),
+                ],
+            ),
+            "Stereolab": make_artist_enrichment(
+                canonical_name="Stereolab",
+                labels=[
+                    LabelInfo(name="Warp Records", label_id=100),
+                    LabelInfo(name="Skam", label_id=200),
+                ],
+            ),
+        }
+
+        edges = extract_label_family(enrichments)
+
+        assert len(edges) == 1
+        assert sorted(edges[0].shared_labels) == ["Skam", "Warp Records"]
+
+    def test_no_shared_labels(self):
+        enrichments = {
+            "Autechre": make_artist_enrichment(
+                canonical_name="Autechre",
+                labels=[LabelInfo(name="Warp Records", label_id=100)],
+            ),
+            "Father John Misty": make_artist_enrichment(
+                canonical_name="Father John Misty",
+                labels=[LabelInfo(name="Sub Pop", label_id=300)],
+            ),
+        }
+
+        edges = extract_label_family(enrichments)
+
+        assert len(edges) == 0
+
+    def test_label_just_at_max_included(self):
+        """A label with exactly max_label_artists should be included."""
+        enrichments = {}
+        for i in range(3):
+            name = f"Artist {i}"
+            enrichments[name] = make_artist_enrichment(
+                canonical_name=name,
+                labels=[LabelInfo(name="Small Label")],
+            )
+
+        edges = extract_label_family(enrichments, max_label_artists=3)
+
+        # 3 artists -> 3 edges (A0-A1, A0-A2, A1-A2)
+        assert len(edges) == 3
+
+
+class TestExtractCompilationCoappearance:
+    """Tests for extract_compilation_coappearance."""
+
+    def test_two_artists_on_same_compilation(self):
+        enrichments = {
+            "Autechre": make_artist_enrichment(
+                canonical_name="Autechre",
+                compilation_appearances=[
+                    CompilationAppearance(
+                        release_id=5000,
+                        release_title="Warp 20 (Recreated)",
+                        other_artists=["Stereolab"],
+                    )
+                ],
+            ),
+            "Stereolab": make_artist_enrichment(
+                canonical_name="Stereolab",
+                compilation_appearances=[
+                    CompilationAppearance(
+                        release_id=5000,
+                        release_title="Warp 20 (Recreated)",
+                        other_artists=["Autechre"],
+                    )
+                ],
+            ),
+        }
+
+        edges = extract_compilation_coappearance(enrichments)
+
+        assert len(edges) == 1
+        assert edges[0].artist_a == "Autechre"
+        assert edges[0].artist_b == "Stereolab"
+        assert edges[0].compilation_count == 1
+        assert edges[0].compilation_titles == ["Warp 20 (Recreated)"]
+
+    def test_three_artists_on_same_compilation(self):
+        enrichments = {
+            "Autechre": make_artist_enrichment(
+                canonical_name="Autechre",
+                compilation_appearances=[
+                    CompilationAppearance(
+                        release_id=5000,
+                        release_title="Warp 20 (Recreated)",
+                        other_artists=["Stereolab", "Cat Power"],
+                    )
+                ],
+            ),
+            "Cat Power": make_artist_enrichment(
+                canonical_name="Cat Power",
+                compilation_appearances=[
+                    CompilationAppearance(
+                        release_id=5000,
+                        release_title="Warp 20 (Recreated)",
+                        other_artists=["Autechre", "Stereolab"],
+                    )
+                ],
+            ),
+            "Stereolab": make_artist_enrichment(
+                canonical_name="Stereolab",
+                compilation_appearances=[
+                    CompilationAppearance(
+                        release_id=5000,
+                        release_title="Warp 20 (Recreated)",
+                        other_artists=["Autechre", "Cat Power"],
+                    )
+                ],
+            ),
+        }
+
+        edges = extract_compilation_coappearance(enrichments)
+
+        assert len(edges) == 3
+        pairs = [(e.artist_a, e.artist_b) for e in edges]
+        assert ("Autechre", "Cat Power") in pairs
+        assert ("Autechre", "Stereolab") in pairs
+        assert ("Cat Power", "Stereolab") in pairs
+
+    def test_artist_alone_on_compilation_no_edges(self):
+        enrichments = {
+            "Autechre": make_artist_enrichment(
+                canonical_name="Autechre",
+                compilation_appearances=[
+                    CompilationAppearance(
+                        release_id=5000,
+                        release_title="Warp 20 (Recreated)",
+                        other_artists=["Unknown Artist"],
+                    )
+                ],
+            ),
+        }
+
+        edges = extract_compilation_coappearance(enrichments)
+
+        assert len(edges) == 0
+
+    def test_no_compilation_appearances(self):
+        enrichments = {
+            "Autechre": make_artist_enrichment(
+                canonical_name="Autechre",
+                compilation_appearances=[],
+            ),
+            "Stereolab": make_artist_enrichment(
+                canonical_name="Stereolab",
+                compilation_appearances=[],
+            ),
+        }
+
+        edges = extract_compilation_coappearance(enrichments)
+
+        assert len(edges) == 0
+
+    def test_two_shared_compilations(self):
+        enrichments = {
+            "Autechre": make_artist_enrichment(
+                canonical_name="Autechre",
+                compilation_appearances=[
+                    CompilationAppearance(
+                        release_id=5000,
+                        release_title="Warp 20 (Recreated)",
+                        other_artists=["Stereolab"],
+                    ),
+                    CompilationAppearance(
+                        release_id=5001,
+                        release_title="Artificial Intelligence",
+                        other_artists=["Stereolab"],
+                    ),
+                ],
+            ),
+            "Stereolab": make_artist_enrichment(
+                canonical_name="Stereolab",
+                compilation_appearances=[
+                    CompilationAppearance(
+                        release_id=5000,
+                        release_title="Warp 20 (Recreated)",
+                        other_artists=["Autechre"],
+                    ),
+                    CompilationAppearance(
+                        release_id=5001,
+                        release_title="Artificial Intelligence",
+                        other_artists=["Autechre"],
+                    ),
+                ],
+            ),
+        }
+
+        edges = extract_compilation_coappearance(enrichments)
+
+        assert len(edges) == 1
+        assert edges[0].compilation_count == 2
+        assert sorted(edges[0].compilation_titles) == [
+            "Artificial Intelligence",
+            "Warp 20 (Recreated)",
+        ]


### PR DESCRIPTION
## Summary

- Add `discogs_edges.py` with four pure edge extraction functions using inverted indexes
- Shared personnel: edges for artists sharing credited musicians
- Shared style: Jaccard similarity on Discogs style tags (min_jaccard threshold)
- Label family: edges for artists on same label (mega-label exclusion > 500 artists)
- Compilation co-appearance: edges for artists on same compilation
- Add four edge models: `SharedPersonnelEdge`, `SharedStyleEdge`, `LabelFamilyEdge`, `CompilationEdge`
- 22 new unit tests with parametrized Jaccard tests and combinatorial edge cases

Closes #39

## Test plan

- [x] 176 unit tests pass (154 existing + 22 new)
- [x] ruff, black, mypy all clean
- [ ] CI passes