### PR TITLE
Add reconciliation log and name-to-ID mapping to EntityStore

### DIFF
--- a/semantic_index/entity_store.py
+++ b/semantic_index/entity_store.py
@@ -17,7 +17,7 @@ import logging
 import sqlite3
 from types import TracebackType
 
-from semantic_index.models import ArtistStats, Entity
+from semantic_index.models import ArtistStats, Entity, ReconciliationEvent
 
 logger = logging.getLogger(__name__)
 
@@ -355,6 +355,81 @@ class EntityStore:
         for name in unique_names:
             result[name] = self.upsert_artist(name)
         return result
+
+    # ------------------------------------------------------------------
+    # Reconciliation Log
+    # ------------------------------------------------------------------
+
+    def log_reconciliation(
+        self,
+        artist_id: int,
+        source: str,
+        external_id: str,
+        confidence: float | None,
+        method: str,
+    ) -> None:
+        """Record a reconciliation event for an artist.
+
+        Args:
+            artist_id: The artist row's primary key.
+            source: External knowledge base ('discogs', 'musicbrainz', 'wikidata').
+            external_id: Identifier in the external source.
+            confidence: Match confidence score, or None if not applicable.
+            method: Matching method ('exact', 'fuzzy', 'api_search', 'cache_lookup').
+
+        Raises:
+            ValueError: If no artist with the given id exists.
+        """
+        row = self._conn.execute("SELECT id FROM artist WHERE id = ?", (artist_id,)).fetchone()
+        if row is None:
+            raise ValueError(f"No artist with id {artist_id}")
+        self._conn.execute(
+            """INSERT INTO reconciliation_log (artist_id, source, external_id, confidence, method)
+               VALUES (?, ?, ?, ?, ?)""",
+            (artist_id, source, external_id, confidence, method),
+        )
+        self._conn.commit()
+
+    def get_reconciliation_history(self, artist_id: int) -> list[ReconciliationEvent]:
+        """Return all reconciliation events for an artist, ordered by insertion.
+
+        Args:
+            artist_id: The artist row's primary key.
+
+        Returns:
+            List of ReconciliationEvent instances, oldest first.
+        """
+        rows = self._conn.execute(
+            """SELECT source, external_id, confidence, method
+               FROM reconciliation_log
+               WHERE artist_id = ?
+               ORDER BY id""",
+            (artist_id,),
+        ).fetchall()
+        return [
+            ReconciliationEvent(
+                source=row[0],
+                external_id=row[1],
+                confidence=row[2],
+                method=row[3],
+            )
+            for row in rows
+        ]
+
+    # ------------------------------------------------------------------
+    # Name-to-ID Mapping
+    # ------------------------------------------------------------------
+
+    def get_name_to_id_mapping(self) -> dict[str, int]:
+        """Return a mapping of canonical_name to artist row id.
+
+        This replaces the inline dict-building pattern in sqlite_export.py.
+
+        Returns:
+            Dict mapping canonical_name -> artist row id.
+        """
+        rows = self._conn.execute("SELECT id, canonical_name FROM artist").fetchall()
+        return {row[1]: row[0] for row in rows}
 
     # ------------------------------------------------------------------
     # Artist Stats

--- a/tests/unit/test_entity_store_crud.py
+++ b/tests/unit/test_entity_store_crud.py
@@ -5,7 +5,7 @@ import sqlite3
 import pytest
 
 from semantic_index.entity_store import EntityStore
