### PR TITLE
Add artist detail and entity group API endpoints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,8 +35,8 @@ SQLite ──→ api (FastAPI + aiosqlite) ──→ JSON responses
 | `semantic_index/sqlite_export.py` | Build and export SQLite graph database with enrichment and edge tables. Supports optional entity store integration for persistent artist identities. |
 | `semantic_index/api/app.py` | FastAPI application factory. Takes a SQLite database path, returns a configured app. |
 | `semantic_index/api/database.py` | Request-scoped SQLite connection dependency for FastAPI. |
-| `semantic_index/api/schemas.py` | Pydantic response models for the Graph API (ArtistSummary, SearchResponse, NeighborsResponse, ExplainResponse). |
-| `semantic_index/api/routes.py` | Graph API query endpoints: search, neighbors by edge type, explain relationships between two artists. |
+| `semantic_index/api/schemas.py` | Pydantic response models for the Graph API (ArtistSummary, ArtistDetail, EntityArtists, SearchResponse, NeighborsResponse, ExplainResponse). |
+| `semantic_index/api/routes.py` | Graph API query endpoints: search, artist detail, neighbors by edge type, explain relationships, entity artist groups. |
 | `run_pipeline.py` | CLI entry point wiring the pipeline. |
 
 ### Column Mappings (0-indexed from SQL INSERT order)
@@ -179,8 +179,10 @@ app = create_app("data/wxyc_artist_graph.db")
 | `GET` | `/` | D3.js graph explorer (interactive visualization). |
 | `GET` | `/health` | Health check — returns artist count or 503 if database is unreachable. |
 | `GET` | `/graph/artists/search?q=autechre&limit=10` | Case-insensitive LIKE search, ordered by total_plays descending. |
+| `GET` | `/graph/artists/{id}` | Full artist detail including external IDs (Discogs, MusicBrainz, Wikidata QID) joined from the entity table. Gracefully degrades on old-schema databases. |
 | `GET` | `/graph/artists/{id}/neighbors?type=djTransition&limit=20` | Neighbors by edge type. Types: `djTransition`, `sharedPersonnel`, `sharedStyle`, `labelFamily`, `compilation`, `crossReference`. |
 | `GET` | `/graph/artists/{id}/explain/{target_id}` | All relationship types between two artists with weights and details. |
+| `GET` | `/graph/entities/{id}/artists` | All artists sharing an entity (alias group). Returns entity metadata and a list of artist summaries. |
 
 ### Deployment
 

