### PR TITLE
Integrate entity store into sqlite_export and pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,12 +27,12 @@ SQLite ──→ api (FastAPI + aiosqlite) ──→ JSON responses
 | `semantic_index/node_attributes.py` | Extract and compute per-artist temporal, DJ, and request statistics. |
 | `semantic_index/cross_reference.py` | Extract cross-reference edges from catalog cross-reference tables. |
 | `semantic_index/discogs_client.py` | Two-tier Discogs client: discogs-cache PostgreSQL with library-metadata-lookup API fallback. |
-| `semantic_index/entity_store.py` | Persistent entity store for reconciled artist identities: schema migration, CRUD, artist upsert, reconciliation log, artist styles. |
+| `semantic_index/entity_store.py` | Persistent entity store for reconciled artist identities: schema creation/migration, CRUD, artist upsert, reconciliation log, artist styles. Creates the artist table from scratch on a fresh database or migrates an existing one. |
 | `semantic_index/reconciliation.py` | Bulk Discogs matching for unreconciled artists via discogs-cache release_artist table. |
 | `semantic_index/discogs_enrichment.py` | Aggregate Discogs metadata (styles, personnel, labels, compilations) per artist. |
 | `semantic_index/discogs_edges.py` | Compute Discogs-derived edges: shared personnel, shared style (Jaccard), label family, compilation co-appearance. |
 | `semantic_index/graph_export.py` | Build NetworkX graph and export GEXF. |
-| `semantic_index/sqlite_export.py` | Build and export SQLite graph database with enrichment and edge tables. |
+| `semantic_index/sqlite_export.py` | Build and export SQLite graph database with enrichment and edge tables. Supports optional entity store integration for persistent artist identities. |
 | `semantic_index/api/app.py` | FastAPI application factory. Takes a SQLite database path, returns a configured app. |
 | `semantic_index/api/database.py` | Request-scoped SQLite connection dependency for FastAPI. |
 | `semantic_index/api/schemas.py` | Pydantic response models for the Graph API (ArtistSummary, SearchResponse, NeighborsResponse, ExplainResponse). |
