### PR TITLE
Wire Discogs enrichment into pipeline and extend SQLite

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,12 +4,13 @@ Builds a semantic artist graph from WXYC DJ transition data. DJs curate transiti
 
 ## Architecture
 
-A batch pipeline that parses a tubafrenzy MySQL dump, extracts artist adjacency pairs from flowsheet data, computes PMI, and exports a GEXF graph and SQLite database.
+A batch pipeline that parses a tubafrenzy MySQL dump, resolves artist names via catalog and Discogs, extracts adjacency pairs and cross-reference edges, computes PMI, enriches artists with Discogs metadata, computes Discogs-derived edges, and exports a GEXF graph and SQLite database.
 
 ```
-SQL dump → sql_parser → models → artist_resolver → adjacency → pmi → graph_export → GEXF
-                                                  → cross_reference →──────────────→ SQLite
-                                                  → node_attributes →──────────────→
+SQL dump → sql_parser → artist_resolver → adjacency → pmi ──────────────→ graph_export → GEXF
+                       → cross_reference ────────────────────────────────→ sqlite_export → SQLite
+                       → node_attributes ────────────────────────────────→
+         → discogs_client → discogs_enrichment → discogs_edges ─────────→
 ```
 
 ### Modules
@@ -17,14 +18,17 @@ SQL dump → sql_parser → models → artist_resolver → adjacency → pmi →
 | Module | Responsibility |
 |--------|---------------|
 | `semantic_index/sql_parser.py` | Parse MySQL INSERT statements from SQL dump files. Streaming interface for large files. |
-| `semantic_index/models.py` | Pydantic data models for flowsheet entries, library records, adjacency pairs, PMI edges. |
-| `semantic_index/artist_resolver.py` | Tier 1 artist name resolution via catalog FK chain (LIBRARY_RELEASE → LIBRARY_CODE). |
+| `semantic_index/models.py` | Pydantic data models for all pipeline entities. |
+| `semantic_index/artist_resolver.py` | Multi-tier artist name resolution: FK chain, name match, normalized, fuzzy (Jaro-Winkler), Discogs, raw fallback. |
 | `semantic_index/adjacency.py` | Extract consecutive artist pairs within radio shows. |
 | `semantic_index/pmi.py` | Compute Pointwise Mutual Information for artist co-occurrences. |
 | `semantic_index/node_attributes.py` | Extract and compute per-artist temporal, DJ, and request statistics. |
 | `semantic_index/cross_reference.py` | Extract cross-reference edges from catalog cross-reference tables. |
+| `semantic_index/discogs_client.py` | Two-tier Discogs client: discogs-cache PostgreSQL with library-metadata-lookup API fallback. |
+| `semantic_index/discogs_enrichment.py` | Aggregate Discogs metadata (styles, personnel, labels, compilations) per artist. |
+| `semantic_index/discogs_edges.py` | Compute Discogs-derived edges: shared personnel, shared style (Jaccard), label family, compilation co-appearance. |
 | `semantic_index/graph_export.py` | Build NetworkX graph and export GEXF. |
-| `semantic_index/sqlite_export.py` | Build and export SQLite graph database. |
+| `semantic_index/sqlite_export.py` | Build and export SQLite graph database with enrichment and edge tables. |
 | `run_pipeline.py` | CLI entry point wiring the pipeline. |
 
 ### Column Mappings (0-indexed from SQL INSERT order)

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
-"""Pipeline CLI: extract adjacency pairs, cross-references, and PMI from a tubafrenzy SQL dump.
+"""Pipeline CLI: extract adjacency pairs, cross-references, PMI, and Discogs enrichment.
 
 Usage:
     python run_pipeline.py /path/to/wxycmusic.sql [--output-dir output/] [--min-count 2]
