### PR TITLE
Entity Store: CRUD operations, artist upsert, and stats update

### DIFF
--- a/semantic_index/entity_store.py
+++ b/semantic_index/entity_store.py
@@ -4,6 +4,9 @@ Manages the entity store tables within a SQLite database: entity (Wikidata QID,
 display name, type), artist migration (adds external ID columns to existing artist
 tables), and Phase 2 placeholder tables (release, label, label_hierarchy).
 
+Provides CRUD operations for entities, artist upsert with COALESCE semantics
+(never overwrites populated fields with NULL), and bulk stat updates.
+
 The ``initialize()`` method is fully idempotent — safe on a fresh database,
 an old-schema database, or an already-migrated database.
 """
@@ -13,6 +16,8 @@ from __future__ import annotations
 import logging
 import sqlite3
 from types import TracebackType
+
+from semantic_index.models import ArtistStats, Entity
 
 logger = logging.getLogger(__name__)
 
@@ -157,6 +162,248 @@ class EntityStore:
                    SET created_at = COALESCE(created_at, strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
                        updated_at = COALESCE(updated_at, strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"""
             )
+
+    # ------------------------------------------------------------------
+    # Entity CRUD
+    # ------------------------------------------------------------------
+
+    def get_or_create_entity(
+        self,
+        name: str,
+        entity_type: str,
+        wikidata_qid: str | None = None,
+    ) -> Entity:
+        """Return an existing entity by name+type, or create a new one.
+
+        If the entity already exists, its wikidata_qid is not overwritten.
+
+        Args:
+            name: Display name of the entity.
+            entity_type: One of 'artist', 'label', etc.
+            wikidata_qid: Optional Wikidata QID to set on creation.
+
+        Returns:
+            The existing or newly created Entity.
+        """
+        row = self._conn.execute(
+            "SELECT id, wikidata_qid, name, entity_type FROM entity WHERE name = ? AND entity_type = ?",
+            (name, entity_type),
+        ).fetchone()
+        if row is not None:
+            return Entity(id=row[0], wikidata_qid=row[1], name=row[2], entity_type=row[3])
+
+        cur = self._conn.execute(
+            "INSERT INTO entity (name, entity_type, wikidata_qid) VALUES (?, ?, ?)",
+            (name, entity_type, wikidata_qid),
+        )
+        self._conn.commit()
+        return Entity(
+            id=cur.lastrowid,  # type: ignore[arg-type]
+            name=name,
+            entity_type=entity_type,
+            wikidata_qid=wikidata_qid,
+        )
+
+    def update_entity_qid(self, entity_id: int, wikidata_qid: str) -> None:
+        """Set the Wikidata QID for an entity.
+
+        Args:
+            entity_id: The entity's primary key.
+            wikidata_qid: The Wikidata QID to assign.
+
+        Raises:
+            ValueError: If no entity with the given id exists.
+        """
+        cur = self._conn.execute(
+            "UPDATE entity SET wikidata_qid = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') WHERE id = ?",
+            (wikidata_qid, entity_id),
+        )
+        if cur.rowcount == 0:
+            raise ValueError(f"No entity with id {entity_id}")
+        self._conn.commit()
+
+    def get_entity_by_qid(self, wikidata_qid: str) -> Entity | None:
+        """Look up an entity by Wikidata QID.
+
+        Args:
+            wikidata_qid: The Wikidata QID to search for.
+
+        Returns:
+            The matching Entity, or None if not found.
+        """
+        row = self._conn.execute(
+            "SELECT id, wikidata_qid, name, entity_type FROM entity WHERE wikidata_qid = ?",
+            (wikidata_qid,),
+        ).fetchone()
+        if row is None:
+            return None
+        return Entity(id=row[0], wikidata_qid=row[1], name=row[2], entity_type=row[3])
+
+    def merge_entities(self, keep_id: int, merge_id: int) -> None:
+        """Merge two entities: re-parent artists from merge_id to keep_id, then delete merge_id.
+
+        Args:
+            keep_id: The entity ID to keep.
+            merge_id: The entity ID to merge into keep_id and delete.
+
+        Raises:
+            ValueError: If keep_id == merge_id, or if either entity doesn't exist.
+        """
+        if keep_id == merge_id:
+            raise ValueError("Cannot merge an entity into itself")
+
+        for eid, label in [(keep_id, "keep"), (merge_id, "merge")]:
+            row = self._conn.execute("SELECT id FROM entity WHERE id = ?", (eid,)).fetchone()
+            if row is None:
+                raise ValueError(f"No entity with id {eid} ({label})")
+
+        self._conn.execute(
+            "UPDATE artist SET entity_id = ? WHERE entity_id = ?", (keep_id, merge_id)
+        )
+        self._conn.execute("DELETE FROM entity WHERE id = ?", (merge_id,))
+        self._conn.commit()
+
+    # ------------------------------------------------------------------
+    # Artist Upsert
+    # ------------------------------------------------------------------
+
+    def upsert_artist(
+        self,
+        canonical_name: str,
+        *,
+        genre: str | None = None,
+        discogs_artist_id: int | None = None,
+        entity_id: int | None = None,
+        musicbrainz_artist_id: str | None = None,
+        wxyc_library_code_id: int | None = None,
+    ) -> int:
+        """Insert or update an artist row using COALESCE semantics.
+
+        On conflict (canonical_name), only updates fields where the new value
+        is not NULL — existing populated fields are never overwritten with NULL.
+
+        Args:
+            canonical_name: The artist's canonical name (unique key).
+            genre: Genre string.
+            discogs_artist_id: Discogs artist ID.
+            entity_id: FK to the entity table.
+            musicbrainz_artist_id: MusicBrainz artist UUID.
+            wxyc_library_code_id: WXYC library code ID.
+
+        Returns:
+            The artist row's integer primary key.
+        """
+        cur = self._conn.execute(
+            """INSERT INTO artist (canonical_name, genre, discogs_artist_id, entity_id,
+                                   musicbrainz_artist_id, wxyc_library_code_id,
+                                   updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+               ON CONFLICT(canonical_name) DO UPDATE SET
+                   genre = COALESCE(excluded.genre, artist.genre),
+                   discogs_artist_id = COALESCE(excluded.discogs_artist_id, artist.discogs_artist_id),
+                   entity_id = COALESCE(excluded.entity_id, artist.entity_id),
+                   musicbrainz_artist_id = COALESCE(excluded.musicbrainz_artist_id, artist.musicbrainz_artist_id),
+                   wxyc_library_code_id = COALESCE(excluded.wxyc_library_code_id, artist.wxyc_library_code_id),
+                   updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+               RETURNING id""",
+            (
+                canonical_name,
+                genre,
+                discogs_artist_id,
+                entity_id,
+                musicbrainz_artist_id,
+                wxyc_library_code_id,
+            ),
+        )
+        row = cur.fetchone()
+        self._conn.commit()
+        assert row is not None  # RETURNING always yields a row
+        return int(row[0])
+
+    def get_artist_by_name(self, canonical_name: str) -> dict[str, object] | None:
+        """Look up an artist row by canonical name.
+
+        Args:
+            canonical_name: The artist's canonical name.
+
+        Returns:
+            A dict of column name -> value, or None if not found.
+        """
+        self._conn.row_factory = sqlite3.Row
+        row = self._conn.execute(
+            "SELECT * FROM artist WHERE canonical_name = ?", (canonical_name,)
+        ).fetchone()
+        self._conn.row_factory = None
+        if row is None:
+            return None
+        return dict(row)
+
+    def bulk_upsert_artists(self, names: list[str]) -> dict[str, int]:
+        """Insert or retrieve artist rows for a list of canonical names.
+
+        This is the main pipeline entry point for ensuring artist rows exist.
+        Deduplicates the input list.
+
+        Args:
+            names: List of canonical artist names.
+
+        Returns:
+            Dict mapping canonical_name -> artist row id.
+        """
+        unique_names = list(dict.fromkeys(names))
+        result: dict[str, int] = {}
+        for name in unique_names:
+            result[name] = self.upsert_artist(name)
+        return result
+
+    # ------------------------------------------------------------------
+    # Artist Stats
+    # ------------------------------------------------------------------
+
+    def update_artist_stats(self, canonical_name: str, stats: ArtistStats) -> None:
+        """Update stats columns for a single artist.
+
+        Args:
+            canonical_name: The artist's canonical name.
+            stats: The ArtistStats to apply.
+
+        Raises:
+            ValueError: If no artist with the given name exists.
+        """
+        cur = self._conn.execute(
+            """UPDATE artist SET
+                   total_plays = ?,
+                   genre = COALESCE(?, genre),
+                   active_first_year = ?,
+                   active_last_year = ?,
+                   dj_count = ?,
+                   request_ratio = ?,
+                   show_count = ?,
+                   updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+               WHERE canonical_name = ?""",
+            (
+                stats.total_plays,
+                stats.genre,
+                stats.active_first_year,
+                stats.active_last_year,
+                stats.dj_count,
+                stats.request_ratio,
+                stats.show_count,
+                canonical_name,
+            ),
+        )
+        if cur.rowcount == 0:
+            raise ValueError(f"No artist with canonical_name '{canonical_name}'")
+        self._conn.commit()
+
+    def bulk_update_stats(self, artist_stats: dict[str, ArtistStats]) -> None:
+        """Update stats for multiple artists in a single transaction.
+
+        Args:
+            artist_stats: Dict mapping canonical_name -> ArtistStats.
+        """
+        for name, stats in artist_stats.items():
+            self.update_artist_stats(name, stats)
 
     def close(self) -> None:
         """Close the database connection."""