@@ -144,6 +144,18 @@ python run_pipeline.py /path/to/wxycmusic.sql [--output-dir output/] [--min-coun
 Output: `output/wxyc_artist_pmi.gexf` (Gephi graph) + `output/wxyc_artist_graph.db` (SQLite database).
 
 Use `--no-sqlite` to skip the SQLite export.
+
+### Entity store mode
+
+Pass `--entity-store-path` to enable the entity store pipeline: artists are managed by the entity store (with persistent reconciliation state) rather than created fresh on each run. The entity store database becomes the SQLite output.
+
+```bash
+python run_pipeline.py dump.sql --entity-store-path output/wxyc_artist_graph.db --discogs-cache-dsn postgresql://...
+```
+
+- `--entity-store-path PATH` — Path to entity store SQLite database. Creates it if needed.
+- `--skip-reconciliation` — Skip Discogs reconciliation step.
+- `--compute-discogs-edges` — Compute Discogs-derived edges (shared personnel, styles, labels, compilations). Off by default.
 
 ## Graph API
 

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -24,6 +24,7 @@ from semantic_index.discogs_edges import (
     extract_shared_styles,
 )
 from semantic_index.discogs_enrichment import DiscogsEnricher
+from semantic_index.entity_store import EntityStore
 from semantic_index.graph_export import build_graph, export_gexf, print_top_neighbors
 from semantic_index.models import (
     FlowsheetEntry,
@@ -32,6 +33,7 @@ from semantic_index.models import (
 )
 from semantic_index.node_attributes import compute_artist_stats
 from semantic_index.pmi import compute_pmi
+from semantic_index.reconciliation import ArtistReconciler
 from semantic_index.sql_parser import iter_table_rows, load_table_rows
 from semantic_index.sqlite_export import export_sqlite
 
@@ -88,6 +90,23 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         type=int,
         default=500,
         help="Exclude labels with more than N artists from label family edges",
+    )
+    parser.add_argument(
+        "--entity-store-path",
+        default=None,
+        help="Path to an entity store SQLite database. Enables entity store mode: "
+        "artists are managed by the entity store rather than created fresh.",
+    )
+    parser.add_argument(
+        "--skip-reconciliation",
+        action="store_true",
+        help="Skip Discogs reconciliation step (requires --entity-store-path)",
+    )
+    parser.add_argument(
+        "--compute-discogs-edges",
+        action="store_true",
+        help="Compute Discogs-derived edges (shared personnel, styles, labels, compilations). "
+        "Off by default.",
     )
     return parser.parse_args(argv)
 
@@ -192,6 +211,38 @@ def run(args: argparse.Namespace) -> None:
     log.info("Re-resolving raw entries with play-count-weighted fuzzy matching...")
     resolved_entries = resolver.re_resolve_with_play_counts(resolved_entries)
 
+    # 5c. Entity store setup (optional)
+    entity_store: EntityStore | None = None
+    if args.entity_store_path:
+        store_path = args.entity_store_path
+        log.info("Opening entity store: %s", store_path)
+        entity_store = EntityStore(store_path)
+        entity_store.initialize()
+
+        # Bulk upsert all resolved artist names
+        all_canonical = list(dict.fromkeys(e.canonical_name for e in resolved_entries))
+        log.info("Bulk upserting %d artists into entity store...", len(all_canonical))
+        entity_store.bulk_upsert_artists(all_canonical)
+
+        # 5d. Reconcile via Discogs (unless skipped or no cache DSN)
+        if not args.skip_reconciliation and args.discogs_cache_dsn:
+            log.info("Running Discogs reconciliation...")
+            reconcile_client = DiscogsClient(
+                cache_dsn=args.discogs_cache_dsn,
+                api_base_url=None,
+            )
+            reconciler = ArtistReconciler(entity_store, reconcile_client)
+            report = reconciler.reconcile_batch()
+            log.info(
+                "Reconciliation: %d attempted, %d succeeded, %d no_match, %d errored",
+                report.attempted,
+                report.succeeded,
+                report.no_match,
+                report.errored,
+            )
+        elif not args.skip_reconciliation:
+            log.warning("Skipping reconciliation: no discogs-cache DSN available")
+
     # 6. Extract adjacency pairs
     log.info("Extracting adjacency pairs...")
     pairs = extract_adjacency_pairs(resolved_entries)
@@ -252,16 +303,17 @@ def run(args: argparse.Namespace) -> None:
         enrichments = enricher.enrich_batch(artist_ids)
         log.info("  %d artists enriched", len(enrichments))
 
-        # Extract Discogs-derived edges
-        log.info("Extracting Discogs-derived edges...")
-        sp_edges = extract_shared_personnel(enrichments)
-        log.info("  %d shared personnel edges", len(sp_edges))
-        ss_edges = extract_shared_styles(enrichments, min_jaccard=args.min_jaccard)
-        log.info("  %d shared style edges", len(ss_edges))
-        lf_edges = extract_label_family(enrichments, max_label_artists=args.max_label_artists)
-        log.info("  %d label family edges", len(lf_edges))
-        comp_edges = extract_compilation_coappearance(enrichments)
-        log.info("  %d compilation edges", len(comp_edges))
+        # Extract Discogs-derived edges (only when explicitly requested)
+        if args.compute_discogs_edges:
+            log.info("Extracting Discogs-derived edges...")
+            sp_edges = extract_shared_personnel(enrichments)
+            log.info("  %d shared personnel edges", len(sp_edges))
+            ss_edges = extract_shared_styles(enrichments, min_jaccard=args.min_jaccard)
+            log.info("  %d shared style edges", len(ss_edges))
+            lf_edges = extract_label_family(enrichments, max_label_artists=args.max_label_artists)
+            log.info("  %d label family edges", len(lf_edges))
+            comp_edges = extract_compilation_coappearance(enrichments)
+            log.info("  %d compilation edges", len(comp_edges))
     elif not args.skip_enrichment:
         log.warning("Skipping Discogs enrichment: no cache DSN or API URL available")
 
@@ -278,7 +330,9 @@ def run(args: argparse.Namespace) -> None:
     log.info("GEXF written to %s", gexf_path)
 
     # 13. Export SQLite database
-    sqlite_path = output_dir / "wxyc_artist_graph.db"
+    sqlite_path = (
+        Path(args.entity_store_path) if entity_store else output_dir / "wxyc_artist_graph.db"
+    )
     if not args.no_sqlite:
         log.info("Exporting SQLite database...")
         export_sqlite(
@@ -292,8 +346,12 @@ def run(args: argparse.Namespace) -> None:
             shared_style_edges=ss_edges,
             label_family_edges=lf_edges,
             compilation_edges=comp_edges,
+            entity_store=entity_store,
         )
         log.info("SQLite written to %s", sqlite_path)
+
+    if entity_store is not None:
+        entity_store.close()
 
     elapsed = time.time() - t0
     log.info("Done in %.1f seconds.", elapsed)
@@ -315,10 +373,11 @@ def run(args: argparse.Namespace) -> None:
     print(f"  Cross-ref edges:         {len(xref_edges):>12,}")
     if enrichments:
         print(f"  Enriched artists:        {len(enrichments):>12,}")
-        print(f"  Shared personnel edges:  {len(sp_edges):>12,}")
-        print(f"  Shared style edges:      {len(ss_edges):>12,}")
-        print(f"  Label family edges:      {len(lf_edges):>12,}")
-        print(f"  Compilation edges:       {len(comp_edges):>12,}")
+        if args.compute_discogs_edges:
+            print(f"  Shared personnel edges:  {len(sp_edges):>12,}")
+            print(f"  Shared style edges:      {len(ss_edges):>12,}")
+            print(f"  Label family edges:      {len(lf_edges):>12,}")
+            print(f"  Compilation edges:       {len(comp_edges):>12,}")
     print(f"  Graph nodes:             {graph.number_of_nodes():>12,}")
     print(f"  Graph edges:             {graph.number_of_edges():>12,}")
     print(f"  GEXF output:             {gexf_path}")

--- a/semantic_index/entity_store.py
+++ b/semantic_index/entity_store.py
@@ -103,6 +103,27 @@ CREATE TABLE IF NOT EXISTS reconciliation_log (
 CREATE INDEX IF NOT EXISTS idx_reconciliation_artist ON reconciliation_log(artist_id);
 """
 
+_ARTIST_TABLE_SCHEMA = """
+CREATE TABLE IF NOT EXISTS artist (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    canonical_name TEXT NOT NULL UNIQUE,
+    genre TEXT,
+    total_plays INTEGER NOT NULL DEFAULT 0,
+    active_first_year INTEGER,
+    active_last_year INTEGER,
+    dj_count INTEGER NOT NULL DEFAULT 0,
+    request_ratio REAL NOT NULL DEFAULT 0.0,
+    show_count INTEGER NOT NULL DEFAULT 0,
+    discogs_artist_id INTEGER,
+    entity_id INTEGER REFERENCES entity(id),
+    musicbrainz_artist_id TEXT,
+    wxyc_library_code_id INTEGER,
+    reconciliation_status TEXT NOT NULL DEFAULT 'unreconciled',
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+"""
+
 _ARTIST_INDEXES = """
 CREATE INDEX IF NOT EXISTS idx_artist_entity ON artist(entity_id);
 CREATE INDEX IF NOT EXISTS idx_artist_discogs ON artist(discogs_artist_id) WHERE discogs_artist_id IS NOT NULL;
@@ -146,13 +167,15 @@ class EntityStore:
         return row is not None
 
     def _migrate_artist_table(self) -> None:
-        """Conditionally add new columns to an existing artist table.
+        """Create the artist table if missing, or add new columns to an existing one.
 
-        Uses PRAGMA table_info to detect which columns already exist and
-        only adds the missing ones. No-op if the table doesn't exist or
-        all columns are already present.
+        On a fresh database, creates the full artist table with all entity
+        store columns. On an old-schema database, uses PRAGMA table_info to
+        detect which columns already exist and only adds the missing ones.
         """
         if not self._has_table("artist"):
+            self._conn.executescript(_ARTIST_TABLE_SCHEMA)
+            logger.info("Created artist table with full entity store schema")
             return
 
         existing = {r[1] for r in self._conn.execute("PRAGMA table_info(artist)")}

--- a/semantic_index/sqlite_export.py
+++ b/semantic_index/sqlite_export.py
@@ -3,6 +3,10 @@
 Creates an artist table with node attributes, edge tables for DJ transitions,
 cross-references, and Discogs-derived relationships (shared personnel, styles,
 labels, compilations), plus enrichment tables for per-artist Discogs metadata.
+
+When an ``EntityStore`` is provided, the artist table already exists (managed
+by the entity store) and export skips artist creation, using the store for ID
+mapping, stats updates, and style persistence instead.
 """
 
 from __future__ import annotations
@@ -15,6 +19,7 @@ from typing import TYPE_CHECKING
 from semantic_index.models import ArtistStats, CrossReferenceEdge, PmiEdge
 
 if TYPE_CHECKING:
+    from semantic_index.entity_store import EntityStore
     from semantic_index.models import (
         ArtistEnrichment,
         CompilationEdge,
@@ -119,6 +124,84 @@ CREATE INDEX IF NOT EXISTS idx_compilation_a ON compilation(artist_a_id);
 CREATE INDEX IF NOT EXISTS idx_compilation_b ON compilation(artist_b_id);
 """
 
+# Edge and enrichment tables only — used when entity_store manages the artist table.
+# Excludes artist (managed by entity store) and artist_style (entity store uses
+# column ``style`` rather than ``style_tag``).
+_EDGE_ENRICHMENT_SCHEMA = """
+CREATE TABLE IF NOT EXISTS dj_transition (
+    source_id INTEGER NOT NULL REFERENCES artist(id),
+    target_id INTEGER NOT NULL REFERENCES artist(id),
+    raw_count INTEGER NOT NULL,
+    pmi REAL NOT NULL,
+    PRIMARY KEY (source_id, target_id)
+);
+
+CREATE TABLE IF NOT EXISTS cross_reference (
+    artist_a_id INTEGER NOT NULL REFERENCES artist(id),
+    artist_b_id INTEGER NOT NULL REFERENCES artist(id),
+    comment TEXT,
+    source TEXT NOT NULL,
+    PRIMARY KEY (artist_a_id, artist_b_id, source)
+);
+
+CREATE TABLE IF NOT EXISTS artist_personnel (
+    artist_id INTEGER NOT NULL REFERENCES artist(id),
+    personnel_name TEXT NOT NULL,
+    role TEXT NOT NULL DEFAULT ''
+);
+
+CREATE TABLE IF NOT EXISTS artist_label (
+    artist_id INTEGER NOT NULL REFERENCES artist(id),
+    label_name TEXT NOT NULL,
+    label_id INTEGER,
+    PRIMARY KEY (artist_id, label_name)
+);
+
+CREATE TABLE IF NOT EXISTS shared_personnel (
+    artist_a_id INTEGER NOT NULL REFERENCES artist(id),
+    artist_b_id INTEGER NOT NULL REFERENCES artist(id),
+    shared_count INTEGER NOT NULL,
+    shared_names TEXT NOT NULL,
+    PRIMARY KEY (artist_a_id, artist_b_id)
+);
+
+CREATE TABLE IF NOT EXISTS shared_style (
+    artist_a_id INTEGER NOT NULL REFERENCES artist(id),
+    artist_b_id INTEGER NOT NULL REFERENCES artist(id),
+    jaccard REAL NOT NULL,
+    shared_tags TEXT NOT NULL,
+    PRIMARY KEY (artist_a_id, artist_b_id)
+);
+
+CREATE TABLE IF NOT EXISTS label_family (
+    artist_a_id INTEGER NOT NULL REFERENCES artist(id),
+    artist_b_id INTEGER NOT NULL REFERENCES artist(id),
+    shared_labels TEXT NOT NULL,
+    PRIMARY KEY (artist_a_id, artist_b_id)
+);
+
+CREATE TABLE IF NOT EXISTS compilation (
+    artist_a_id INTEGER NOT NULL REFERENCES artist(id),
+    artist_b_id INTEGER NOT NULL REFERENCES artist(id),
+    compilation_count INTEGER NOT NULL,
+    compilation_titles TEXT NOT NULL,
+    PRIMARY KEY (artist_a_id, artist_b_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_transition_source ON dj_transition(source_id, pmi DESC);
+CREATE INDEX IF NOT EXISTS idx_transition_target ON dj_transition(target_id, pmi DESC);
+CREATE INDEX IF NOT EXISTS idx_xref_a ON cross_reference(artist_a_id);
+CREATE INDEX IF NOT EXISTS idx_xref_b ON cross_reference(artist_b_id);
+CREATE INDEX IF NOT EXISTS idx_shared_personnel_a ON shared_personnel(artist_a_id);
+CREATE INDEX IF NOT EXISTS idx_shared_personnel_b ON shared_personnel(artist_b_id);
+CREATE INDEX IF NOT EXISTS idx_shared_style_a ON shared_style(artist_a_id);
+CREATE INDEX IF NOT EXISTS idx_shared_style_b ON shared_style(artist_b_id);
+CREATE INDEX IF NOT EXISTS idx_label_family_a ON label_family(artist_a_id);
+CREATE INDEX IF NOT EXISTS idx_label_family_b ON label_family(artist_b_id);
+CREATE INDEX IF NOT EXISTS idx_compilation_a ON compilation(artist_a_id);
+CREATE INDEX IF NOT EXISTS idx_compilation_b ON compilation(artist_b_id);
+"""
+
 
 def export_sqlite(
     path: str,
@@ -131,6 +214,7 @@ def export_sqlite(
     shared_style_edges: list[SharedStyleEdge] | None = None,
     label_family_edges: list[LabelFamilyEdge] | None = None,
     compilation_edges: list[CompilationEdge] | None = None,
+    entity_store: EntityStore | None = None,
 ) -> None:
     """Export the artist graph to a SQLite database.
 
@@ -145,7 +229,54 @@ def export_sqlite(
         shared_style_edges: Optional shared style edges.
         label_family_edges: Optional label family edges.
         compilation_edges: Optional compilation co-appearance edges.
+        entity_store: Optional entity store. When provided, the artist table
+            is assumed to already exist and be populated. Stats are updated
+            via the store, and ID mapping comes from the store.
     """
+    enrichments = enrichments or {}
+
+    if entity_store is not None:
+        _export_with_entity_store(
+            path,
+            entity_store,
+            artist_stats,
+            pmi_edges,
+            xref_edges,
+            min_count,
+            enrichments,
+            shared_personnel_edges or [],
+            shared_style_edges or [],
+            label_family_edges or [],
+            compilation_edges or [],
+        )
+    else:
+        _export_standalone(
+            path,
+            artist_stats,
+            pmi_edges,
+            xref_edges,
+            min_count,
+            enrichments,
+            shared_personnel_edges or [],
+            shared_style_edges or [],
+            label_family_edges or [],
+            compilation_edges or [],
+        )
+
+
+def _export_standalone(
+    path: str,
+    artist_stats: dict[str, ArtistStats],
+    pmi_edges: list[PmiEdge],
+    xref_edges: list[CrossReferenceEdge],
+    min_count: int,
+    enrichments: dict[str, ArtistEnrichment],
+    shared_personnel_edges: list[SharedPersonnelEdge],
+    shared_style_edges: list[SharedStyleEdge],
+    label_family_edges: list[LabelFamilyEdge],
+    compilation_edges: list[CompilationEdge],
+) -> None:
+    """Original export path: create all tables from scratch."""
     conn = sqlite3.connect(path)
     conn.execute("PRAGMA journal_mode=WAL")
     conn.execute("PRAGMA foreign_keys=ON")
@@ -159,7 +290,6 @@ def export_sqlite(
         all_names.add(xref.artist_b)
 
     # Insert artists
-    enrichments = enrichments or {}
     artist_rows = []
     for name in sorted(all_names):
         stats = artist_stats.get(name)
@@ -198,7 +328,89 @@ def export_sqlite(
     for row in conn.execute("SELECT id, canonical_name FROM artist"):
         name_to_id[row[1]] = row[0]
 
-    # Insert DJ transition edges (filtered)
+    # Insert edges and enrichments
+    _insert_edges(conn, name_to_id, pmi_edges, xref_edges, min_count)
+    _insert_enrichments(conn, enrichments, name_to_id)
+    _insert_discogs_edges(
+        conn,
+        name_to_id,
+        shared_personnel_edges,
+        shared_style_edges,
+        label_family_edges,
+        compilation_edges,
+    )
+
+    conn.commit()
+    _log_counts(conn)
+    conn.close()
+
+
+def _export_with_entity_store(
+    path: str,
+    entity_store: EntityStore,
+    artist_stats: dict[str, ArtistStats],
+    pmi_edges: list[PmiEdge],
+    xref_edges: list[CrossReferenceEdge],
+    min_count: int,
+    enrichments: dict[str, ArtistEnrichment],
+    shared_personnel_edges: list[SharedPersonnelEdge],
+    shared_style_edges: list[SharedStyleEdge],
+    label_family_edges: list[LabelFamilyEdge],
+    compilation_edges: list[CompilationEdge],
+) -> None:
+    """Export path when an entity store manages the artist table."""
+    conn = entity_store._conn
+
+    # Create only edge and enrichment tables (artist + artist_style already exist)
+    conn.executescript(_EDGE_ENRICHMENT_SCHEMA)
+
+    # Ensure xref-only artists exist in the entity store
+    xref_names: set[str] = set()
+    for xref in xref_edges:
+        xref_names.add(xref.artist_a)
+        xref_names.add(xref.artist_b)
+
+    existing = set(entity_store.get_name_to_id_mapping().keys())
+    missing = xref_names - existing
+    if missing:
+        entity_store.bulk_upsert_artists(sorted(missing))
+
+    # Update stats via entity store
+    if artist_stats:
+        entity_store.bulk_update_stats(artist_stats)
+
+    # Get ID mapping from entity store
+    name_to_id = entity_store.get_name_to_id_mapping()
+
+    # Insert edges
+    _insert_edges(conn, name_to_id, pmi_edges, xref_edges, min_count)
+
+    # Insert enrichments — styles go through entity store, personnel/labels go to tables
+    _insert_enrichments_with_store(conn, entity_store, enrichments, name_to_id)
+
+    # Insert Discogs-derived edges
+    _insert_discogs_edges(
+        conn,
+        name_to_id,
+        shared_personnel_edges,
+        shared_style_edges,
+        label_family_edges,
+        compilation_edges,
+    )
+
+    conn.commit()
+    _log_counts(conn)
+
+
+def _insert_edges(
+    conn: sqlite3.Connection,
+    name_to_id: dict[str, int],
+    pmi_edges: list[PmiEdge],
+    xref_edges: list[CrossReferenceEdge],
+    min_count: int,
+) -> None:
+    """Insert DJ transition and cross-reference edges."""
+    # DJ transitions (filtered)
     transition_rows = []
     for edge in pmi_edges:
         if edge.raw_count < min_count or edge.pmi <= 0:
@@ -213,7 +425,7 @@ def export_sqlite(
         transition_rows,
     )
 
-    # Insert cross-reference edges
+    # Cross-references
     xref_rows = []
     for xref in xref_edges:
         a_id = name_to_id.get(xref.artist_a)
@@ -225,38 +437,6 @@ def export_sqlite(
         "INSERT INTO cross_reference (artist_a_id, artist_b_id, comment, source) VALUES (?, ?, ?, ?)",
         xref_rows,
     )
-
-    # Insert enrichment data (styles, personnel, labels per artist)
-    _insert_enrichments(conn, enrichments, name_to_id)
-
-    # Insert Discogs-derived edges
-    _insert_discogs_edges(
-        conn,
-        name_to_id,
-        shared_personnel_edges or [],
-        shared_style_edges or [],
-        label_family_edges or [],
-        compilation_edges or [],
-    )
-
-    conn.commit()
-
-    artist_count = conn.execute("SELECT COUNT(*) FROM artist").fetchone()[0]
-    transition_count = conn.execute("SELECT COUNT(*) FROM dj_transition").fetchone()[0]
-    xref_count = conn.execute("SELECT COUNT(*) FROM cross_reference").fetchone()[0]
-    logger.info(
-        "SQLite export: %d artists, %d DJ transitions, %d cross-references",
-        artist_count,
-        transition_count,
-        xref_count,
-    )
-
-    for table in ("shared_personnel", "shared_style", "label_family", "compilation"):
-        count = conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]  # noqa: S608
-        if count > 0:
-            logger.info("  %s: %d edges", table, count)
-
-    conn.close()
 
 
 def _insert_enrichments(
@@ -289,6 +469,48 @@ def _insert_enrichments(
             "INSERT OR IGNORE INTO artist_style (artist_id, style_tag) VALUES (?, ?)",
             style_rows,
         )
+    if personnel_rows:
+        conn.executemany(
+            "INSERT OR IGNORE INTO artist_personnel (artist_id, personnel_name, role) VALUES (?, ?, ?)",
+            personnel_rows,
+        )
+    if label_rows:
+        conn.executemany(
+            "INSERT OR IGNORE INTO artist_label (artist_id, label_name, label_id) VALUES (?, ?, ?)",
+            label_rows,
+        )
+
+
+def _insert_enrichments_with_store(
+    conn: sqlite3.Connection,
+    entity_store: EntityStore,
+    enrichments: dict[str, ArtistEnrichment],
+    name_to_id: dict[str, int],
+) -> None:
+    """Insert enrichment data, routing styles through the entity store.
+
+    The entity store's ``artist_style`` table uses column ``style`` (not
+    ``style_tag``), so styles must go through ``persist_artist_styles()``.
+    Personnel and labels are inserted into their own tables as usual.
+    """
+    personnel_rows = []
+    label_rows = []
+
+    for name, enrich in enrichments.items():
+        artist_id = name_to_id.get(name)
+        if artist_id is None:
+            continue
+
+        if enrich.styles:
+            entity_store.persist_artist_styles(artist_id, enrich.styles)
+
+        for credit in enrich.personnel:
+            for role in credit.roles or [""]:
+                personnel_rows.append((artist_id, credit.name, role or ""))
+
+        for label in enrich.labels:
+            label_rows.append((artist_id, label.name, label.label_id))
+
     if personnel_rows:
         conn.executemany(
             "INSERT OR IGNORE INTO artist_personnel (artist_id, personnel_name, role) VALUES (?, ?, ?)",
@@ -369,3 +591,21 @@ def _insert_discogs_edges(
             "INSERT OR IGNORE INTO compilation (artist_a_id, artist_b_id, compilation_count, compilation_titles) VALUES (?, ?, ?, ?)",
             rows,
         )
+
+
+def _log_counts(conn: sqlite3.Connection) -> None:
+    """Log summary counts for all tables."""
+    artist_count = conn.execute("SELECT COUNT(*) FROM artist").fetchone()[0]
+    transition_count = conn.execute("SELECT COUNT(*) FROM dj_transition").fetchone()[0]
+    xref_count = conn.execute("SELECT COUNT(*) FROM cross_reference").fetchone()[0]
+    logger.info(
+        "SQLite export: %d artists, %d DJ transitions, %d cross-references",
+        artist_count,
+        transition_count,
+        xref_count,
+    )
+
+    for table in ("shared_personnel", "shared_style", "label_family", "compilation"):
+        count = conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]  # noqa: S608
+        if count > 0:
+            logger.info("  %s: %d edges", table, count)

--- a/tests/unit/test_run_pipeline.py
+++ b/tests/unit/test_run_pipeline.py
@@ -1,0 +1,49 @@
+"""Tests for run_pipeline CLI argument parsing and entity store integration."""
+
+from run_pipeline import parse_args
+
+
+class TestParseArgs:
+    def test_entity_store_path_default(self):
+        args = parse_args(["dump.sql"])
+        assert args.entity_store_path is None
+
+    def test_entity_store_path_flag(self):
+        args = parse_args(["dump.sql", "--entity-store-path", "/tmp/store.db"])
+        assert args.entity_store_path == "/tmp/store.db"
+
+    def test_skip_reconciliation_default(self):
+        args = parse_args(["dump.sql"])
+        assert args.skip_reconciliation is False
+
+    def test_skip_reconciliation_flag(self):
+        args = parse_args(["dump.sql", "--skip-reconciliation"])
+        assert args.skip_reconciliation is True
+
+    def test_compute_discogs_edges_default(self):
+        args = parse_args(["dump.sql"])
+        assert args.compute_discogs_edges is False
+
+    def test_compute_discogs_edges_flag(self):
+        args = parse_args(["dump.sql", "--compute-discogs-edges"])
+        assert args.compute_discogs_edges is True
+
+    def test_existing_flags_preserved(self):
+        """Existing flags should still work."""
+        args = parse_args(
+            [
+                "dump.sql",
+                "--output-dir",
+                "out",
+                "--min-count",
+                "5",
+                "--no-sqlite",
+                "--skip-enrichment",
+                "--verbose",
+            ]
+        )
+        assert args.output_dir == "out"
+        assert args.min_count == 5
+        assert args.no_sqlite is True
+        assert args.skip_enrichment is True
+        assert args.verbose is True

--- a/tests/unit/test_sqlite_export_entity_store.py
+++ b/tests/unit/test_sqlite_export_entity_store.py
@@ -1,0 +1,321 @@
+"""Tests for sqlite_export integration with EntityStore.
+
+When an EntityStore is provided, export_sqlite should:
+- Skip artist table creation (artists already exist in the entity store)
+- Use EntityStore.get_name_to_id_mapping() for ID resolution
+- Use EntityStore.bulk_update_stats() for stats
+- Use EntityStore.persist_artist_styles() for enrichment styles
+- Still create edge tables and insert edges normally
+"""
+
+import sqlite3
+
+import pytest
+
+from semantic_index.entity_store import EntityStore
+from semantic_index.models import (
+    ArtistEnrichment,
+    ArtistStats,
+    CrossReferenceEdge,
+    LabelInfo,
+    PersonnelCredit,
+    PmiEdge,
+)
+from semantic_index.sqlite_export import export_sqlite
+
+
+@pytest.fixture()
+def entity_store_db(tmp_path):
+    """Create an EntityStore with pre-populated artists and return (store, db_path)."""
+    db_path = str(tmp_path / "test.db")
+    store = EntityStore(db_path)
+    store.initialize()
+
+    # Bulk upsert some artists — simulates pipeline step
+    store.bulk_upsert_artists(["Autechre", "Stereolab", "Cat Power"])
+
+    return store, db_path
+
+
+class TestEntityStoreMode:
+    def test_uses_existing_artist_ids(self, entity_store_db):
+        """Artist IDs come from the entity store, not from fresh INSERTs."""
+        store, db_path = entity_store_db
+
+        expected_mapping = store.get_name_to_id_mapping()
+        stats = {
+            "Autechre": ArtistStats(canonical_name="Autechre", total_plays=50),
+            "Stereolab": ArtistStats(canonical_name="Stereolab", total_plays=30),
+        }
+        edges = [PmiEdge(source="Autechre", target="Stereolab", raw_count=5, pmi=3.0)]
+
+        export_sqlite(
+            db_path,
+            artist_stats=stats,
+            pmi_edges=edges,
+            xref_edges=[],
+            min_count=1,
+            entity_store=store,
+        )
+
+        # Verify the transition edge uses the entity store's IDs
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+        row = conn.execute("SELECT * FROM dj_transition").fetchone()
+        assert row is not None
+        assert row["source_id"] == expected_mapping["Autechre"]
+        assert row["target_id"] == expected_mapping["Stereolab"]
+        conn.close()
+
+    def test_updates_stats_on_existing_artists(self, entity_store_db):
+        """Stats are applied to existing artist rows via entity_store."""
+        store, db_path = entity_store_db
+
+        stats = {
+            "Autechre": ArtistStats(
+                canonical_name="Autechre",
+                total_plays=50,
+                genre="Electronic",
+                active_first_year=2004,
+                active_last_year=2025,
+                dj_count=15,
+                request_ratio=0.1,
+                show_count=40,
+            ),
+        }
+
+        export_sqlite(
+            db_path,
+            artist_stats=stats,
+            pmi_edges=[],
+            xref_edges=[],
+            entity_store=store,
+        )
+
+        row = store.get_artist_by_name("Autechre")
+        assert row is not None
+        assert row["total_plays"] == 50
+        assert row["genre"] == "Electronic"
+        assert row["dj_count"] == 15
+
+    def test_does_not_duplicate_artists(self, entity_store_db):
+        """Entity store mode should not create duplicate artist rows."""
+        store, db_path = entity_store_db
+
+        stats = {
+            "Autechre": ArtistStats(canonical_name="Autechre", total_plays=50),
+        }
+
+        export_sqlite(
+            db_path,
+            artist_stats=stats,
+            pmi_edges=[],
+            xref_edges=[],
+            entity_store=store,
+        )
+
+        conn = sqlite3.connect(db_path)
+        count = conn.execute(
+            "SELECT COUNT(*) FROM artist WHERE canonical_name = 'Autechre'"
+        ).fetchone()[0]
+        assert count == 1
+        conn.close()
+
+    def test_creates_edge_tables(self, entity_store_db):
+        """Edge tables are created even in entity store mode."""
+        store, db_path = entity_store_db
+
+        export_sqlite(
+            db_path,
+            artist_stats={},
+            pmi_edges=[],
+            xref_edges=[],
+            entity_store=store,
+        )
+
+        conn = sqlite3.connect(db_path)
+        tables = {
+            row[0]
+            for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
+        }
+        assert "dj_transition" in tables
+        assert "cross_reference" in tables
+        assert "shared_personnel" in tables
+        assert "shared_style" in tables
+        assert "label_family" in tables
+        assert "compilation" in tables
+        conn.close()
+
+    def test_inserts_cross_reference_edges(self, entity_store_db):
+        """Cross-reference edges use entity store IDs."""
+        store, db_path = entity_store_db
+        mapping = store.get_name_to_id_mapping()
+
+        xrefs = [
+            CrossReferenceEdge(
+                artist_a="Autechre",
+                artist_b="Stereolab",
+                comment="See also",
+                source="library_code",
+            )
+        ]
+
+        export_sqlite(
+            db_path,
+            artist_stats={},
+            pmi_edges=[],
+            xref_edges=xrefs,
+            entity_store=store,
+        )
+
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+        row = conn.execute("SELECT * FROM cross_reference").fetchone()
+        assert row is not None
+        assert row["artist_a_id"] == mapping["Autechre"]
+        assert row["artist_b_id"] == mapping["Stereolab"]
+        assert row["comment"] == "See also"
+        conn.close()
+
+    def test_xref_artists_not_in_store_are_upserted(self, entity_store_db):
+        """Cross-ref artists not already in the entity store get upserted."""
+        store, db_path = entity_store_db
+
+        xrefs = [
+            CrossReferenceEdge(
+                artist_a="Autechre",
+                artist_b="Father John Misty",
+                comment="",
+                source="library_code",
+            )
+        ]
+
+        export_sqlite(
+            db_path,
+            artist_stats={},
+            pmi_edges=[],
+            xref_edges=xrefs,
+            entity_store=store,
+        )
+
+        row = store.get_artist_by_name("Father John Misty")
+        assert row is not None
+
+    def test_enrichment_styles_persisted_via_store(self, entity_store_db):
+        """When entity_store is provided, enrichment styles go through persist_artist_styles."""
+        store, db_path = entity_store_db
+
+        enrichments = {
+            "Autechre": ArtistEnrichment(
+                canonical_name="Autechre",
+                discogs_artist_id=42,
+                styles=["IDM", "Abstract"],
+                personnel=[],
+                labels=[],
+                compilation_appearances=[],
+            ),
+        }
+
+        export_sqlite(
+            db_path,
+            artist_stats={},
+            pmi_edges=[],
+            xref_edges=[],
+            enrichments=enrichments,
+            entity_store=store,
+        )
+
+        styles = store.get_artist_styles(store.get_name_to_id_mapping()["Autechre"])
+        assert "IDM" in styles
+        assert "Abstract" in styles
+
+    def test_enrichment_personnel_inserted(self, entity_store_db):
+        """Personnel enrichment data is still inserted into artist_personnel."""
+        store, db_path = entity_store_db
+
+        enrichments = {
+            "Autechre": ArtistEnrichment(
+                canonical_name="Autechre",
+                discogs_artist_id=42,
+                styles=[],
+                personnel=[PersonnelCredit(name="Rob Brown", roles=["Written-By"])],
+                labels=[],
+                compilation_appearances=[],
+            ),
+        }
+
+        export_sqlite(
+            db_path,
+            artist_stats={},
+            pmi_edges=[],
+            xref_edges=[],
+            enrichments=enrichments,
+            entity_store=store,
+        )
+
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+        row = conn.execute("SELECT * FROM artist_personnel").fetchone()
+        assert row is not None
+        assert row["personnel_name"] == "Rob Brown"
+        conn.close()
+
+    def test_enrichment_labels_inserted(self, entity_store_db):
+        """Label enrichment data is still inserted into artist_label."""
+        store, db_path = entity_store_db
+
+        enrichments = {
+            "Autechre": ArtistEnrichment(
+                canonical_name="Autechre",
+                discogs_artist_id=42,
+                styles=[],
+                personnel=[],
+                labels=[LabelInfo(name="Warp Records", label_id=100)],
+                compilation_appearances=[],
+            ),
+        }
+
+        export_sqlite(
+            db_path,
+            artist_stats={},
+            pmi_edges=[],
+            xref_edges=[],
+            enrichments=enrichments,
+            entity_store=store,
+        )
+
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+        row = conn.execute("SELECT * FROM artist_label").fetchone()
+        assert row is not None
+        assert row["label_name"] == "Warp Records"
+        conn.close()
+
+
+class TestBackwardCompatibility:
+    def test_without_entity_store_unchanged(self):
+        """Without entity_store, behavior is identical to before."""
+        import tempfile
+
+        stats = {
+            "Autechre": ArtistStats(canonical_name="Autechre", total_plays=50),
+            "Stereolab": ArtistStats(canonical_name="Stereolab", total_plays=30),
+        }
+        edges = [PmiEdge(source="Autechre", target="Stereolab", raw_count=5, pmi=3.0)]
+        path = tempfile.mktemp(suffix=".db")
+
+        export_sqlite(
+            path,
+            artist_stats=stats,
+            pmi_edges=edges,
+            xref_edges=[],
+            min_count=1,
+        )
+
+        conn = sqlite3.connect(path)
+        conn.row_factory = sqlite3.Row
+        count = conn.execute("SELECT COUNT(*) FROM artist").fetchone()[0]
+        assert count == 2
+        transition = conn.execute("SELECT COUNT(*) FROM dj_transition").fetchone()[0]
+        assert transition == 1
+        conn.close()


### PR DESCRIPTION
## Summary

- Wire `EntityStore` into `sqlite_export.py` as an optional parameter for persistent artist identities. When provided, skip artist table creation and use entity store for ID mapping, stats updates, and style persistence. Backward compatible: without entity_store, behaves exactly as today.
- Extend `run_pipeline.py` with `--entity-store-path`, `--skip-reconciliation`, and `--compute-discogs-edges` flags. New pipeline steps: open entity store, bulk upsert artists, reconcile via Discogs.
- Enable `EntityStore` to create the artist table from scratch on fresh databases (previously only migrated existing tables).

Closes #58

## Test plan

- [x] New tests in `test_sqlite_export_entity_store.py` verify entity store mode: ID mapping, stats updates, edge insertion, xref artist upsert, enrichment routing, backward compatibility
- [x] New tests in `test_run_pipeline.py` verify CLI arg parsing for all new flags
- [x] All 345 unit tests pass
- [x] All existing sqlite_export and entity_store tests still pass (no regressions)
- [x] ruff check, ruff format, mypy all clean