+    python run_pipeline.py dump.sql --discogs-cache-dsn postgresql://... --api-base-url https://...
 """
 
 import argparse
 import logging
+import os
 import sys
 import time
 from pathlib import Path
@@ -14,6 +16,14 @@ from pathlib import Path
 from semantic_index.adjacency import extract_adjacency_pairs
 from semantic_index.artist_resolver import ArtistResolver
 from semantic_index.cross_reference import CrossReferenceExtractor
+from semantic_index.discogs_client import DiscogsClient
+from semantic_index.discogs_edges import (
+    extract_compilation_coappearance,
+    extract_label_family,
+    extract_shared_personnel,
+    extract_shared_styles,
+)
+from semantic_index.discogs_enrichment import DiscogsEnricher
 from semantic_index.graph_export import build_graph, export_gexf, print_top_neighbors
 from semantic_index.models import (
     FlowsheetEntry,
@@ -59,6 +69,26 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument("--verbose", "-v", action="store_true", help="Enable debug logging")
     parser.add_argument("--no-sqlite", action="store_true", help="Skip SQLite database export")
+    parser.add_argument(
+        "--discogs-cache-dsn",
+        default=os.environ.get("DATABASE_URL_DISCOGS"),
+        help="PostgreSQL DSN for discogs-cache (default: DATABASE_URL_DISCOGS env var)",
+    )
+    parser.add_argument(
+        "--api-base-url",
+        default="https://library-metadata-lookup-staging.up.railway.app",
+        help="Base URL for library-metadata-lookup API",
+    )
+    parser.add_argument("--skip-enrichment", action="store_true", help="Skip Discogs enrichment")
+    parser.add_argument(
+        "--min-jaccard", type=float, default=0.1, help="Minimum Jaccard for shared style edges"
+    )
+    parser.add_argument(
+        "--max-label-artists",
+        type=int,
+        default=500,
+        help="Exclude labels with more than N artists from label family edges",
+    )
     return parser.parse_args(argv)
 
 
@@ -197,10 +227,44 @@ def run(args: argparse.Namespace) -> None:
 
     xref_edges = lc_xrefs + rel_xrefs
 
-    # 10. Print top neighbors for spotlight artists
+    # 10. Discogs enrichment (optional)
+    enrichments = {}
+    sp_edges = []
+    ss_edges = []
+    lf_edges = []
+    comp_edges = []
+
+    if not args.skip_enrichment and (args.discogs_cache_dsn or args.api_base_url):
+        log.info("Setting up Discogs client...")
+        discogs_client = DiscogsClient(
+            cache_dsn=args.discogs_cache_dsn,
+            api_base_url=args.api_base_url,
+        )
+
+        # Enrich all canonical artists
+        log.info("Enriching artists with Discogs metadata...")
+        enricher = DiscogsEnricher(discogs_client)
+        artist_ids = dict.fromkeys(artist_stats)
+        enrichments = enricher.enrich_batch(artist_ids)
+        log.info("  %d artists enriched", len(enrichments))
+
+        # Extract Discogs-derived edges
+        log.info("Extracting Discogs-derived edges...")
+        sp_edges = extract_shared_personnel(enrichments)
+        log.info("  %d shared personnel edges", len(sp_edges))
+        ss_edges = extract_shared_styles(enrichments, min_jaccard=args.min_jaccard)
+        log.info("  %d shared style edges", len(ss_edges))
+        lf_edges = extract_label_family(enrichments, max_label_artists=args.max_label_artists)
+        log.info("  %d label family edges", len(lf_edges))
+        comp_edges = extract_compilation_coappearance(enrichments)
+        log.info("  %d compilation edges", len(comp_edges))
+    elif not args.skip_enrichment:
+        log.warning("Skipping Discogs enrichment: no cache DSN or API URL available")
+
+    # 11. Print top neighbors for spotlight artists
     print_top_neighbors(edges, SPOTLIGHT_ARTISTS, n=20)
 
-    # 11. Build graph and export GEXF
+    # 12. Build graph and export GEXF
     log.info("Building graph (min_count=%d)...", args.min_count)
     graph = build_graph(edges, artist_stats, min_count=args.min_count)
     log.info("  %d nodes, %d edges", graph.number_of_nodes(), graph.number_of_edges())
@@ -209,7 +273,7 @@ def run(args: argparse.Namespace) -> None:
     export_gexf(graph, str(gexf_path))
     log.info("GEXF written to %s", gexf_path)
 
-    # 12. Export SQLite database
+    # 13. Export SQLite database
     sqlite_path = output_dir / "wxyc_artist_graph.db"
     if not args.no_sqlite:
         log.info("Exporting SQLite database...")
@@ -219,6 +283,11 @@ def run(args: argparse.Namespace) -> None:
             pmi_edges=edges,
             xref_edges=xref_edges,
             min_count=args.min_count,
+            enrichments=enrichments,
+            shared_personnel_edges=sp_edges,
+            shared_style_edges=ss_edges,
+            label_family_edges=lf_edges,
+            compilation_edges=comp_edges,
         )
         log.info("SQLite written to %s", sqlite_path)
 
@@ -240,6 +309,12 @@ def run(args: argparse.Namespace) -> None:
     print(f"  Adjacency pairs:         {len(pairs):>12,}")
     print(f"  Unique PMI edges:        {len(edges):>12,}")
     print(f"  Cross-ref edges:         {len(xref_edges):>12,}")
+    if enrichments:
+        print(f"  Enriched artists:        {len(enrichments):>12,}")
+        print(f"  Shared personnel edges:  {len(sp_edges):>12,}")
+        print(f"  Shared style edges:      {len(ss_edges):>12,}")
+        print(f"  Label family edges:      {len(lf_edges):>12,}")
+        print(f"  Compilation edges:       {len(comp_edges):>12,}")
     print(f"  Graph nodes:             {graph.number_of_nodes():>12,}")
     print(f"  Graph edges:             {graph.number_of_edges():>12,}")
     print(f"  GEXF output:             {gexf_path}")

--- a/semantic_index/sqlite_export.py
+++ b/semantic_index/sqlite_export.py
@@ -1,13 +1,27 @@
 """Export the artist graph to a SQLite database.
 