-from semantic_index.models import ArtistStats
+from semantic_index.models import ArtistStats, ReconciliationEvent
 
 # The old artist schema — matches sqlite_export._SCHEMA artist table
 _OLD_ARTIST_SCHEMA = """
@@ -316,3 +316,168 @@ class TestBulkUpdateStats:
             "SELECT discogs_artist_id FROM artist WHERE canonical_name = 'Autechre'"
         ).fetchone()
         assert row[0] == 42
+
+
+# ---------------------------------------------------------------------------
+# Step 5: Reconciliation Log
+# ---------------------------------------------------------------------------
+
+
+class TestLogReconciliation:
+    def test_logs_event(self, store: EntityStore):
+        artist_id = store.upsert_artist("Autechre")
+        store.log_reconciliation(
+            artist_id=artist_id,
+            source="discogs",
+            external_id="42",
+            confidence=0.95,
+            method="exact",
+        )
+        row = store._conn.execute(
+            "SELECT artist_id, source, external_id, confidence, method FROM reconciliation_log"
+        ).fetchone()
+        assert row[0] == artist_id
+        assert row[1] == "discogs"
+        assert row[2] == "42"
+        assert row[3] == pytest.approx(0.95)
+        assert row[4] == "exact"
+
+    def test_logs_without_confidence(self, store: EntityStore):
+        artist_id = store.upsert_artist("Stereolab")
+        store.log_reconciliation(
+            artist_id=artist_id,
+            source="wikidata",
+            external_id="Q483477",
+            confidence=None,
+            method="api_search",
+        )
+        row = store._conn.execute(
+            "SELECT confidence FROM reconciliation_log WHERE artist_id = ?",
+            (artist_id,),
+        ).fetchone()
+        assert row[0] is None
+
+    def test_nonexistent_artist_raises(self, store: EntityStore):
+        with pytest.raises(ValueError, match="No artist with id"):
+            store.log_reconciliation(
+                artist_id=9999,
+                source="discogs",
+                external_id="42",
+                confidence=0.9,
+                method="exact",
+            )
+
+    def test_multiple_events_for_same_artist(self, store: EntityStore):
+        artist_id = store.upsert_artist("Cat Power")
+        store.log_reconciliation(
+            artist_id=artist_id,
+            source="discogs",
+            external_id="123",
+            confidence=0.8,
+            method="fuzzy",
+        )
+        store.log_reconciliation(
+            artist_id=artist_id,
+            source="wikidata",
+            external_id="Q271362",
+            confidence=0.95,
+            method="exact",
+        )
+        count = store._conn.execute(
+            "SELECT COUNT(*) FROM reconciliation_log WHERE artist_id = ?",
+            (artist_id,),
+        ).fetchone()[0]
+        assert count == 2
+
+
+class TestGetReconciliationHistory:
+    def test_returns_events(self, store: EntityStore):
+        artist_id = store.upsert_artist("Autechre")
+        store.log_reconciliation(
+            artist_id=artist_id,
+            source="discogs",
+            external_id="42",
+            confidence=0.95,
+            method="exact",
+        )
+        history = store.get_reconciliation_history(artist_id)
+        assert len(history) == 1
+        event = history[0]
+        assert isinstance(event, ReconciliationEvent)
+        assert event.source == "discogs"
+        assert event.external_id == "42"
+        assert event.confidence == pytest.approx(0.95)
+        assert event.method == "exact"
+
+    def test_empty_history(self, store: EntityStore):
+        artist_id = store.upsert_artist("Jessica Pratt")
+        history = store.get_reconciliation_history(artist_id)
+        assert history == []
+
+    def test_multiple_events_ordered(self, store: EntityStore):
+        """Events should be returned in insertion order (by id)."""
+        artist_id = store.upsert_artist("Father John Misty")
+        store.log_reconciliation(
+            artist_id=artist_id,
+            source="discogs",
+            external_id="999",
+            confidence=0.7,
+            method="fuzzy",
+        )
+        store.log_reconciliation(
+            artist_id=artist_id,
+            source="wikidata",
+            external_id="Q1234",
+            confidence=0.99,
+            method="exact",
+        )
+        history = store.get_reconciliation_history(artist_id)
+        assert len(history) == 2
+        assert history[0].source == "discogs"
+        assert history[1].source == "wikidata"
+
+    def test_does_not_include_other_artists(self, store: EntityStore):
+        id_a = store.upsert_artist("Autechre")
+        id_b = store.upsert_artist("Stereolab")
+        store.log_reconciliation(
+            artist_id=id_a,
+            source="discogs",
+            external_id="42",
+            confidence=0.9,
+            method="exact",
+        )
+        store.log_reconciliation(
+            artist_id=id_b,
+            source="discogs",
+            external_id="99",
+            confidence=0.8,
+            method="fuzzy",
+        )
+        history = store.get_reconciliation_history(id_a)
+        assert len(history) == 1
+        assert history[0].external_id == "42"
+
+
+# ---------------------------------------------------------------------------
+# Step 6: Name-to-ID Mapping
+# ---------------------------------------------------------------------------
+
+
+class TestGetNameToIdMapping:
+    def test_returns_mapping(self, store: EntityStore):
+        id_map = store.bulk_upsert_artists(["Autechre", "Stereolab", "Cat Power"])
+        mapping = store.get_name_to_id_mapping()
+        assert mapping == id_map
+
+    def test_empty_table(self, store: EntityStore):
+        mapping = store.get_name_to_id_mapping()
+        assert mapping == {}
+
+    def test_matches_individual_upserts(self, store: EntityStore):
+        """Mapping should be consistent with individual upsert return values."""
+        a_id = store.upsert_artist("Sessa", genre="Latin")
+        b_id = store.upsert_artist("Buck Meek", genre="Rock")
+        mapping = store.get_name_to_id_mapping()
+        assert mapping["Sessa"] == a_id
+        assert mapping["Buck Meek"] == b_id
+        assert len(mapping) == 2


### PR DESCRIPTION
## Summary

- Add `log_reconciliation()` and `get_reconciliation_history()` methods to `EntityStore` for recording and retrieving reconciliation audit trail events (source, external ID, confidence, method)
- Add `get_name_to_id_mapping()` method that returns the canonical_name → artist row ID dict, replacing the inline dict-building pattern in `sqlite_export.py`
- Add 11 new unit tests covering both features with WXYC example artists

Closes #55

## Test plan

- [x] All 78 entity store unit tests pass
- [x] ruff check and format pass
- [x] mypy passes on changed files (pre-existing fastapi stub errors unrelated)