--- a/tests/unit/test_entity_store_crud.py
+++ b/tests/unit/test_entity_store_crud.py
@@ -1,0 +1,318 @@
+"""Tests for EntityStore CRUD operations, artist upsert, and stats update."""
+
+import sqlite3
+
+import pytest
+
+from semantic_index.entity_store import EntityStore
+from semantic_index.models import ArtistStats
+
+# The old artist schema — matches sqlite_export._SCHEMA artist table
+_OLD_ARTIST_SCHEMA = """
+CREATE TABLE artist (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    canonical_name TEXT NOT NULL UNIQUE,
+    genre TEXT,
+    total_plays INTEGER NOT NULL DEFAULT 0,
+    active_first_year INTEGER,
+    active_last_year INTEGER,
+    dj_count INTEGER NOT NULL DEFAULT 0,
+    request_ratio REAL NOT NULL DEFAULT 0.0,
+    show_count INTEGER NOT NULL DEFAULT 0,
+    discogs_artist_id INTEGER
+);
+"""
+
+
+@pytest.fixture()
+def store(tmp_path) -> EntityStore:
+    """An initialized EntityStore with a pre-migrated artist table."""
+    db_path = str(tmp_path / "test.db")
+    conn = sqlite3.connect(db_path)
+    conn.executescript(_OLD_ARTIST_SCHEMA)
+    conn.close()
+    s = EntityStore(db_path)
+    s.initialize()
+    return s
+
+
+# ---------------------------------------------------------------------------
+# Step 2: Entity CRUD
+# ---------------------------------------------------------------------------
+
+
+class TestGetOrCreateEntity:
+    def test_creates_new_entity(self, store: EntityStore):
+        entity = store.get_or_create_entity("Autechre", "artist")
+        assert entity.name == "Autechre"
+        assert entity.entity_type == "artist"
+        assert entity.id is not None
+        assert entity.wikidata_qid is None
+
+    def test_returns_existing_entity(self, store: EntityStore):
+        first = store.get_or_create_entity("Stereolab", "artist")
+        second = store.get_or_create_entity("Stereolab", "artist")
+        assert first.id == second.id
+
+    def test_with_wikidata_qid(self, store: EntityStore):
+        entity = store.get_or_create_entity("Autechre", "artist", wikidata_qid="Q207406")
+        assert entity.wikidata_qid == "Q207406"
+
+    def test_different_entity_types(self, store: EntityStore):
+        artist = store.get_or_create_entity("Warp Records", "label")
+        assert artist.entity_type == "label"
+
+    def test_get_or_create_does_not_overwrite_existing_qid(self, store: EntityStore):
+        """If an entity already has a QID, get_or_create should not overwrite it."""
+        store.get_or_create_entity("Autechre", "artist", wikidata_qid="Q207406")
+        again = store.get_or_create_entity("Autechre", "artist", wikidata_qid="Q999999")
+        assert again.wikidata_qid == "Q207406"
+
+
+class TestUpdateEntityQid:
+    def test_update_qid(self, store: EntityStore):
+        entity = store.get_or_create_entity("Cat Power", "artist")
+        assert entity.wikidata_qid is None
+        store.update_entity_qid(entity.id, "Q271362")
+        updated = store.get_entity_by_qid("Q271362")
+        assert updated is not None
+        assert updated.name == "Cat Power"
+
+    def test_update_qid_nonexistent_entity(self, store: EntityStore):
+        with pytest.raises(ValueError, match="No entity with id"):
+            store.update_entity_qid(9999, "Q123")
+
+
+class TestGetEntityByQid:
+    def test_found(self, store: EntityStore):
+        store.get_or_create_entity("Autechre", "artist", wikidata_qid="Q207406")
+        entity = store.get_entity_by_qid("Q207406")
+        assert entity is not None
+        assert entity.name == "Autechre"
+
+    def test_not_found(self, store: EntityStore):
+        result = store.get_entity_by_qid("Q000000")
+        assert result is None
+
+
+class TestMergeEntities:
+    def test_merge_reparents_artists(self, store: EntityStore):
+        keep = store.get_or_create_entity("Autechre", "artist")
+        merge = store.get_or_create_entity("Autechre (UK)", "artist")
+
+        # Create an artist row linked to the merge entity
+        store._conn.execute(
+            """INSERT INTO artist (canonical_name, total_plays, dj_count, request_ratio, show_count, entity_id)
+               VALUES ('Autechre (UK)', 5, 2, 0.0, 3, ?)""",
+            (merge.id,),
+        )
+        store._conn.commit()
+
+        store.merge_entities(keep.id, merge.id)
+
+        # Artist should now point to the keep entity
+        row = store._conn.execute(
+            "SELECT entity_id FROM artist WHERE canonical_name = 'Autechre (UK)'"
+        ).fetchone()
+        assert row[0] == keep.id
+
+        # Merged entity should be deleted
+        row = store._conn.execute("SELECT id FROM entity WHERE id = ?", (merge.id,)).fetchone()
+        assert row is None
+
+    def test_merge_nonexistent_raises(self, store: EntityStore):
+        keep = store.get_or_create_entity("Autechre", "artist")
+        with pytest.raises(ValueError, match="No entity with id"):
+            store.merge_entities(keep.id, 9999)
+
+    def test_merge_same_entity_raises(self, store: EntityStore):
+        entity = store.get_or_create_entity("Autechre", "artist")
+        with pytest.raises(ValueError, match="Cannot merge"):
+            store.merge_entities(entity.id, entity.id)
+
+
+# ---------------------------------------------------------------------------
+# Step 3: Artist Upsert
+# ---------------------------------------------------------------------------
+
+
+class TestUpsertArtist:
+    def test_insert_new_artist(self, store: EntityStore):
+        artist_id = store.upsert_artist("Autechre")
+        assert artist_id is not None
+        row = store._conn.execute(
+            "SELECT canonical_name FROM artist WHERE id = ?", (artist_id,)
+        ).fetchone()
+        assert row[0] == "Autechre"
+
+    def test_upsert_existing_returns_same_id(self, store: EntityStore):
+        first_id = store.upsert_artist("Stereolab")
+        second_id = store.upsert_artist("Stereolab")
+        assert first_id == second_id
+
+    def test_upsert_with_genre(self, store: EntityStore):
+        store.upsert_artist("Autechre", genre="Electronic")
+        row = store._conn.execute(
+            "SELECT genre FROM artist WHERE canonical_name = 'Autechre'"
+        ).fetchone()
+        assert row[0] == "Electronic"
+
+    def test_upsert_does_not_overwrite_with_null(self, store: EntityStore):
+        """COALESCE semantics: NULL arguments don't clobber existing data."""
+        store.upsert_artist("Autechre", genre="Electronic")
+        store.upsert_artist("Autechre")  # genre=None
+        row = store._conn.execute(
+            "SELECT genre FROM artist WHERE canonical_name = 'Autechre'"
+        ).fetchone()
+        assert row[0] == "Electronic"
+
+    def test_upsert_updates_populated_field(self, store: EntityStore):
+        """An explicit non-None value should update an existing field."""
+        store.upsert_artist("Autechre", genre="Electronic")
+        store.upsert_artist("Autechre", genre="IDM")
+        row = store._conn.execute(
+            "SELECT genre FROM artist WHERE canonical_name = 'Autechre'"
+        ).fetchone()
+        assert row[0] == "IDM"
+
+    def test_upsert_with_discogs_artist_id(self, store: EntityStore):
+        store.upsert_artist("Autechre", discogs_artist_id=42)
+        row = store._conn.execute(
+            "SELECT discogs_artist_id FROM artist WHERE canonical_name = 'Autechre'"
+        ).fetchone()
+        assert row[0] == 42
+
+    def test_upsert_with_entity_id(self, store: EntityStore):
+        entity = store.get_or_create_entity("Autechre", "artist")
+        store.upsert_artist("Autechre", entity_id=entity.id)
+        row = store._conn.execute(
+            "SELECT entity_id FROM artist WHERE canonical_name = 'Autechre'"
+        ).fetchone()
+        assert row[0] == entity.id
+
+
+class TestGetArtistByName:
+    def test_found(self, store: EntityStore):
+        store.upsert_artist("Father John Misty", genre="Rock")
+        row = store.get_artist_by_name("Father John Misty")
+        assert row is not None
+        assert row["canonical_name"] == "Father John Misty"
+        assert row["genre"] == "Rock"
+
+    def test_not_found(self, store: EntityStore):
+        result = store.get_artist_by_name("Nonexistent Artist")
+        assert result is None
+
+
+class TestBulkUpsertArtists:
+    def test_bulk_upsert_creates_multiple(self, store: EntityStore):
+        names = ["Autechre", "Stereolab", "Cat Power", "Buck Meek"]
+        id_map = store.bulk_upsert_artists(names)
+        assert len(id_map) == 4
+        assert all(isinstance(v, int) for v in id_map.values())
+        assert set(id_map.keys()) == set(names)
+
+    def test_bulk_upsert_idempotent(self, store: EntityStore):
+        names = ["Autechre", "Stereolab"]
+        first = store.bulk_upsert_artists(names)
+        second = store.bulk_upsert_artists(names)
+        assert first == second
+
+    def test_bulk_upsert_mixed_existing_and_new(self, store: EntityStore):
+        store.upsert_artist("Autechre", genre="Electronic")
+        names = ["Autechre", "Juana Molina"]
+        id_map = store.bulk_upsert_artists(names)
+        assert len(id_map) == 2
+        # Original genre should be preserved
+        row = store._conn.execute(
+            "SELECT genre FROM artist WHERE canonical_name = 'Autechre'"
+        ).fetchone()
+        assert row[0] == "Electronic"
+
+    def test_bulk_upsert_empty_list(self, store: EntityStore):
+        id_map = store.bulk_upsert_artists([])
+        assert id_map == {}
+
+    def test_bulk_upsert_deduplicates_input(self, store: EntityStore):
+        names = ["Autechre", "Autechre", "Stereolab"]
+        id_map = store.bulk_upsert_artists(names)
+        assert len(id_map) == 2
+
+
+# ---------------------------------------------------------------------------
+# Step 4: Artist Stats
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateArtistStats:
+    def test_updates_stats_for_existing_artist(self, store: EntityStore):
+        store.upsert_artist("Autechre")
+        stats = ArtistStats(
+            canonical_name="Autechre",
+            total_plays=50,
+            genre="Electronic",
+            active_first_year=1998,
+            active_last_year=2024,
+            dj_count=15,
+            request_ratio=0.1,
+            show_count=40,
+        )
+        store.update_artist_stats("Autechre", stats)
+
+        row = store._conn.execute(
+            """SELECT total_plays, genre, active_first_year, active_last_year,
+                      dj_count, request_ratio, show_count
+               FROM artist WHERE canonical_name = 'Autechre'"""
+        ).fetchone()
+        assert row[0] == 50
+        assert row[1] == "Electronic"
+        assert row[2] == 1998
+        assert row[3] == 2024
+        assert row[4] == 15
+        assert row[5] == pytest.approx(0.1)
+        assert row[6] == 40
+
+    def test_updates_nonexistent_artist_raises(self, store: EntityStore):
+        stats = ArtistStats(canonical_name="Nobody", total_plays=1)
+        with pytest.raises(ValueError, match="No artist"):
+            store.update_artist_stats("Nobody", stats)
+
+
+class TestBulkUpdateStats:
+    def test_bulk_update_multiple_artists(self, store: EntityStore):
+        store.bulk_upsert_artists(["Autechre", "Stereolab", "Cat Power"])
+        artist_stats = {
+            "Autechre": ArtistStats(
+                canonical_name="Autechre", total_plays=50, genre="Electronic", dj_count=15
+            ),
+            "Stereolab": ArtistStats(
+                canonical_name="Stereolab", total_plays=30, genre="Rock", dj_count=10
+            ),
+            "Cat Power": ArtistStats(
+                canonical_name="Cat Power", total_plays=20, genre="Rock", dj_count=8
+            ),
+        }
+        store.bulk_update_stats(artist_stats)
+
+        for name, stats in artist_stats.items():
+            row = store._conn.execute(
+                "SELECT total_plays, genre, dj_count FROM artist WHERE canonical_name = ?",
+                (name,),
+            ).fetchone()
+            assert row[0] == stats.total_plays
+            assert row[1] == stats.genre
+            assert row[2] == stats.dj_count
+
+    def test_bulk_update_empty_dict(self, store: EntityStore):
+        store.bulk_update_stats({})  # Should not raise
+
+    def test_bulk_update_preserves_other_fields(self, store: EntityStore):
+        store.upsert_artist("Autechre", discogs_artist_id=42)
+        stats = {
+            "Autechre": ArtistStats(canonical_name="Autechre", total_plays=50, genre="Electronic"),
+        }
+        store.bulk_update_stats(stats)
+        row = store._conn.execute(
+            "SELECT discogs_artist_id FROM artist WHERE canonical_name = 'Autechre'"
+        ).fetchone()
+        assert row[0] == 42


### PR DESCRIPTION
## Summary

Closes #54

- **Entity CRUD**: `get_or_create_entity`, `update_entity_qid`, `get_entity_by_qid`, `merge_entities` (re-parents artists and deletes merged entity)
- **Artist upsert**: `upsert_artist` with `INSERT ON CONFLICT` using `COALESCE` so `NULL` arguments never overwrite populated fields; `bulk_upsert_artists` as the main pipeline entry point; `get_artist_by_name` for lookups
- **Artist stats**: `update_artist_stats` and `bulk_update_stats` apply `ArtistStats` to existing artist rows

Depends on #53 (entity store schema and migration, already merged into this branch).

## Test plan

- [x] 31 new unit tests covering all CRUD methods, upsert COALESCE semantics, error paths, bulk operations, and stats updates
- [x] All 250 unit tests pass
- [x] mypy, ruff check, ruff format all clean