-Creates an artist table with node attributes, a dj_transition table for
-PMI-weighted edges, and a cross_reference table for catalog cross-reference edges.
+Creates an artist table with node attributes, edge tables for DJ transitions,
+cross-references, and Discogs-derived relationships (shared personnel, styles,
+labels, compilations), plus enrichment tables for per-artist Discogs metadata.
 """
 
+from __future__ import annotations
+
+import json
 import logging
 import sqlite3
+from typing import TYPE_CHECKING
 
 from semantic_index.models import ArtistStats, CrossReferenceEdge, PmiEdge
+
+if TYPE_CHECKING:
+    from semantic_index.models import (
+        ArtistEnrichment,
+        CompilationEdge,
+        LabelFamilyEdge,
+        SharedPersonnelEdge,
+        SharedStyleEdge,
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -21,7 +35,8 @@ CREATE TABLE IF NOT EXISTS artist (
     active_last_year INTEGER,
     dj_count INTEGER NOT NULL DEFAULT 0,
     request_ratio REAL NOT NULL DEFAULT 0.0,
-    show_count INTEGER NOT NULL DEFAULT 0
+    show_count INTEGER NOT NULL DEFAULT 0,
+    discogs_artist_id INTEGER
 );
 
 CREATE TABLE IF NOT EXISTS dj_transition (
@@ -40,10 +55,68 @@ CREATE TABLE IF NOT EXISTS cross_reference (
     PRIMARY KEY (artist_a_id, artist_b_id, source)
 );
 
+CREATE TABLE IF NOT EXISTS artist_style (
+    artist_id INTEGER NOT NULL REFERENCES artist(id),
+    style_tag TEXT NOT NULL,
+    PRIMARY KEY (artist_id, style_tag)
+);
+
+CREATE TABLE IF NOT EXISTS artist_personnel (
+    artist_id INTEGER NOT NULL REFERENCES artist(id),
+    personnel_name TEXT NOT NULL,
+    role TEXT NOT NULL DEFAULT ''
+);
+
+CREATE TABLE IF NOT EXISTS artist_label (
+    artist_id INTEGER NOT NULL REFERENCES artist(id),
+    label_name TEXT NOT NULL,
+    label_id INTEGER,
+    PRIMARY KEY (artist_id, label_name)
+);
+
+CREATE TABLE IF NOT EXISTS shared_personnel (
+    artist_a_id INTEGER NOT NULL REFERENCES artist(id),
+    artist_b_id INTEGER NOT NULL REFERENCES artist(id),
+    shared_count INTEGER NOT NULL,
+    shared_names TEXT NOT NULL,
+    PRIMARY KEY (artist_a_id, artist_b_id)
+);
+
+CREATE TABLE IF NOT EXISTS shared_style (
+    artist_a_id INTEGER NOT NULL REFERENCES artist(id),
+    artist_b_id INTEGER NOT NULL REFERENCES artist(id),
+    jaccard REAL NOT NULL,
+    shared_tags TEXT NOT NULL,
+    PRIMARY KEY (artist_a_id, artist_b_id)
+);
+
+CREATE TABLE IF NOT EXISTS label_family (
+    artist_a_id INTEGER NOT NULL REFERENCES artist(id),
+    artist_b_id INTEGER NOT NULL REFERENCES artist(id),
+    shared_labels TEXT NOT NULL,
+    PRIMARY KEY (artist_a_id, artist_b_id)
+);
+
+CREATE TABLE IF NOT EXISTS compilation (
+    artist_a_id INTEGER NOT NULL REFERENCES artist(id),
+    artist_b_id INTEGER NOT NULL REFERENCES artist(id),
+    compilation_count INTEGER NOT NULL,
+    compilation_titles TEXT NOT NULL,
+    PRIMARY KEY (artist_a_id, artist_b_id)
+);
+
 CREATE INDEX IF NOT EXISTS idx_transition_source ON dj_transition(source_id, pmi DESC);
 CREATE INDEX IF NOT EXISTS idx_transition_target ON dj_transition(target_id, pmi DESC);
 CREATE INDEX IF NOT EXISTS idx_xref_a ON cross_reference(artist_a_id);
 CREATE INDEX IF NOT EXISTS idx_xref_b ON cross_reference(artist_b_id);
+CREATE INDEX IF NOT EXISTS idx_shared_personnel_a ON shared_personnel(artist_a_id);
+CREATE INDEX IF NOT EXISTS idx_shared_personnel_b ON shared_personnel(artist_b_id);
+CREATE INDEX IF NOT EXISTS idx_shared_style_a ON shared_style(artist_a_id);
+CREATE INDEX IF NOT EXISTS idx_shared_style_b ON shared_style(artist_b_id);
+CREATE INDEX IF NOT EXISTS idx_label_family_a ON label_family(artist_a_id);
+CREATE INDEX IF NOT EXISTS idx_label_family_b ON label_family(artist_b_id);
+CREATE INDEX IF NOT EXISTS idx_compilation_a ON compilation(artist_a_id);
+CREATE INDEX IF NOT EXISTS idx_compilation_b ON compilation(artist_b_id);
 """
 
 
