### PR TITLE
Add entity store Pydantic models and test factory

### DIFF
--- a/semantic_index/models.py
+++ b/semantic_index/models.py
@@ -212,3 +212,35 @@ class CompilationEdge(BaseModel):
     artist_b: str
     compilation_count: int
     compilation_titles: list[str]
+
+
+# --- Entity store models ---
+
+
+class Entity(BaseModel):
+    """A real-world person, group, or organization in the entity store."""
+
+    id: int
+    wikidata_qid: str | None = None
+    name: str
+    entity_type: str = "artist"
+
+
+class ReconciliationEvent(BaseModel):
+    """A single reconciliation lookup result from an external knowledge base."""
+
+    source: str  # 'discogs', 'musicbrainz', 'wikidata'
+    external_id: str
+    confidence: float | None = None
+    method: str  # 'exact', 'fuzzy', 'api_search', 'cache_lookup'
+
+
+class ReconciliationReport(BaseModel):
+    """Summary of a reconciliation batch run."""
+
+    total: int  # Total artists in the input set
+    attempted: int  # Artists where reconciliation was attempted (status was 'unreconciled')
+    succeeded: int  # Attempts that found at least one external match
+    no_match: int  # Attempts where the lookup returned no result
+    errored: int  # Attempts that failed due to an exception
+    skipped: int  # Artists already in 'partial' or 'reconciled' status

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ from semantic_index.models import (
     DiscogsLabel,
     DiscogsRelease,
     DiscogsTrack,
+    Entity,
     FlowsheetEntry,
     LabelInfo,
     LibraryCode,
@@ -158,3 +159,15 @@ def make_personnel_credit(
         name=name,
         roles=roles if roles is not None else ["Written-By"],
     )
+
+
+def make_entity(
+    name: str = "Autechre",
+    entity_type: str = "artist",
+    wikidata_qid: str | None = None,
+) -> Entity:
+    """Create an Entity instance for testing.
+
+    Uses a fixed id=1 since the real id is assigned by SQLite AUTOINCREMENT.
+    """
+    return Entity(id=1, name=name, entity_type=entity_type, wikidata_qid=wikidata_qid)

--- a/tests/unit/test_entity_store_models.py
+++ b/tests/unit/test_entity_store_models.py
@@ -1,0 +1,118 @@
+"""Tests for entity store Pydantic models and factory functions."""
+
+import pytest
+
+from semantic_index.models import Entity, ReconciliationEvent, ReconciliationReport
+from tests.conftest import make_entity
+
+
+class TestEntity:
+    def test_defaults(self):
+        entity = Entity(id=1, name="Autechre")
+        assert entity.id == 1
+        assert entity.name == "Autechre"
+        assert entity.entity_type == "artist"
+        assert entity.wikidata_qid is None
+
+    def test_with_wikidata_qid(self):
+        entity = Entity(id=1, name="Autechre", wikidata_qid="Q207406")
+        assert entity.wikidata_qid == "Q207406"
+
+    def test_entity_type_override(self):
+        entity = Entity(id=1, name="Warp Records", entity_type="label")
+        assert entity.entity_type == "label"
+
+
+class TestReconciliationEvent:
+    def test_required_fields(self):
+        event = ReconciliationEvent(
+            source="discogs",
+            external_id="42",
+            method="exact",
+        )
+        assert event.source == "discogs"
+        assert event.external_id == "42"
+        assert event.method == "exact"
+        assert event.confidence is None
+
+    def test_with_confidence(self):
+        event = ReconciliationEvent(
+            source="musicbrainz",
+            external_id="a7f7df4a-77d8-4f12-8acd-5c60c93f4de8",
+            confidence=0.95,
+            method="fuzzy",
+        )
+        assert event.confidence == 0.95
+
+    @pytest.mark.parametrize(
+        "source",
+        ["discogs", "musicbrainz", "wikidata"],
+    )
+    def test_valid_sources(self, source: str):
+        event = ReconciliationEvent(source=source, external_id="1", method="exact")
+        assert event.source == source
+
+    @pytest.mark.parametrize(
+        "method",
+        ["exact", "fuzzy", "api_search", "cache_lookup"],
+    )
+    def test_valid_methods(self, method: str):
+        event = ReconciliationEvent(source="discogs", external_id="1", method=method)
+        assert event.method == method
+
+
+class TestReconciliationReport:
+    def test_all_fields(self):
+        report = ReconciliationReport(
+            total=100,
+            attempted=80,
+            succeeded=60,
+            no_match=15,
+            errored=5,
+            skipped=20,
+        )
+        assert report.total == 100
+        assert report.attempted == 80
+        assert report.succeeded == 60
+        assert report.no_match == 15
+        assert report.errored == 5
+        assert report.skipped == 20
+
+    def test_counts_are_consistent(self):
+        """attempted + skipped == total; succeeded + no_match + errored == attempted."""
+        report = ReconciliationReport(
+            total=50,
+            attempted=40,
+            succeeded=30,
+            no_match=8,
+            errored=2,
+            skipped=10,
+        )
+        assert report.attempted + report.skipped == report.total
+        assert report.succeeded + report.no_match + report.errored == report.attempted
+
+    def test_zero_report(self):
+        report = ReconciliationReport(
+            total=0, attempted=0, succeeded=0, no_match=0, errored=0, skipped=0
+        )
+        assert report.total == 0
+
+
+class TestMakeEntity:
+    def test_defaults(self):
+        entity = make_entity()
+        assert entity.name == "Autechre"
+        assert entity.entity_type == "artist"
+        assert entity.wikidata_qid is None
+
+    def test_custom_name(self):
+        entity = make_entity(name="Stereolab")
+        assert entity.name == "Stereolab"
+
+    def test_custom_wikidata_qid(self):
+        entity = make_entity(wikidata_qid="Q207406")
+        assert entity.wikidata_qid == "Q207406"
+
+    def test_custom_entity_type(self):
+        entity = make_entity(entity_type="label")
+        assert entity.entity_type == "label"


### PR DESCRIPTION
## Summary

- Add `Entity`, `ReconciliationEvent`, and `ReconciliationReport` Pydantic models to `semantic_index/models.py` for the knowledge graph entity store
- Add `make_entity()` factory function to `tests/conftest.py` for use in entity store tests
- Add 19 unit tests covering all three models and the factory function

The `make_entity_store()` factory depends on the `EntityStore` class from #53 and will be added in that PR.

Closes #56

## Test plan

- [x] All 19 new tests in `test_entity_store_models.py` pass
- [x] Full unit test suite (202 tests) passes
- [x] `ruff check` and `ruff format --check` pass
- [x] `mypy` clean (no new errors)