--- a/semantic_index/api/routes.py
+++ b/semantic_index/api/routes.py
@@ -10,7 +10,9 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 
 from semantic_index.api.database import get_db
 from semantic_index.api.schemas import (
+    ArtistDetail,
     ArtistSummary,
+    EntityArtists,
     ExplainResponse,
     NeighborEntry,
     NeighborsResponse,
@@ -66,6 +68,19 @@ def search_artists(
     return SearchResponse(results=[_artist_summary(r) for r in rows])
 
 
+@router.get("/artists/{artist_id}", response_model=ArtistDetail)
+def get_artist_detail(
+    artist_id: int,
+    db: sqlite3.Connection = Depends(get_db),
+) -> ArtistDetail:
+    """Return full artist detail including external IDs from the entity table.
+
+    Gracefully handles databases without entity store columns by falling back
+    to NULL values for entity fields.
+    """
+    return _get_artist_detail(db, artist_id)
+
+
 @router.get("/artists/{artist_id}/neighbors", response_model=NeighborsResponse)
 def get_neighbors(
     artist_id: int,
@@ -95,6 +110,95 @@ def explain_relationship(
         relationships.extend(rels)
 
     return ExplainResponse(source=source, target=target, relationships=relationships)
+
+
+@router.get("/entities/{entity_id}/artists", response_model=EntityArtists)
+def get_entity_artists(
+    entity_id: int,
+    db: sqlite3.Connection = Depends(get_db),
+) -> EntityArtists:
+    """Return all artists sharing an entity (alias group)."""
+    entity_row = db.execute(
+        "SELECT id, name, wikidata_qid FROM entity WHERE id = ?",
+        (entity_id,),
+    ).fetchone()
+    if entity_row is None:
+        raise HTTPException(status_code=404, detail="Entity not found")
+
+    artist_rows = db.execute(
+        "SELECT id, canonical_name, genre, total_plays FROM artist WHERE entity_id = ?",
+        (entity_id,),
+    ).fetchall()
+
+    return EntityArtists(
+        entity_id=entity_row["id"],
+        entity_name=entity_row["name"],
+        wikidata_qid=entity_row["wikidata_qid"],
+        artists=[_artist_summary(r) for r in artist_rows],
+    )
+
+
+def _get_artist_detail(db: sqlite3.Connection, artist_id: int) -> ArtistDetail:
+    """Fetch full artist detail, joining entity table when available.
+
+    Falls back gracefully when entity store columns don't exist in the database
+    (old schema without entity_id, discogs_artist_id, etc.).
+    """
+    try:
+        row = db.execute(
+            "SELECT a.id, a.canonical_name, a.genre, a.total_plays, "
+            "  a.active_first_year, a.active_last_year, a.dj_count, "
+            "  a.request_ratio, a.show_count, "
+            "  a.entity_id, a.discogs_artist_id, a.musicbrainz_artist_id, "
+            "  a.reconciliation_status, "
+            "  e.wikidata_qid "
+            "FROM artist a "
+            "LEFT JOIN entity e ON a.entity_id = e.id "
+            "WHERE a.id = ?",
+            (artist_id,),
+        ).fetchone()
+    except sqlite3.OperationalError:
+        # Old schema: entity columns or entity table don't exist
+        row = db.execute(
+            "SELECT id, canonical_name, genre, total_plays, "
+            "  active_first_year, active_last_year, dj_count, "
+            "  request_ratio, show_count "
+            "FROM artist WHERE id = ?",
+            (artist_id,),
+        ).fetchone()
+        if row is None:
+            raise HTTPException(status_code=404, detail="Artist not found") from None
+        return ArtistDetail(
+            id=row["id"],
+            canonical_name=row["canonical_name"],
+            genre=row["genre"],
+            total_plays=row["total_plays"],
+            active_first_year=row["active_first_year"],
+            active_last_year=row["active_last_year"],
+            dj_count=row["dj_count"],
+            request_ratio=row["request_ratio"],
+            show_count=row["show_count"],
+        )
+
+    if row is None:
+        raise HTTPException(status_code=404, detail="Artist not found")
+
+    return ArtistDetail(
+        id=row["id"],
+        canonical_name=row["canonical_name"],
+        genre=row["genre"],
+        total_plays=row["total_plays"],
+        active_first_year=row["active_first_year"],
+        active_last_year=row["active_last_year"],
+        dj_count=row["dj_count"],
+        request_ratio=row["request_ratio"],
+        show_count=row["show_count"],
+        entity_id=row["entity_id"],
+        discogs_artist_id=row["discogs_artist_id"],
+        musicbrainz_artist_id=row["musicbrainz_artist_id"],
+        wikidata_qid=row["wikidata_qid"],
+        reconciliation_status=row["reconciliation_status"],
+    )
 
 
 def _query_neighbors(

--- a/semantic_index/api/schemas.py
+++ b/semantic_index/api/schemas.py
@@ -52,3 +52,31 @@ class ExplainResponse(BaseModel):
     source: ArtistSummary
     target: ArtistSummary
     relationships: list[Relationship]
+
+
+class ArtistDetail(BaseModel):
+    """Full artist detail including external IDs from joined entity table."""
+
+    id: int
+    canonical_name: str
+    genre: str | None = None
+    total_plays: int = 0
+    active_first_year: int | None = None
+    active_last_year: int | None = None
+    dj_count: int = 0
+    request_ratio: float = 0.0
+    show_count: int = 0
+    entity_id: int | None = None
+    discogs_artist_id: int | None = None
+    musicbrainz_artist_id: str | None = None
+    wikidata_qid: str | None = None
+    reconciliation_status: str = "unreconciled"
+
+
+class EntityArtists(BaseModel):
+    """Response for GET /graph/entities/{id}/artists — all artists sharing an entity."""
+
+    entity_id: int
+    entity_name: str
+    wikidata_qid: str | None = None
+    artists: list[ArtistSummary]

--- a/tests/unit/test_api_routes.py
+++ b/tests/unit/test_api_routes.py
@@ -1,4 +1,4 @@
-"""Tests for Graph API query endpoints: search, neighbors, explain."""
+"""Tests for Graph API query endpoints: search, neighbors, explain, artist detail, entity artists."""
 
 from __future__ import annotations
 
@@ -10,6 +10,7 @@ import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 
 from semantic_index.api.app import create_app
+from semantic_index.entity_store import EntityStore
 from semantic_index.models import (
     ArtistStats,
     CrossReferenceEdge,
@@ -350,3 +351,236 @@ class TestExplain:
         assert "crossReference" in types
         xref_rel = next(r for r in data["relationships"] if r["type"] == "crossReference")
         assert xref_rel["detail"]["comment"] == "See also"
+
+
+def _build_entity_store_fixture_db() -> str:
+    """Create a fixture SQLite database with entity store tables and return its path."""
+    path = tempfile.mktemp(suffix=".db")
+    store = EntityStore(path)
+    store.initialize()
+
+    # Create entities
+    entity_ae = store.get_or_create_entity("Autechre", "artist")
+    store.update_entity_qid(entity_ae.id, "Q375855")
+    entity_sl = store.get_or_create_entity("Stereolab", "artist")
+
+    # Upsert artists linked to entities
+    store.upsert_artist(
+        "Autechre",
+        genre="Electronic",
+        discogs_artist_id=1240,
+        entity_id=entity_ae.id,
+        musicbrainz_artist_id="410c9baf-5469-44f6-9852-826524b80c61",
+    )
+    store.upsert_artist(
+        "Stereolab",
+        genre="Rock",
+        entity_id=entity_sl.id,
+    )
+    # An alias pointing to the same entity as Autechre
+    store.upsert_artist(
+        "Ae",
+        genre="Electronic",
+        entity_id=entity_ae.id,
+    )
+    # An artist with no entity
+    store.upsert_artist("Cat Power", genre="Rock")
+
+    # Update stats
+    store.update_artist_stats(
+        "Autechre",
+        ArtistStats(
+            canonical_name="Autechre",
+            total_plays=50,
+            genre="Electronic",
+            active_first_year=2004,
+            active_last_year=2025,
+            dj_count=15,
+            request_ratio=0.1,
+            show_count=40,
+        ),
+    )
+    store.update_artist_stats(
+        "Stereolab",
+        ArtistStats(
+            canonical_name="Stereolab",
+            total_plays=30,
+            genre="Rock",
+            active_first_year=2003,
+            active_last_year=2024,
+            dj_count=10,
+            request_ratio=0.05,
+            show_count=25,
+        ),
+    )
+    store.update_artist_stats(
+        "Ae",
+        ArtistStats(
+            canonical_name="Ae",
+            total_plays=5,
+            genre="Electronic",
+            active_first_year=2015,
+            active_last_year=2020,
+            dj_count=2,
+            request_ratio=0.0,
+            show_count=3,
+        ),
+    )
+    store.update_artist_stats(
+        "Cat Power",
+        ArtistStats(
+            canonical_name="Cat Power",
+            total_plays=20,
+            genre="Rock",
+            active_first_year=2005,
+            active_last_year=2023,
+            dj_count=8,
+            request_ratio=0.02,
+            show_count=15,
+        ),
+    )
+
+    # Mark reconciliation status for Autechre
+    store.update_reconciliation_status(
+        store.get_artist_by_name("Autechre")["id"],
+        "reconciled",  # type: ignore[index]
+    )
+
+    store.close()
+    return path
+
+
+@pytest.fixture(scope="module")
+def entity_db_path() -> str:
+    return _build_entity_store_fixture_db()
+
+
+@pytest.fixture(scope="module")
+def entity_artist_ids(entity_db_path: str) -> dict[str, int]:
+    """Return a mapping of canonical_name -> id from the entity store database."""
+    conn = sqlite3.connect(entity_db_path)
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute("SELECT id, canonical_name FROM artist").fetchall()
+    conn.close()
+    return {r["canonical_name"]: r["id"] for r in rows}
+
+
+@pytest.fixture(scope="module")
+def entity_ids(entity_db_path: str) -> dict[str, int]:
+    """Return a mapping of entity name -> entity id."""
+    conn = sqlite3.connect(entity_db_path)
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute("SELECT id, name FROM entity").fetchall()
+    conn.close()
+    return {r["name"]: r["id"] for r in rows}
+
+
+@pytest_asyncio.fixture
+async def entity_client(entity_db_path: str) -> AsyncClient:
+    app = create_app(entity_db_path)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+class TestArtistDetail:
+    @pytest.mark.asyncio
+    async def test_artist_detail_with_entity(
+        self, entity_client: AsyncClient, entity_artist_ids: dict[str, int]
+    ) -> None:
+        """Artist detail returns all fields including external IDs from joined entity."""
+        aid = entity_artist_ids["Autechre"]
+        resp = await entity_client.get(f"/graph/artists/{aid}")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["canonical_name"] == "Autechre"
+        assert data["genre"] == "Electronic"
+        assert data["total_plays"] == 50
+        assert data["active_first_year"] == 2004
+        assert data["active_last_year"] == 2025
+        assert data["dj_count"] == 15
+        assert data["request_ratio"] == 0.1
+        assert data["show_count"] == 40
+        assert data["discogs_artist_id"] == 1240
+        assert data["musicbrainz_artist_id"] == "410c9baf-5469-44f6-9852-826524b80c61"
+        assert data["wikidata_qid"] == "Q375855"
+        assert data["reconciliation_status"] == "reconciled"
+
+    @pytest.mark.asyncio
+    async def test_artist_detail_no_entity(
+        self, entity_client: AsyncClient, entity_artist_ids: dict[str, int]
+    ) -> None:
+        """Artist with no entity_id returns None for entity fields."""
+        aid = entity_artist_ids["Cat Power"]
+        resp = await entity_client.get(f"/graph/artists/{aid}")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["canonical_name"] == "Cat Power"
+        assert data["entity_id"] is None
+        assert data["discogs_artist_id"] is None
+        assert data["musicbrainz_artist_id"] is None
+        assert data["wikidata_qid"] is None
+        assert data["reconciliation_status"] == "unreconciled"
+
+    @pytest.mark.asyncio
+    async def test_artist_detail_404(self, entity_client: AsyncClient) -> None:
+        """Unknown artist ID returns 404."""
+        resp = await entity_client.get("/graph/artists/99999")
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_artist_detail_old_schema(
+        self, client: AsyncClient, artist_ids: dict[str, int]
+    ) -> None:
+        """Databases without entity columns gracefully return None for entity fields."""
+        aid = artist_ids["Autechre"]
+        resp = await client.get(f"/graph/artists/{aid}")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["canonical_name"] == "Autechre"
+        assert data["entity_id"] is None
+        assert data["discogs_artist_id"] is None
+        assert data["musicbrainz_artist_id"] is None
+        assert data["wikidata_qid"] is None
+        assert data["reconciliation_status"] == "unreconciled"
+
+
+class TestEntityArtists:
+    @pytest.mark.asyncio
+    async def test_entity_artists_grouped(
+        self,
+        entity_client: AsyncClient,
+        entity_ids: dict[str, int],
+    ) -> None:
+        """Entity artists endpoint returns all artists sharing the entity."""
+        eid = entity_ids["Autechre"]
+        resp = await entity_client.get(f"/graph/entities/{eid}/artists")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["entity_id"] == eid
+        assert data["entity_name"] == "Autechre"
+        assert data["wikidata_qid"] == "Q375855"
+        names = {a["canonical_name"] for a in data["artists"]}
+        assert names == {"Autechre", "Ae"}
+
+    @pytest.mark.asyncio
+    async def test_entity_artists_single(
+        self,
+        entity_client: AsyncClient,
+        entity_ids: dict[str, int],
+    ) -> None:
+        """Entity with a single artist returns a list of one."""
+        eid = entity_ids["Stereolab"]
+        resp = await entity_client.get(f"/graph/entities/{eid}/artists")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["entity_id"] == eid
+        assert data["entity_name"] == "Stereolab"
+        assert len(data["artists"]) == 1
+        assert data["artists"][0]["canonical_name"] == "Stereolab"
+
+    @pytest.mark.asyncio
+    async def test_entity_artists_404(self, entity_client: AsyncClient) -> None:
+        """Unknown entity ID returns 404."""
+        resp = await entity_client.get("/graph/entities/99999/artists")
+        assert resp.status_code == 404


### PR DESCRIPTION
## Summary

- Add `GET /graph/artists/{id}` endpoint returning full artist detail including external IDs (Discogs artist ID, MusicBrainz artist ID, Wikidata QID) joined from the entity table, with reconciliation status. Gracefully degrades on old-schema databases without entity store columns.
- Add `GET /graph/entities/{id}/artists` endpoint returning all artists sharing an entity (alias group), with entity metadata and a list of artist summaries.
- Add `ArtistDetail` and `EntityArtists` response schemas to `semantic_index/api/schemas.py`.
- 7 new unit tests covering: detail with entity, detail without entity, 404 for unknown artist, old-schema fallback, entity group with aliases, single-artist entity, and 404 for unknown entity.

Closes #59

## Test plan

- [x] `pytest tests/unit/ -v` -- all 352 tests pass
- [x] `ruff check .` -- no lint issues
- [x] `ruff format --check .` -- all files formatted
- [x] `mypy semantic_index/` -- no type errors