@@ -53,6 +126,11 @@ def export_sqlite(
     pmi_edges: list[PmiEdge],
     xref_edges: list[CrossReferenceEdge],
     min_count: int = 2,
+    enrichments: dict[str, ArtistEnrichment] | None = None,
+    shared_personnel_edges: list[SharedPersonnelEdge] | None = None,
+    shared_style_edges: list[SharedStyleEdge] | None = None,
+    label_family_edges: list[LabelFamilyEdge] | None = None,
+    compilation_edges: list[CompilationEdge] | None = None,
 ) -> None:
     """Export the artist graph to a SQLite database.
 
@@ -62,6 +140,11 @@ def export_sqlite(
         pmi_edges: PMI-weighted DJ transition edges.
         xref_edges: Cross-reference edges from the library catalog.
         min_count: Minimum raw co-occurrence count for DJ transition edges.
+        enrichments: Optional Discogs enrichment data per artist.
+        shared_personnel_edges: Optional shared personnel edges.
+        shared_style_edges: Optional shared style edges.
+        label_family_edges: Optional label family edges.
+        compilation_edges: Optional compilation co-appearance edges.
     """
     conn = sqlite3.connect(path)
     conn.execute("PRAGMA journal_mode=WAL")
@@ -76,9 +159,12 @@ def export_sqlite(
         all_names.add(xref.artist_b)
 
     # Insert artists
+    enrichments = enrichments or {}
     artist_rows = []
     for name in sorted(all_names):
         stats = artist_stats.get(name)
+        enrich = enrichments.get(name)
+        discogs_id = enrich.discogs_artist_id if enrich else None
         if stats:
             artist_rows.append(
                 (
@@ -90,19 +176,19 @@ def export_sqlite(
                     stats.dj_count,
                     stats.request_ratio,
                     stats.show_count,
+                    discogs_id,
                 )
             )
         else:
-            # Catalog-only artist (from cross-references, not in flowsheet)
-            artist_rows.append((name, None, 0, None, None, 0, 0.0, 0))
+            artist_rows.append((name, None, 0, None, None, 0, 0.0, 0, discogs_id))
 
     conn.executemany(
         """
         INSERT INTO artist (
             canonical_name, genre, total_plays,
             active_first_year, active_last_year,
-            dj_count, request_ratio, show_count
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            dj_count, request_ratio, show_count, discogs_artist_id
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         artist_rows,
     )
@@ -140,6 +226,19 @@ def export_sqlite(
         xref_rows,
     )
 
+    # Insert enrichment data (styles, personnel, labels per artist)
+    _insert_enrichments(conn, enrichments, name_to_id)
+
+    # Insert Discogs-derived edges
+    _insert_discogs_edges(
+        conn,
+        name_to_id,
+        shared_personnel_edges or [],
+        shared_style_edges or [],
+        label_family_edges or [],
+        compilation_edges or [],
+    )
+
     conn.commit()
 
     artist_count = conn.execute("SELECT COUNT(*) FROM artist").fetchone()[0]
@@ -152,4 +251,121 @@ def export_sqlite(
         xref_count,
     )
 
+    for table in ("shared_personnel", "shared_style", "label_family", "compilation"):
+        count = conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]  # noqa: S608
+        if count > 0:
+            logger.info("  %s: %d edges", table, count)
+
     conn.close()
+
+
+def _insert_enrichments(
+    conn: sqlite3.Connection,
+    enrichments: dict[str, ArtistEnrichment],
+    name_to_id: dict[str, int],
+) -> None:
+    """Insert per-artist enrichment data (styles, personnel, labels)."""
+    style_rows = []
+    personnel_rows = []
+    label_rows = []
+
+    for name, enrich in enrichments.items():
+        artist_id = name_to_id.get(name)
+        if artist_id is None:
+            continue
+
+        for style in enrich.styles:
+            style_rows.append((artist_id, style))
+
+        for credit in enrich.personnel:
+            for role in credit.roles or [""]:
+                personnel_rows.append((artist_id, credit.name, role or ""))
+
+        for label in enrich.labels:
+            label_rows.append((artist_id, label.name, label.label_id))
+
+    if style_rows:
+        conn.executemany(
+            "INSERT OR IGNORE INTO artist_style (artist_id, style_tag) VALUES (?, ?)",
+            style_rows,
+        )
+    if personnel_rows:
+        conn.executemany(
+            "INSERT OR IGNORE INTO artist_personnel (artist_id, personnel_name, role) VALUES (?, ?, ?)",
+            personnel_rows,
+        )
+    if label_rows:
+        conn.executemany(
+            "INSERT OR IGNORE INTO artist_label (artist_id, label_name, label_id) VALUES (?, ?, ?)",
+            label_rows,
+        )
+
+
+def _resolve_edge_rows(
+    rows: list[tuple],
+    name_to_id: dict[str, int],
+) -> list[tuple]:
+    """Map artist names in first two columns to IDs."""
+    resolved = []
+    for row in rows:
+        a_id = name_to_id.get(row[0])
+        b_id = name_to_id.get(row[1])
+        if a_id is not None and b_id is not None:
+            resolved.append((a_id, b_id, *row[2:]))
+    return resolved
+
+
+def _insert_discogs_edges(
+    conn: sqlite3.Connection,
+    name_to_id: dict[str, int],
+    shared_personnel: list[SharedPersonnelEdge],
+    shared_styles: list[SharedStyleEdge],
+    label_family: list[LabelFamilyEdge],
+    compilations: list[CompilationEdge],
+) -> None:
+    """Insert Discogs-derived edge tables."""
+    rows = _resolve_edge_rows(
+        [
+            (e.artist_a, e.artist_b, e.shared_count, json.dumps(e.shared_names))
+            for e in shared_personnel
+        ],
+        name_to_id,
+    )
+    if rows:
+        conn.executemany(
+            "INSERT OR IGNORE INTO shared_personnel (artist_a_id, artist_b_id, shared_count, shared_names) VALUES (?, ?, ?, ?)",
+            rows,
+        )
+
+    rows = _resolve_edge_rows(
+        [(e.artist_a, e.artist_b, e.jaccard, json.dumps(e.shared_tags)) for e in shared_styles],
+        name_to_id,
+    )
+    if rows:
+        conn.executemany(
+            "INSERT OR IGNORE INTO shared_style (artist_a_id, artist_b_id, jaccard, shared_tags) VALUES (?, ?, ?, ?)",
+            rows,
+        )
+
+    rows = _resolve_edge_rows(
+        [(e.artist_a, e.artist_b, json.dumps(e.shared_labels)) for e in label_family],
+        name_to_id,
+    )
+    if rows:
+        conn.executemany(
+            "INSERT OR IGNORE INTO label_family (artist_a_id, artist_b_id, shared_labels) VALUES (?, ?, ?)",
+            rows,
+        )
+
+    rows = _resolve_edge_rows(
+        [
+            (e.artist_a, e.artist_b, e.compilation_count, json.dumps(e.compilation_titles))
+            for e in compilations
+        ],
+        name_to_id,
+    )
+    if rows:
+        conn.executemany(
+            "INSERT OR IGNORE INTO compilation (artist_a_id, artist_b_id, compilation_count, compilation_titles) VALUES (?, ?, ?, ?)",
+            rows,
+        )

--- a/tests/unit/test_sqlite_export.py
+++ b/tests/unit/test_sqlite_export.py
@@ -27,6 +27,13 @@ class TestSchemaCreation:
         assert "artist" in tables
         assert "dj_transition" in tables
         assert "cross_reference" in tables
+        assert "artist_style" in tables
+        assert "artist_personnel" in tables
+        assert "artist_label" in tables
+        assert "shared_personnel" in tables
+        assert "shared_style" in tables
+        assert "label_family" in tables
+        assert "compilation" in tables
 
     def test_indexes_exist(self):
         conn, _ = _export_and_connect(artist_stats={}, pmi_edges=[], xref_edges=[])


### PR DESCRIPTION
## Summary

- Add CLI flags: `--discogs-cache-dsn`, `--api-base-url`, `--skip-enrichment`, `--min-jaccard`, `--max-label-artists`
- Wire DiscogsClient → DiscogsEnricher → edge extraction into the pipeline
- Extend SQLite with 7 new tables: `artist_style`, `artist_personnel`, `artist_label`, `shared_personnel`, `shared_style`, `label_family`, `compilation`
- Add `discogs_artist_id` column to `artist` table
- Update CLAUDE.md with new modules and architecture diagram
- Graceful degradation when Discogs backends unavailable

**Note:** This PR includes PR 4's commit (discogs_edges.py) via cherry-pick. Merge PR 4 (#40) first, then this PR will rebase cleanly.

Closes #41

## Test plan

- [x] 176 unit tests pass
- [x] ruff, black, mypy all clean
- [ ] CI passes
- [ ] `python run_pipeline.py dump.sql --skip-enrichment` still works (existing behavior)
- [ ] `python run_pipeline.py dump.sql --discogs-cache-dsn postgresql://...` produces enriched SQLite