### PR TITLE
Add reconciliation module with bulk Discogs matching

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,8 @@ SQLite ──→ api (FastAPI + aiosqlite) ──→ JSON responses
 | `semantic_index/node_attributes.py` | Extract and compute per-artist temporal, DJ, and request statistics. |
 | `semantic_index/cross_reference.py` | Extract cross-reference edges from catalog cross-reference tables. |
 | `semantic_index/discogs_client.py` | Two-tier Discogs client: discogs-cache PostgreSQL with library-metadata-lookup API fallback. |
+| `semantic_index/entity_store.py` | Persistent entity store for reconciled artist identities: schema migration, CRUD, artist upsert, reconciliation log, artist styles. |
+| `semantic_index/reconciliation.py` | Bulk Discogs matching for unreconciled artists via discogs-cache release_artist table. |
 | `semantic_index/discogs_enrichment.py` | Aggregate Discogs metadata (styles, personnel, labels, compilations) per artist. |
 | `semantic_index/discogs_edges.py` | Compute Discogs-derived edges: shared personnel, shared style (Jaccard), label family, compilation co-appearance. |
 | `semantic_index/graph_export.py` | Build NetworkX graph and export GEXF. |
@@ -78,6 +80,33 @@ CREATE TABLE cross_reference (
     comment TEXT,
     source TEXT NOT NULL,
     PRIMARY KEY (artist_a_id, artist_b_id, source)
+);
+
+-- Entity store tables (created by EntityStore.initialize())
+
+CREATE TABLE entity (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    wikidata_qid TEXT UNIQUE,
+    name TEXT NOT NULL,
+    entity_type TEXT NOT NULL DEFAULT 'artist',
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
+CREATE TABLE artist_style (
+    artist_id INTEGER NOT NULL REFERENCES artist(id),
+    style TEXT NOT NULL,
+    PRIMARY KEY (artist_id, style)
+);
+
+CREATE TABLE reconciliation_log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    artist_id INTEGER NOT NULL REFERENCES artist(id),
+    source TEXT NOT NULL,
+    external_id TEXT NOT NULL,
+    confidence REAL,
+    method TEXT NOT NULL,
+    created_at TEXT NOT NULL
 );
 ```
 

--- a/semantic_index/entity_store.py
+++ b/semantic_index/entity_store.py
@@ -80,6 +80,14 @@ CREATE TABLE IF NOT EXISTS label_hierarchy (
     PRIMARY KEY (parent_label_id, child_label_id)
 );
 
+-- Per-artist style tags from Discogs (persisted during reconciliation)
+
+CREATE TABLE IF NOT EXISTS artist_style (
+    artist_id INTEGER NOT NULL REFERENCES artist(id),
+    style TEXT NOT NULL,
+    PRIMARY KEY (artist_id, style)
+);
+
 -- Reconciliation audit trail
 
 CREATE TABLE IF NOT EXISTS reconciliation_log (
@@ -415,6 +423,82 @@ class EntityStore:
             )
             for row in rows
         ]
+
+    # ------------------------------------------------------------------
+    # Reconciliation Queries
+    # ------------------------------------------------------------------
+
+    def get_unreconciled_artists(self, limit: int | None = None) -> list[tuple[int, str]]:
+        """Return (id, canonical_name) pairs for artists with status 'unreconciled'.
+
+        Args:
+            limit: Maximum number of artists to return. None for all.
+
+        Returns:
+            List of (artist_id, canonical_name) tuples.
+        """
+        sql = "SELECT id, canonical_name FROM artist WHERE reconciliation_status = 'unreconciled'"
+        if limit is not None:
+            sql += f" LIMIT {limit}"
+        rows = self._conn.execute(sql).fetchall()
+        return [(row[0], row[1]) for row in rows]
+
+    def update_reconciliation_status(self, artist_id: int, status: str) -> None:
+        """Update the reconciliation status for an artist.
+
+        Args:
+            artist_id: The artist row's primary key.
+            status: New status ('reconciled', 'no_match', 'partial', etc.).
+
+        Raises:
+            ValueError: If no artist with the given id exists.
+        """
+        cur = self._conn.execute(
+            """UPDATE artist SET reconciliation_status = ?,
+                   updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+               WHERE id = ?""",
+            (status, artist_id),
+        )
+        if cur.rowcount == 0:
+            raise ValueError(f"No artist with id {artist_id}")
+        self._conn.commit()
+
+    # ------------------------------------------------------------------
+    # Artist Styles
+    # ------------------------------------------------------------------
+
+    def persist_artist_styles(self, artist_id: int, styles: list[str]) -> None:
+        """Persist Discogs style tags for an artist (idempotent).
+
+        Uses INSERT OR IGNORE so overlapping styles from repeat calls
+        do not raise errors or create duplicates.
+
+        Args:
+            artist_id: The artist row's primary key.
+            styles: List of Discogs style strings.
+        """
+        if not styles:
+            return
+        self._conn.executemany(
+            "INSERT OR IGNORE INTO artist_style (artist_id, style) VALUES (?, ?)",
+            [(artist_id, style) for style in styles],
+        )
+        self._conn.commit()
+
+    def get_artist_styles(self, artist_id: int) -> list[str]:
+        """Return all style tags for an artist, sorted alphabetically.
+
+        Args:
+            artist_id: The artist row's primary key.
+
+        Returns:
+            Sorted list of style strings.
+        """
+        rows = self._conn.execute(
+            "SELECT style FROM artist_style WHERE artist_id = ? ORDER BY style",
+            (artist_id,),
+        ).fetchall()
+        return [row[0] for row in rows]
 
     # ------------------------------------------------------------------
     # Name-to-ID Mapping

--- a/semantic_index/reconciliation.py
+++ b/semantic_index/reconciliation.py
@@ -1,0 +1,177 @@
+"""Reconciliation module: bulk Discogs matching for unreconciled artists.
+
+Queries the entity store for artists with ``reconciliation_status='unreconciled'``,
+matches them against the discogs-cache PostgreSQL ``release_artist`` table in
+batches, persists per-artist styles from ``release_style``, and updates each
+artist's ``discogs_artist_id`` and reconciliation status.
+
+Usage::
+
+    from semantic_index.discogs_client import DiscogsClient
+    from semantic_index.entity_store import EntityStore
+    from semantic_index.reconciliation import ArtistReconciler
+
+    store = EntityStore("output/wxyc_artist_graph.db")
+    store.initialize()
+    client = DiscogsClient(cache_dsn="postgresql://...", api_base_url=None)
+    reconciler = ArtistReconciler(store, client)
+    report = reconciler.reconcile_batch(batch_size=1000)
+"""
+
+from __future__ import annotations
+
+import logging
+
+from semantic_index.discogs_client import DiscogsClient
+from semantic_index.entity_store import EntityStore
+from semantic_index.models import ReconciliationReport
+
+logger = logging.getLogger(__name__)
+
+
+class ArtistReconciler:
+    """Bulk Discogs matching for unreconciled artists.
+
+    Args:
+        store: Entity store for reading/writing artist data.
+        client: Discogs client whose cache connection is used for bulk lookups.
+    """
+
+    def __init__(self, store: EntityStore, client: DiscogsClient) -> None:
+        self._store = store
+        self._client = client
+
+    def reconcile_batch(self, batch_size: int = 1000) -> ReconciliationReport:
+        """Query unreconciled artists and process in batches.
+
+        Only artists with ``reconciliation_status='unreconciled'`` are
+        attempted. Artists with any other status are counted as skipped.
+
+        Args:
+            batch_size: Number of artist names per bulk Discogs query.
+
+        Returns:
+            ReconciliationReport with counts of attempted, succeeded,
+            no_match, errored, and skipped artists.
+        """
+        total = self._store._conn.execute("SELECT COUNT(*) FROM artist").fetchone()[0]
+        unreconciled = self._store.get_unreconciled_artists()
+        skipped = total - len(unreconciled)
+
+        succeeded = 0
+        no_match = 0
+        errored = 0
+
+        # Build id lookup for the unreconciled set
+        name_to_id = {name: aid for aid, name in unreconciled}
+
+        for batch_start in range(0, len(unreconciled), batch_size):
+            batch = unreconciled[batch_start : batch_start + batch_size]
+            batch_names = [name for _, name in batch]
+
+            try:
+                matches = self._reconcile_discogs_bulk(batch_names)
+            except Exception:
+                logger.warning("Bulk reconciliation failed for batch", exc_info=True)
+                errored += len(batch_names)
+                continue
+
+            for name in batch_names:
+                artist_id = name_to_id[name]
+                if name in matches:
+                    discogs_id, styles = matches[name]
+                    self._store.upsert_artist(name, discogs_artist_id=discogs_id)
+                    if styles:
+                        self._store.persist_artist_styles(artist_id, styles)
+                    self._store.log_reconciliation(
+                        artist_id=artist_id,
+                        source="discogs",
+                        external_id=str(discogs_id),
+                        confidence=None,
+                        method="cache_lookup",
+                    )
+                    self._store.update_reconciliation_status(artist_id, "reconciled")
+                    succeeded += 1
+                else:
+                    self._store.update_reconciliation_status(artist_id, "no_match")
+                    no_match += 1
+
+        attempted = succeeded + no_match + errored
+        logger.info(
+            "Reconciliation complete: %d attempted, %d succeeded, %d no_match, %d errored, %d skipped",
+            attempted,
+            succeeded,
+            no_match,
+            errored,
+            skipped,
+        )
+        return ReconciliationReport(
+            total=total,
+            attempted=attempted,
+            succeeded=succeeded,
+            no_match=no_match,
+            errored=errored,
+            skipped=skipped,
+        )
+
+    def _reconcile_discogs_bulk(self, names: list[str]) -> dict[str, tuple[int, list[str]]]:
+        """Batch Discogs lookup via the ``release_artist`` table.
+
+        Queries the discogs-cache PostgreSQL using ``ANY()`` for efficient
+        bulk matching, then fetches per-artist styles from ``release_style``.
+
+        Args:
+            names: List of canonical artist names to look up.
+
+        Returns:
+            Dict mapping canonical_name to ``(discogs_artist_id, [styles])``.
+            Only names with a match are included.
+        """
+        if not names:
+            return {}
+
+        conn = self._client._get_cache_conn()
+        if conn is None:
+            return {}
+
+        lower_to_canonical: dict[str, str] = {n.lower(): n for n in names}
+        lower_names = list(lower_to_canonical.keys())
+
+        # 1. Match artist names against release_artist
+        rows = conn.execute(
+            "SELECT DISTINCT lower(ra.artist_name), ra.artist_id "
+            "FROM release_artist ra "
+            "WHERE ra.extra = 0 AND lower(ra.artist_name) = ANY(%s)",
+            (lower_names,),
+        ).fetchall()
+
+        matches: dict[str, int] = {}
+        for lower_name, artist_id in rows:
+            canonical = lower_to_canonical.get(lower_name)
+            if canonical is not None and artist_id is not None:
+                matches[canonical] = artist_id
+
+        if not matches:
+            return {}
+
+        # 2. Fetch styles for matched artists
+        matched_lower = [n.lower() for n in matches]
+        style_rows = conn.execute(
+            "SELECT DISTINCT lower(ra.artist_name), rs.style "
+            "FROM release_style rs "
+            "JOIN release_artist ra ON rs.release_id = ra.release_id "
+            "WHERE ra.extra = 0 AND lower(ra.artist_name) = ANY(%s)",
+            (matched_lower,),
+        ).fetchall()
+
+        artist_styles: dict[str, list[str]] = {}
+        for lower_name, style in style_rows:
+            canonical = lower_to_canonical.get(lower_name)
+            if canonical is not None:
+                artist_styles.setdefault(canonical, []).append(style)
+
+        # 3. Build result
+        return {
+            canonical: (discogs_id, artist_styles.get(canonical, []))
+            for canonical, discogs_id in matches.items()
+        }

--- a/tests/unit/test_entity_store_reconciliation.py
+++ b/tests/unit/test_entity_store_reconciliation.py
@@ -1,0 +1,176 @@
+"""Tests for EntityStore reconciliation support: unreconciled queries, status updates, artist styles."""
+
+import sqlite3
+
+import pytest
+
+from semantic_index.entity_store import EntityStore
+
+# The old artist schema — matches sqlite_export._SCHEMA artist table
+_OLD_ARTIST_SCHEMA = """
+CREATE TABLE artist (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    canonical_name TEXT NOT NULL UNIQUE,
+    genre TEXT,
+    total_plays INTEGER NOT NULL DEFAULT 0,
+    active_first_year INTEGER,
+    active_last_year INTEGER,
+    dj_count INTEGER NOT NULL DEFAULT 0,
+    request_ratio REAL NOT NULL DEFAULT 0.0,
+    show_count INTEGER NOT NULL DEFAULT 0,
+    discogs_artist_id INTEGER
+);
+"""
+
+
+@pytest.fixture()
+def store(tmp_path) -> EntityStore:
+    """An initialized EntityStore with a pre-migrated artist table."""
+    db_path = str(tmp_path / "test.db")
+    conn = sqlite3.connect(db_path)
+    conn.executescript(_OLD_ARTIST_SCHEMA)
+    conn.close()
+    s = EntityStore(db_path)
+    s.initialize()
+    return s
+
+
+# ---------------------------------------------------------------------------
+# get_unreconciled_artists
+# ---------------------------------------------------------------------------
+
+
+class TestGetUnreconciledArtists:
+    def test_returns_unreconciled(self, store: EntityStore):
+        store.bulk_upsert_artists(["Autechre", "Stereolab"])
+        unreconciled = store.get_unreconciled_artists()
+        assert len(unreconciled) == 2
+        names = {name for _, name in unreconciled}
+        assert names == {"Autechre", "Stereolab"}
+
+    def test_skips_reconciled(self, store: EntityStore):
+        aid = store.upsert_artist("Autechre")
+        store.update_reconciliation_status(aid, "reconciled")
+        store.upsert_artist("Stereolab")
+        unreconciled = store.get_unreconciled_artists()
+        assert len(unreconciled) == 1
+        assert unreconciled[0][1] == "Stereolab"
+
+    def test_skips_no_match(self, store: EntityStore):
+        aid = store.upsert_artist("Autechre")
+        store.update_reconciliation_status(aid, "no_match")
+        store.upsert_artist("Cat Power")
+        unreconciled = store.get_unreconciled_artists()
+        assert len(unreconciled) == 1
+        assert unreconciled[0][1] == "Cat Power"
+
+    def test_respects_limit(self, store: EntityStore):
+        store.bulk_upsert_artists(["Autechre", "Stereolab", "Cat Power", "Buck Meek"])
+        unreconciled = store.get_unreconciled_artists(limit=2)
+        assert len(unreconciled) == 2
+
+    def test_no_limit_returns_all(self, store: EntityStore):
+        store.bulk_upsert_artists(["Autechre", "Stereolab", "Cat Power"])
+        unreconciled = store.get_unreconciled_artists()
+        assert len(unreconciled) == 3
+
+    def test_empty_table(self, store: EntityStore):
+        assert store.get_unreconciled_artists() == []
+
+    def test_returns_id_and_name_tuples(self, store: EntityStore):
+        expected_id = store.upsert_artist("Father John Misty")
+        unreconciled = store.get_unreconciled_artists()
+        assert unreconciled[0] == (expected_id, "Father John Misty")
+
+
+# ---------------------------------------------------------------------------
+# update_reconciliation_status
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateReconciliationStatus:
+    def test_updates_to_reconciled(self, store: EntityStore):
+        aid = store.upsert_artist("Autechre")
+        store.update_reconciliation_status(aid, "reconciled")
+        row = store._conn.execute(
+            "SELECT reconciliation_status FROM artist WHERE id = ?", (aid,)
+        ).fetchone()
+        assert row[0] == "reconciled"
+
+    def test_updates_to_no_match(self, store: EntityStore):
+        aid = store.upsert_artist("Stereolab")
+        store.update_reconciliation_status(aid, "no_match")
+        row = store._conn.execute(
+            "SELECT reconciliation_status FROM artist WHERE id = ?", (aid,)
+        ).fetchone()
+        assert row[0] == "no_match"
+
+    def test_nonexistent_artist_raises(self, store: EntityStore):
+        with pytest.raises(ValueError, match="No artist with id"):
+            store.update_reconciliation_status(9999, "reconciled")
+
+    def test_updates_updated_at(self, store: EntityStore):
+        aid = store.upsert_artist("Cat Power")
+        before = store._conn.execute(
+            "SELECT updated_at FROM artist WHERE id = ?", (aid,)
+        ).fetchone()[0]
+        store.update_reconciliation_status(aid, "reconciled")
+        after = store._conn.execute(
+            "SELECT updated_at FROM artist WHERE id = ?", (aid,)
+        ).fetchone()[0]
+        assert after is not None
+        assert after >= before
+
+
+# ---------------------------------------------------------------------------
+# Artist styles
+# ---------------------------------------------------------------------------
+
+
+class TestArtistStyleTable:
+    def test_table_created_on_initialize(self, store: EntityStore):
+        row = store._conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='artist_style'"
+        ).fetchone()
+        assert row is not None
+
+
+class TestPersistArtistStyles:
+    def test_persist_styles(self, store: EntityStore):
+        aid = store.upsert_artist("Autechre")
+        store.persist_artist_styles(aid, ["IDM", "Abstract", "Experimental"])
+        styles = store.get_artist_styles(aid)
+        assert set(styles) == {"IDM", "Abstract", "Experimental"}
+
+    def test_persist_empty_list(self, store: EntityStore):
+        aid = store.upsert_artist("Stereolab")
+        store.persist_artist_styles(aid, [])
+        assert store.get_artist_styles(aid) == []
+
+    def test_persist_idempotent(self, store: EntityStore):
+        """Persisting overlapping styles should not create duplicates."""
+        aid = store.upsert_artist("Autechre")
+        store.persist_artist_styles(aid, ["IDM", "Abstract"])
+        store.persist_artist_styles(aid, ["IDM", "Experimental"])
+        styles = store.get_artist_styles(aid)
+        assert set(styles) == {"IDM", "Abstract", "Experimental"}
+
+    def test_different_artists_independent(self, store: EntityStore):
+        aid_a = store.upsert_artist("Autechre")
+        aid_b = store.upsert_artist("Cat Power")
+        store.persist_artist_styles(aid_a, ["IDM", "Abstract"])
+        store.persist_artist_styles(aid_b, ["Indie Rock", "Lo-Fi"])
+        assert set(store.get_artist_styles(aid_a)) == {"IDM", "Abstract"}
+        assert set(store.get_artist_styles(aid_b)) == {"Indie Rock", "Lo-Fi"}
+
+
+class TestGetArtistStyles:
+    def test_empty_for_new_artist(self, store: EntityStore):
+        aid = store.upsert_artist("Jessica Pratt")
+        assert store.get_artist_styles(aid) == []
+
+    def test_returns_sorted(self, store: EntityStore):
+        aid = store.upsert_artist("Sessa")
+        store.persist_artist_styles(aid, ["MPB", "Bossa Nova", "Art Pop"])
+        styles = store.get_artist_styles(aid)
+        assert styles == sorted(styles)

--- a/tests/unit/test_reconciliation.py
+++ b/tests/unit/test_reconciliation.py
@@ -1,0 +1,368 @@
+"""Tests for the reconciliation module: ArtistReconciler batch Discogs matching."""
+
+import sqlite3
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from semantic_index.discogs_client import DiscogsClient
+from semantic_index.entity_store import EntityStore
+from semantic_index.models import ReconciliationReport
+from semantic_index.reconciliation import ArtistReconciler
+
+# The old artist schema — matches sqlite_export._SCHEMA artist table
+_OLD_ARTIST_SCHEMA = """
+CREATE TABLE artist (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    canonical_name TEXT NOT NULL UNIQUE,
+    genre TEXT,
+    total_plays INTEGER NOT NULL DEFAULT 0,
+    active_first_year INTEGER,
+    active_last_year INTEGER,
+    dj_count INTEGER NOT NULL DEFAULT 0,
+    request_ratio REAL NOT NULL DEFAULT 0.0,
+    show_count INTEGER NOT NULL DEFAULT 0,
+    discogs_artist_id INTEGER
+);
+"""
+
+
+@pytest.fixture()
+def store(tmp_path) -> EntityStore:
+    """An initialized EntityStore with a pre-migrated artist table."""
+    db_path = str(tmp_path / "test.db")
+    conn = sqlite3.connect(db_path)
+    conn.executescript(_OLD_ARTIST_SCHEMA)
+    conn.close()
+    s = EntityStore(db_path)
+    s.initialize()
+    return s
+
+
+def _make_mock_cache_conn(
+    artist_matches: list[tuple[str, int]],
+    style_rows: list[tuple[str, str]],
+) -> MagicMock:
+    """Build a mock psycopg connection for bulk reconciliation queries.
+
+    Args:
+        artist_matches: List of (artist_name, artist_id) rows from release_artist.
+        style_rows: List of (artist_name, style) rows from release_style JOIN release_artist.
+    """
+    mock_conn = MagicMock()
+
+    def execute_side_effect(sql, params=None):
+        result = MagicMock()
+        sql_lower = sql.strip().lower()
+        if "release_artist" in sql_lower and "release_style" not in sql_lower:
+            result.fetchall.return_value = artist_matches
+        elif "release_style" in sql_lower:
+            result.fetchall.return_value = style_rows
+        else:
+            result.fetchall.return_value = []
+        return result
+
+    mock_conn.execute.side_effect = execute_side_effect
+    return mock_conn
+
+
+def _make_discogs_client_with_mock(mock_conn: MagicMock) -> DiscogsClient:
+    """Create a DiscogsClient whose cache connection is the given mock."""
+    # Mark mock as not closed so _get_cache_conn() reuses it
+    mock_conn.closed = False
+    client = DiscogsClient(cache_dsn="postgresql://test", api_base_url=None)
+    client._cache_conn = mock_conn
+    return client
+
+
+# ---------------------------------------------------------------------------
+# _reconcile_discogs_bulk
+# ---------------------------------------------------------------------------
+
+
+class TestReconcileDiscogsBulk:
+    def test_returns_matches_with_artist_ids(self, store: EntityStore):
+        mock_conn = _make_mock_cache_conn(
+            artist_matches=[("autechre", 42), ("stereolab", 99)],
+            style_rows=[("autechre", "IDM"), ("autechre", "Abstract"), ("stereolab", "Krautrock")],
+        )
+        client = _make_discogs_client_with_mock(mock_conn)
+        reconciler = ArtistReconciler(store, client)
+
+        result = reconciler._reconcile_discogs_bulk(["Autechre", "Stereolab"])
+        assert "Autechre" in result
+        assert result["Autechre"][0] == 42
+        assert "Stereolab" in result
+        assert result["Stereolab"][0] == 99
+
+    def test_returns_styles_for_matched_artists(self, store: EntityStore):
+        mock_conn = _make_mock_cache_conn(
+            artist_matches=[("autechre", 42)],
+            style_rows=[("autechre", "IDM"), ("autechre", "Abstract")],
+        )
+        client = _make_discogs_client_with_mock(mock_conn)
+        reconciler = ArtistReconciler(store, client)
+
+        result = reconciler._reconcile_discogs_bulk(["Autechre"])
+        assert set(result["Autechre"][1]) == {"IDM", "Abstract"}
+
+    def test_unmatched_names_excluded(self, store: EntityStore):
+        mock_conn = _make_mock_cache_conn(
+            artist_matches=[("autechre", 42)],
+            style_rows=[("autechre", "IDM")],
+        )
+        client = _make_discogs_client_with_mock(mock_conn)
+        reconciler = ArtistReconciler(store, client)
+
+        result = reconciler._reconcile_discogs_bulk(["Autechre", "Unknown Band"])
+        assert "Autechre" in result
+        assert "Unknown Band" not in result
+
+    def test_no_matches_returns_empty(self, store: EntityStore):
+        mock_conn = _make_mock_cache_conn(artist_matches=[], style_rows=[])
+        client = _make_discogs_client_with_mock(mock_conn)
+        reconciler = ArtistReconciler(store, client)
+
+        result = reconciler._reconcile_discogs_bulk(["Unknown Band"])
+        assert result == {}
+
+    def test_no_cache_returns_empty(self, store: EntityStore):
+        client = DiscogsClient(cache_dsn=None, api_base_url=None)
+        reconciler = ArtistReconciler(store, client)
+
+        result = reconciler._reconcile_discogs_bulk(["Autechre"])
+        assert result == {}
+
+    def test_empty_names_returns_empty(self, store: EntityStore):
+        mock_conn = _make_mock_cache_conn(artist_matches=[], style_rows=[])
+        client = _make_discogs_client_with_mock(mock_conn)
+        reconciler = ArtistReconciler(store, client)
+
+        result = reconciler._reconcile_discogs_bulk([])
+        assert result == {}
+
+    def test_case_insensitive_matching(self, store: EntityStore):
+        """Canonical names may differ in case from Discogs names."""
+        mock_conn = _make_mock_cache_conn(
+            artist_matches=[("father john misty", 555)],
+            style_rows=[("father john misty", "Indie Rock")],
+        )
+        client = _make_discogs_client_with_mock(mock_conn)
+        reconciler = ArtistReconciler(store, client)
+
+        result = reconciler._reconcile_discogs_bulk(["Father John Misty"])
+        assert "Father John Misty" in result
+        assert result["Father John Misty"][0] == 555
+
+    def test_matched_with_no_styles(self, store: EntityStore):
+        mock_conn = _make_mock_cache_conn(
+            artist_matches=[("sessa", 777)],
+            style_rows=[],
+        )
+        client = _make_discogs_client_with_mock(mock_conn)
+        reconciler = ArtistReconciler(store, client)
+
+        result = reconciler._reconcile_discogs_bulk(["Sessa"])
+        assert result["Sessa"] == (777, [])
+
+
+# ---------------------------------------------------------------------------
+# reconcile_batch
+# ---------------------------------------------------------------------------
+
+
+class TestReconcileBatch:
+    def test_returns_reconciliation_report(self, store: EntityStore):
+        store.bulk_upsert_artists(["Autechre", "Cat Power"])
+        mock_conn = _make_mock_cache_conn(
+            artist_matches=[("autechre", 42)],
+            style_rows=[("autechre", "IDM")],
+        )
+        client = _make_discogs_client_with_mock(mock_conn)
+        reconciler = ArtistReconciler(store, client)
+
+        report = reconciler.reconcile_batch()
+        assert isinstance(report, ReconciliationReport)
+        assert report.total == 2
+        assert report.attempted == 2
+        assert report.succeeded == 1
+        assert report.no_match == 1
+        assert report.errored == 0
+        assert report.skipped == 0
+
+    def test_updates_discogs_artist_id(self, store: EntityStore):
+        store.upsert_artist("Autechre")
+        mock_conn = _make_mock_cache_conn(
+            artist_matches=[("autechre", 42)],
+            style_rows=[],
+        )
+        client = _make_discogs_client_with_mock(mock_conn)
+        reconciler = ArtistReconciler(store, client)
+
+        reconciler.reconcile_batch()
+        row = store.get_artist_by_name("Autechre")
+        assert row is not None
+        assert row["discogs_artist_id"] == 42
+
+    def test_persists_styles(self, store: EntityStore):
+        aid = store.upsert_artist("Autechre")
+        mock_conn = _make_mock_cache_conn(
+            artist_matches=[("autechre", 42)],
+            style_rows=[("autechre", "IDM"), ("autechre", "Abstract")],
+        )
+        client = _make_discogs_client_with_mock(mock_conn)
+        reconciler = ArtistReconciler(store, client)
+
+        reconciler.reconcile_batch()
+        styles = store.get_artist_styles(aid)
+        assert set(styles) == {"IDM", "Abstract"}
+
+    def test_logs_reconciliation_event(self, store: EntityStore):
+        aid = store.upsert_artist("Autechre")
+        mock_conn = _make_mock_cache_conn(
+            artist_matches=[("autechre", 42)],
+            style_rows=[],
+        )
+        client = _make_discogs_client_with_mock(mock_conn)
+        reconciler = ArtistReconciler(store, client)
+
+        reconciler.reconcile_batch()
+        history = store.get_reconciliation_history(aid)
+        assert len(history) == 1
+        assert history[0].source == "discogs"
+        assert history[0].external_id == "42"
+        assert history[0].method == "cache_lookup"
+
+    def test_updates_status_reconciled(self, store: EntityStore):
+        aid = store.upsert_artist("Autechre")
+        mock_conn = _make_mock_cache_conn(
+            artist_matches=[("autechre", 42)],
+            style_rows=[],
+        )
+        client = _make_discogs_client_with_mock(mock_conn)
+        reconciler = ArtistReconciler(store, client)
+
+        reconciler.reconcile_batch()
+        row = store._conn.execute(
+            "SELECT reconciliation_status FROM artist WHERE id = ?", (aid,)
+        ).fetchone()
+        assert row[0] == "reconciled"
+
+    def test_updates_status_no_match(self, store: EntityStore):
+        aid = store.upsert_artist("Unknown Band")
+        mock_conn = _make_mock_cache_conn(artist_matches=[], style_rows=[])
+        client = _make_discogs_client_with_mock(mock_conn)
+        reconciler = ArtistReconciler(store, client)
+
+        reconciler.reconcile_batch()
+        row = store._conn.execute(
+            "SELECT reconciliation_status FROM artist WHERE id = ?", (aid,)
+        ).fetchone()
+        assert row[0] == "no_match"
+
+    def test_incremental_skips_already_reconciled(self, store: EntityStore):
+        aid_reconciled = store.upsert_artist("Autechre", discogs_artist_id=42)
+        store.update_reconciliation_status(aid_reconciled, "reconciled")
+        store.upsert_artist("Stereolab")
+
+        mock_conn = _make_mock_cache_conn(
+            artist_matches=[("stereolab", 99)],
+            style_rows=[],
+        )
+        client = _make_discogs_client_with_mock(mock_conn)
+        reconciler = ArtistReconciler(store, client)
+
+        report = reconciler.reconcile_batch()
+        assert report.total == 2
+        assert report.skipped == 1
+        assert report.attempted == 1
+        assert report.succeeded == 1
+
+    def test_incremental_skips_no_match_status(self, store: EntityStore):
+        aid = store.upsert_artist("Unknown Band")
+        store.update_reconciliation_status(aid, "no_match")
+        store.upsert_artist("Cat Power")
+
+        mock_conn = _make_mock_cache_conn(
+            artist_matches=[("cat power", 88)],
+            style_rows=[],
+        )
+        client = _make_discogs_client_with_mock(mock_conn)
+        reconciler = ArtistReconciler(store, client)
+
+        report = reconciler.reconcile_batch()
+        assert report.skipped == 1
+        assert report.attempted == 1
+
+    def test_empty_artist_table(self, store: EntityStore):
+        mock_conn = _make_mock_cache_conn(artist_matches=[], style_rows=[])
+        client = _make_discogs_client_with_mock(mock_conn)
+        reconciler = ArtistReconciler(store, client)
+
+        report = reconciler.reconcile_batch()
+        assert report.total == 0
+        assert report.attempted == 0
+        assert report.succeeded == 0
+        assert report.skipped == 0
+
+    def test_batch_size_parameter(self, store: EntityStore):
+        """With batch_size=2, three artists should be processed in two batches."""
+        store.bulk_upsert_artists(["Autechre", "Stereolab", "Cat Power"])
+
+        call_count = 0
+        original_method = ArtistReconciler._reconcile_discogs_bulk
+
+        def tracking_bulk(self_inner, names):
+            nonlocal call_count
+            call_count += 1
+            return original_method(self_inner, names)
+
+        mock_conn = _make_mock_cache_conn(
+            artist_matches=[("autechre", 42), ("stereolab", 99), ("cat power", 88)],
+            style_rows=[],
+        )
+        client = _make_discogs_client_with_mock(mock_conn)
+        reconciler = ArtistReconciler(store, client)
+
+        with patch.object(ArtistReconciler, "_reconcile_discogs_bulk", tracking_bulk):
+            reconciler.reconcile_batch(batch_size=2)
+
+        assert call_count == 2  # ceil(3/2) = 2 batches
+
+    def test_multiple_artists_matched(self, store: EntityStore):
+        store.bulk_upsert_artists(["Autechre", "Stereolab", "Father John Misty"])
+        mock_conn = _make_mock_cache_conn(
+            artist_matches=[
+                ("autechre", 42),
+                ("stereolab", 99),
+                ("father john misty", 555),
+            ],
+            style_rows=[
+                ("autechre", "IDM"),
+                ("stereolab", "Krautrock"),
+                ("stereolab", "Post-Rock"),
+                ("father john misty", "Indie Rock"),
+            ],
+        )
+        client = _make_discogs_client_with_mock(mock_conn)
+        reconciler = ArtistReconciler(store, client)
+
+        report = reconciler.reconcile_batch()
+        assert report.succeeded == 3
+        assert report.no_match == 0
+
+        # Verify each artist got the right discogs_artist_id
+        assert store.get_artist_by_name("Autechre")["discogs_artist_id"] == 42
+        assert store.get_artist_by_name("Stereolab")["discogs_artist_id"] == 99
+        assert store.get_artist_by_name("Father John Misty")["discogs_artist_id"] == 555
+
+    def test_cache_error_counts_as_no_match(self, store: EntityStore):
+        """If the cache connection fails, all artists should be no_match."""
+        store.upsert_artist("Autechre")
+        client = DiscogsClient(cache_dsn=None, api_base_url=None)
+        reconciler = ArtistReconciler(store, client)
+
+        report = reconciler.reconcile_batch()
+        assert report.attempted == 1
+        assert report.no_match == 1
+        assert report.succeeded == 0


### PR DESCRIPTION
## Summary

- Adds `ArtistReconciler` class in `semantic_index/reconciliation.py` that queries unreconciled artists from the entity store and matches them against the discogs-cache `release_artist` table in configurable batches using `ANY()` queries
- For each match, persists the `discogs_artist_id`, per-artist styles from `release_style`, logs the reconciliation event, and updates reconciliation status
- Incremental: only processes artists with `reconciliation_status='unreconciled'`; already-reconciled or no-match artists are skipped
- Adds EntityStore support: `artist_style` table, `get_unreconciled_artists()`, `update_reconciliation_status()`, `persist_artist_styles()`, `get_artist_styles()`
- 38 new unit tests covering both the EntityStore additions and the ArtistReconciler

Closes #57

## Test plan

- [x] 18 new EntityStore reconciliation tests (unreconciled queries, status updates, artist styles)
- [x] 20 new ArtistReconciler tests (bulk matching, batch processing, incremental behavior, style persistence, reconciliation logging)
- [x] All 299 existing unit tests pass
- [x] ruff check clean
- [x] ruff format clean
- [x] mypy clean on new/modified files