### PR TITLE
Fix explorer API_BASE URL parsing in production

### DIFF
--- a/explorer/index.html
+++ b/explorer/index.html
@@ -84,7 +84,7 @@
 <script>
 const API_BASE = window.location.hostname === 'localhost' || window.location.protocol === 'file:'
   ? 'http://localhost:8000'
-  : '';  // Same origin in production
+  : window.location.origin;
 
 const GENRE_COLORS = {
   'Electronic': '#4fc3f7',


### PR DESCRIPTION
## Summary

- Fix `new URL(path, API_BASE)` failing in production because an empty string is not a valid base URL
- Use `window.location.origin` instead, which provides the full scheme + host (e.g. `https://semantic-index-production.up.railway.app`)

## Test plan

- [ ] Verify the explorer loads and searches work on the Railway deployment
- [ ] Verify local development still uses `http://localhost:8000`