### PR TITLE
Add Discogs alias reconciliation for no_match artists

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ SQLite ──→ api (FastAPI + aiosqlite) ──→ JSON responses
 | `semantic_index/cross_reference.py` | Extract cross-reference edges from catalog cross-reference tables. |
 | `semantic_index/discogs_client.py` | Two-tier Discogs client: discogs-cache PostgreSQL with library-metadata-lookup API fallback. |
 | `semantic_index/entity_store.py` | Persistent entity store for reconciled artist identities: schema creation/migration, CRUD, artist upsert, reconciliation log, artist styles. Creates the artist table from scratch on a fresh database or migrates an existing one. |
-| `semantic_index/reconciliation.py` | Bulk Discogs matching for unreconciled artists via discogs-cache release_artist table. |
+| `semantic_index/reconciliation.py` | Bulk Discogs matching for unreconciled artists via discogs-cache release_artist table, with alias retry via artist_alias and artist_name_variation tables. |
 | `semantic_index/discogs_enrichment.py` | Aggregate Discogs metadata (styles, personnel, labels, compilations) per artist. |
 | `semantic_index/discogs_edges.py` | Compute Discogs-derived edges: shared personnel, shared style (Jaccard), label family, compilation co-appearance. |
 | `semantic_index/graph_export.py` | Build NetworkX graph and export GEXF. |

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -291,6 +291,16 @@ def run(args: argparse.Namespace) -> None:
                 report.no_match,
                 report.errored,
             )
+
+            # Retry no_match artists against alias and name variation tables
+            alias_report = reconciler.reconcile_aliases()
+            log.info(
+                "Alias reconciliation: %d attempted, %d succeeded, %d no_match, %d errored",
+                alias_report.attempted,
+                alias_report.succeeded,
+                alias_report.no_match,
+                alias_report.errored,
+            )
         elif not args.skip_reconciliation:
             log.warning("Skipping reconciliation: no discogs-cache DSN available")
 

--- a/semantic_index/entity_store.py
+++ b/semantic_index/entity_store.py
@@ -466,6 +466,21 @@ class EntityStore:
         rows = self._conn.execute(sql).fetchall()
         return [(row[0], row[1]) for row in rows]
 
+    def get_no_match_artists(self, limit: int | None = None) -> list[tuple[int, str]]:
+        """Return (id, canonical_name) pairs for artists with status 'no_match'.
+
+        Args:
+            limit: Maximum number of artists to return. None for all.
+
+        Returns:
+            List of (artist_id, canonical_name) tuples.
+        """
+        sql = "SELECT id, canonical_name FROM artist WHERE reconciliation_status = 'no_match'"
+        if limit is not None:
+            sql += f" LIMIT {limit}"
+        rows = self._conn.execute(sql).fetchall()
+        return [(row[0], row[1]) for row in rows]
+
     def update_reconciliation_status(self, artist_id: int, status: str) -> None:
         """Update the reconciliation status for an artist.
 

--- a/semantic_index/reconciliation.py
+++ b/semantic_index/reconciliation.py
@@ -114,6 +114,78 @@ class ArtistReconciler:
             skipped=skipped,
         )
 
+    def reconcile_aliases(self, batch_size: int = 1000) -> ReconciliationReport:
+        """Retry no_match artists against Discogs alias and name variation tables.
+
+        Queries artists with ``reconciliation_status='no_match'`` (set by a
+        prior ``reconcile_batch()`` run) and attempts to match them via the
+        discogs-cache ``artist_alias`` and ``artist_name_variation`` tables.
+
+        Args:
+            batch_size: Number of artist names per bulk Discogs query.
+
+        Returns:
+            ReconciliationReport with counts of attempted, succeeded,
+            no_match, errored, and skipped artists.
+        """
+        total = self._store._conn.execute("SELECT COUNT(*) FROM artist").fetchone()[0]
+        no_match_artists = self._store.get_no_match_artists()
+        skipped = total - len(no_match_artists)
+
+        succeeded = 0
+        no_match = 0
+        errored = 0
+
+        name_to_id = {name: aid for aid, name in no_match_artists}
+
+        for batch_start in range(0, len(no_match_artists), batch_size):
+            batch = no_match_artists[batch_start : batch_start + batch_size]
+            batch_names = [name for _, name in batch]
+
+            try:
+                matches = self._reconcile_discogs_aliases(batch_names)
+            except Exception:
+                logger.warning("Alias reconciliation failed for batch", exc_info=True)
+                errored += len(batch_names)
+                continue
+
+            for name in batch_names:
+                artist_id = name_to_id[name]
+                if name in matches:
+                    discogs_id, styles = matches[name]
+                    self._store.upsert_artist(name, discogs_artist_id=discogs_id)
+                    if styles:
+                        self._store.persist_artist_styles(artist_id, styles)
+                    self._store.log_reconciliation(
+                        artist_id=artist_id,
+                        source="discogs",
+                        external_id=str(discogs_id),
+                        confidence=None,
+                        method="alias_lookup",
+                    )
+                    self._store.update_reconciliation_status(artist_id, "reconciled")
+                    succeeded += 1
+                else:
+                    no_match += 1
+
+        attempted = succeeded + no_match + errored
+        logger.info(
+            "Alias reconciliation complete: %d attempted, %d succeeded, %d no_match, %d errored, %d skipped",
+            attempted,
+            succeeded,
+            no_match,
+            errored,
+            skipped,
+        )
+        return ReconciliationReport(
+            total=total,
+            attempted=attempted,
+            succeeded=succeeded,
+            no_match=no_match,
+            errored=errored,
+            skipped=skipped,
+        )
+
     @staticmethod
     def _query_with_fallback(
         conn: object, primary_sql: str, fallback_sql: str, params: tuple
@@ -192,5 +264,78 @@ class ArtistReconciler:
         # 3. Build result
         return {
             canonical: (discogs_id, artist_styles.get(canonical, []))
+            for canonical, discogs_id in matches.items()
+        }
+
+    def _reconcile_discogs_aliases(self, names: list[str]) -> dict[str, tuple[int, list[str]]]:
+        """Batch Discogs alias lookup via ``artist_alias`` and ``artist_name_variation``.
+
+        Queries the discogs-cache PostgreSQL using ``ANY()`` for efficient
+        bulk matching against alias names and name variations, then fetches
+        per-artist styles from ``release_style``.
+
+        Args:
+            names: List of canonical artist names to look up.
+
+        Returns:
+            Dict mapping canonical_name to ``(discogs_artist_id, [styles])``.
+            Only names with a match are included.
+        """
+        if not names:
+            return {}
+
+        conn = self._client._get_cache_conn()
+        if conn is None:
+            return {}
+
+        lower_to_canonical: dict[str, str] = {n.lower(): n for n in names}
+        lower_names = list(lower_to_canonical.keys())
+
+        # 1. Try artist_alias table
+        alias_rows = conn.execute(
+            "SELECT lower(alias_name), artist_id FROM artist_alias WHERE lower(alias_name) = ANY(%s)",
+            (lower_names,),
+        ).fetchall()
+
+        matches: dict[str, int] = {}
+        for lower_name, artist_id in alias_rows:
+            canonical = lower_to_canonical.get(lower_name)
+            if canonical is not None and artist_id is not None:
+                matches[canonical] = artist_id
+
+        # 2. Try artist_name_variation for remaining unmatched names
+        remaining = [n for n in lower_names if lower_to_canonical.get(n) not in matches]
+        if remaining:
+            variation_rows = conn.execute(
+                "SELECT lower(name), artist_id "
+                "FROM artist_name_variation WHERE lower(name) = ANY(%s)",
+                (remaining,),
+            ).fetchall()
+
+            for lower_name, artist_id in variation_rows:
+                canonical = lower_to_canonical.get(lower_name)
+                if canonical is not None and artist_id is not None:
+                    matches[canonical] = artist_id
+
+        if not matches:
+            return {}
+
+        # 3. Fetch styles by artist_id for matched artists
+        matched_ids = list(set(matches.values()))
+        style_rows = conn.execute(
+            "SELECT DISTINCT ra.artist_id, rs.style "
+            "FROM release_style rs "
+            "JOIN release_artist ra ON rs.release_id = ra.release_id "
+            "WHERE ra.extra = 0 AND ra.artist_id = ANY(%s)",
+            (matched_ids,),
+        ).fetchall()
+
+        id_styles: dict[int, list[str]] = {}
+        for artist_id, style in style_rows:
+            id_styles.setdefault(artist_id, []).append(style)
+
+        # 4. Build result
+        return {
+            canonical: (discogs_id, id_styles.get(discogs_id, []))
             for canonical, discogs_id in matches.items()
         }

--- a/tests/unit/test_entity_store_reconciliation.py
+++ b/tests/unit/test_entity_store_reconciliation.py
@@ -84,6 +84,56 @@ class TestGetUnreconciledArtists:
 
 
 # ---------------------------------------------------------------------------
+# get_no_match_artists
+# ---------------------------------------------------------------------------
+
+
+class TestGetNoMatchArtists:
+    def test_returns_no_match(self, store: EntityStore):
+        aid_a = store.upsert_artist("Autechre")
+        aid_b = store.upsert_artist("Stereolab")
+        store.update_reconciliation_status(aid_a, "no_match")
+        store.update_reconciliation_status(aid_b, "no_match")
+        no_match = store.get_no_match_artists()
+        assert len(no_match) == 2
+        names = {name for _, name in no_match}
+        assert names == {"Autechre", "Stereolab"}
+
+    def test_skips_reconciled(self, store: EntityStore):
+        aid = store.upsert_artist("Autechre")
+        store.update_reconciliation_status(aid, "reconciled")
+        aid_b = store.upsert_artist("Stereolab")
+        store.update_reconciliation_status(aid_b, "no_match")
+        no_match = store.get_no_match_artists()
+        assert len(no_match) == 1
+        assert no_match[0][1] == "Stereolab"
+
+    def test_skips_unreconciled(self, store: EntityStore):
+        store.upsert_artist("Autechre")  # default 'unreconciled'
+        aid_b = store.upsert_artist("Cat Power")
+        store.update_reconciliation_status(aid_b, "no_match")
+        no_match = store.get_no_match_artists()
+        assert len(no_match) == 1
+        assert no_match[0][1] == "Cat Power"
+
+    def test_respects_limit(self, store: EntityStore):
+        for name in ["Autechre", "Stereolab", "Cat Power", "Buck Meek"]:
+            aid = store.upsert_artist(name)
+            store.update_reconciliation_status(aid, "no_match")
+        no_match = store.get_no_match_artists(limit=2)
+        assert len(no_match) == 2
+
+    def test_empty_table(self, store: EntityStore):
+        assert store.get_no_match_artists() == []
+
+    def test_returns_id_and_name_tuples(self, store: EntityStore):
+        expected_id = store.upsert_artist("Father John Misty")
+        store.update_reconciliation_status(expected_id, "no_match")
+        no_match = store.get_no_match_artists()
+        assert no_match[0] == (expected_id, "Father John Misty")
+
+
+# ---------------------------------------------------------------------------
 # update_reconciliation_status
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_reconciliation.py
+++ b/tests/unit/test_reconciliation.py
@@ -366,3 +366,326 @@ class TestReconcileBatch:
         assert report.attempted == 1
         assert report.no_match == 1
         assert report.succeeded == 0
+
+
+# ---------------------------------------------------------------------------
+# _reconcile_discogs_aliases
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_alias_cache_conn(
+    alias_matches: list[tuple[str, int]],
+    variation_matches: list[tuple[str, int]],
+    style_rows: list[tuple[int, str]],
+) -> MagicMock:
+    """Build a mock psycopg connection for alias reconciliation queries.
+
+    Args:
+        alias_matches: List of (alias_name, artist_id) rows from artist_alias.
+        variation_matches: List of (name, artist_id) rows from artist_name_variation.
+        style_rows: List of (artist_id, style) rows from release_style JOIN release_artist.
+    """
+    mock_conn = MagicMock()
+
+    def execute_side_effect(sql, params=None):
+        result = MagicMock()
+        sql_lower = sql.strip().lower()
+        if "artist_alias" in sql_lower:
+            result.fetchall.return_value = alias_matches
+        elif "artist_name_variation" in sql_lower:
+            result.fetchall.return_value = variation_matches
+        elif "release_style" in sql_lower:
+            result.fetchall.return_value = style_rows
+        else:
+            result.fetchall.return_value = []
+        return result
+
+    mock_conn.execute.side_effect = execute_side_effect
+    return mock_conn
+
+
+class TestReconcileDiscogsAliases:
+    def test_matches_via_alias(self, store: EntityStore):
+        mock_conn = _make_mock_alias_cache_conn(
+            alias_matches=[("j dilla", 259)],
+            variation_matches=[],
+            style_rows=[(259, "Hip Hop"), (259, "Instrumental")],
+        )
+        client = _make_discogs_client_with_mock(mock_conn)
+        reconciler = ArtistReconciler(store, client)
+
+        result = reconciler._reconcile_discogs_aliases(["J Dilla"])
+        assert "J Dilla" in result
+        assert result["J Dilla"][0] == 259
+        assert set(result["J Dilla"][1]) == {"Hip Hop", "Instrumental"}
+
+    def test_matches_via_name_variation(self, store: EntityStore):
+        mock_conn = _make_mock_alias_cache_conn(
+            alias_matches=[],
+            variation_matches=[("aphex twin", 45)],
+            style_rows=[(45, "IDM"), (45, "Ambient")],
+        )
+        client = _make_discogs_client_with_mock(mock_conn)
+        reconciler = ArtistReconciler(store, client)
+
+        result = reconciler._reconcile_discogs_aliases(["Aphex Twin"])
+        assert "Aphex Twin" in result
+        assert result["Aphex Twin"][0] == 45
+
+    def test_alias_takes_precedence_over_variation(self, store: EntityStore):
+        """If both tables match, alias result wins."""
+        mock_conn = _make_mock_alias_cache_conn(
+            alias_matches=[("autechre", 42)],
+            variation_matches=[("autechre", 999)],
+            style_rows=[],
+        )
+        client = _make_discogs_client_with_mock(mock_conn)
+        reconciler = ArtistReconciler(store, client)
+
+        result = reconciler._reconcile_discogs_aliases(["Autechre"])
+        assert result["Autechre"][0] == 42
+
+    def test_no_matches_returns_empty(self, store: EntityStore):
+        mock_conn = _make_mock_alias_cache_conn(
+            alias_matches=[], variation_matches=[], style_rows=[]
+        )
+        client = _make_discogs_client_with_mock(mock_conn)
+        reconciler = ArtistReconciler(store, client)
+
+        result = reconciler._reconcile_discogs_aliases(["Unknown Band"])
+        assert result == {}
+
+    def test_no_cache_returns_empty(self, store: EntityStore):
+        client = DiscogsClient(cache_dsn=None, api_base_url=None)
+        reconciler = ArtistReconciler(store, client)
+
+        result = reconciler._reconcile_discogs_aliases(["Autechre"])
+        assert result == {}
+
+    def test_empty_names_returns_empty(self, store: EntityStore):
+        mock_conn = _make_mock_alias_cache_conn(
+            alias_matches=[], variation_matches=[], style_rows=[]
+        )
+        client = _make_discogs_client_with_mock(mock_conn)
+        reconciler = ArtistReconciler(store, client)
+
+        result = reconciler._reconcile_discogs_aliases([])
+        assert result == {}
+
+    def test_case_insensitive_matching(self, store: EntityStore):
+        mock_conn = _make_mock_alias_cache_conn(
+            alias_matches=[("cat power", 88)],
+            variation_matches=[],
+            style_rows=[(88, "Indie Rock")],
+        )
+        client = _make_discogs_client_with_mock(mock_conn)
+        reconciler = ArtistReconciler(store, client)
+
+        result = reconciler._reconcile_discogs_aliases(["Cat Power"])
+        assert "Cat Power" in result
+        assert result["Cat Power"][0] == 88
+
+    def test_matched_with_no_styles(self, store: EntityStore):
+        mock_conn = _make_mock_alias_cache_conn(
+            alias_matches=[("sessa", 777)],
+            variation_matches=[],
+            style_rows=[],
+        )
+        client = _make_discogs_client_with_mock(mock_conn)
+        reconciler = ArtistReconciler(store, client)
+
+        result = reconciler._reconcile_discogs_aliases(["Sessa"])
+        assert result["Sessa"] == (777, [])
+
+    def test_multiple_names_mixed_sources(self, store: EntityStore):
+        """Some names match via alias, others via name variation."""
+        mock_conn = _make_mock_alias_cache_conn(
+            alias_matches=[("stereolab", 99)],
+            variation_matches=[("jessica pratt", 333)],
+            style_rows=[(99, "Krautrock"), (333, "Folk")],
+        )
+        client = _make_discogs_client_with_mock(mock_conn)
+        reconciler = ArtistReconciler(store, client)
+
+        result = reconciler._reconcile_discogs_aliases(["Stereolab", "Jessica Pratt", "Unknown"])
+        assert "Stereolab" in result
+        assert "Jessica Pratt" in result
+        assert "Unknown" not in result
+
+
+# ---------------------------------------------------------------------------
+# reconcile_aliases
+# ---------------------------------------------------------------------------
+
+
+class TestReconcileAliases:
+    def _set_up_no_match_artists(self, store: EntityStore, names: list[str]) -> dict[str, int]:
+        """Insert artists and set them to no_match status. Returns name->id mapping."""
+        mapping: dict[str, int] = {}
+        for name in names:
+            aid = store.upsert_artist(name)
+            store.update_reconciliation_status(aid, "no_match")
+            mapping[name] = aid
+        return mapping
+
+    def test_returns_reconciliation_report(self, store: EntityStore):
+        self._set_up_no_match_artists(store, ["Autechre", "Cat Power"])
+        mock_conn = _make_mock_alias_cache_conn(
+            alias_matches=[("autechre", 42)],
+            variation_matches=[],
+            style_rows=[(42, "IDM")],
+        )
+        client = _make_discogs_client_with_mock(mock_conn)
+        reconciler = ArtistReconciler(store, client)
+
+        report = reconciler.reconcile_aliases()
+        assert isinstance(report, ReconciliationReport)
+        assert report.total == 2
+        assert report.attempted == 2
+        assert report.succeeded == 1
+        assert report.no_match == 1
+        assert report.errored == 0
+        assert report.skipped == 0
+
+    def test_updates_discogs_artist_id(self, store: EntityStore):
+        self._set_up_no_match_artists(store, ["Autechre"])
+        mock_conn = _make_mock_alias_cache_conn(
+            alias_matches=[("autechre", 42)],
+            variation_matches=[],
+            style_rows=[],
+        )
+        client = _make_discogs_client_with_mock(mock_conn)
+        reconciler = ArtistReconciler(store, client)
+
+        reconciler.reconcile_aliases()
+        row = store.get_artist_by_name("Autechre")
+        assert row is not None
+        assert row["discogs_artist_id"] == 42
+
+    def test_persists_styles(self, store: EntityStore):
+        mapping = self._set_up_no_match_artists(store, ["Autechre"])
+        mock_conn = _make_mock_alias_cache_conn(
+            alias_matches=[("autechre", 42)],
+            variation_matches=[],
+            style_rows=[(42, "IDM"), (42, "Abstract")],
+        )
+        client = _make_discogs_client_with_mock(mock_conn)
+        reconciler = ArtistReconciler(store, client)
+
+        reconciler.reconcile_aliases()
+        styles = store.get_artist_styles(mapping["Autechre"])
+        assert set(styles) == {"IDM", "Abstract"}
+
+    def test_logs_reconciliation_event_with_alias_method(self, store: EntityStore):
+        mapping = self._set_up_no_match_artists(store, ["Autechre"])
+        mock_conn = _make_mock_alias_cache_conn(
+            alias_matches=[("autechre", 42)],
+            variation_matches=[],
+            style_rows=[],
+        )
+        client = _make_discogs_client_with_mock(mock_conn)
+        reconciler = ArtistReconciler(store, client)
+
+        reconciler.reconcile_aliases()
+        history = store.get_reconciliation_history(mapping["Autechre"])
+        assert len(history) == 1
+        assert history[0].source == "discogs"
+        assert history[0].external_id == "42"
+        assert history[0].method == "alias_lookup"
+
+    def test_updates_status_reconciled(self, store: EntityStore):
+        mapping = self._set_up_no_match_artists(store, ["Autechre"])
+        mock_conn = _make_mock_alias_cache_conn(
+            alias_matches=[("autechre", 42)],
+            variation_matches=[],
+            style_rows=[],
+        )
+        client = _make_discogs_client_with_mock(mock_conn)
+        reconciler = ArtistReconciler(store, client)
+
+        reconciler.reconcile_aliases()
+        row = store._conn.execute(
+            "SELECT reconciliation_status FROM artist WHERE id = ?", (mapping["Autechre"],)
+        ).fetchone()
+        assert row[0] == "reconciled"
+
+    def test_unmatched_stay_no_match(self, store: EntityStore):
+        mapping = self._set_up_no_match_artists(store, ["Unknown Band"])
+        mock_conn = _make_mock_alias_cache_conn(
+            alias_matches=[], variation_matches=[], style_rows=[]
+        )
+        client = _make_discogs_client_with_mock(mock_conn)
+        reconciler = ArtistReconciler(store, client)
+
+        reconciler.reconcile_aliases()
+        row = store._conn.execute(
+            "SELECT reconciliation_status FROM artist WHERE id = ?", (mapping["Unknown Band"],)
+        ).fetchone()
+        assert row[0] == "no_match"
+
+    def test_skips_unreconciled_and_reconciled(self, store: EntityStore):
+        store.upsert_artist("Stereolab")  # default 'unreconciled'
+        aid_rec = store.upsert_artist("Father John Misty")
+        store.update_reconciliation_status(aid_rec, "reconciled")
+        self._set_up_no_match_artists(store, ["Cat Power"])
+
+        mock_conn = _make_mock_alias_cache_conn(
+            alias_matches=[("cat power", 88)],
+            variation_matches=[],
+            style_rows=[],
+        )
+        client = _make_discogs_client_with_mock(mock_conn)
+        reconciler = ArtistReconciler(store, client)
+
+        report = reconciler.reconcile_aliases()
+        assert report.total == 3
+        assert report.skipped == 2
+        assert report.attempted == 1
+        assert report.succeeded == 1
+
+    def test_empty_no_match_set(self, store: EntityStore):
+        store.upsert_artist("Autechre")  # default 'unreconciled'
+        mock_conn = _make_mock_alias_cache_conn(
+            alias_matches=[], variation_matches=[], style_rows=[]
+        )
+        client = _make_discogs_client_with_mock(mock_conn)
+        reconciler = ArtistReconciler(store, client)
+
+        report = reconciler.reconcile_aliases()
+        assert report.total == 1
+        assert report.attempted == 0
+        assert report.skipped == 1
+
+    def test_batch_size_parameter(self, store: EntityStore):
+        self._set_up_no_match_artists(store, ["Autechre", "Stereolab", "Cat Power"])
+
+        call_count = 0
+        original_method = ArtistReconciler._reconcile_discogs_aliases
+
+        def tracking_alias(self_inner, names):
+            nonlocal call_count
+            call_count += 1
+            return original_method(self_inner, names)
+
+        mock_conn = _make_mock_alias_cache_conn(
+            alias_matches=[("autechre", 42), ("stereolab", 99), ("cat power", 88)],
+            variation_matches=[],
+            style_rows=[],
+        )
+        client = _make_discogs_client_with_mock(mock_conn)
+        reconciler = ArtistReconciler(store, client)
+
+        with patch.object(ArtistReconciler, "_reconcile_discogs_aliases", tracking_alias):
+            reconciler.reconcile_aliases(batch_size=2)
+
+        assert call_count == 2  # ceil(3/2) = 2 batches
+
+    def test_no_cache_counts_as_no_match(self, store: EntityStore):
+        self._set_up_no_match_artists(store, ["Autechre"])
+        client = DiscogsClient(cache_dsn=None, api_base_url=None)
+        reconciler = ArtistReconciler(store, client)
+
+        report = reconciler.reconcile_aliases()
+        assert report.attempted == 1
+        assert report.no_match == 1
+        assert report.succeeded == 0


### PR DESCRIPTION
## Summary

- Extends `ArtistReconciler` with `reconcile_aliases()` method that retries artists with `no_match` status against the discogs-cache `artist_alias` and `artist_name_variation` tables using the existing batch `ANY()` pattern
- Adds `EntityStore.get_no_match_artists()` query method for selecting artists with `no_match` reconciliation status
- Wired into `run_pipeline.py` to run automatically after the primary `reconcile_batch()` pass

Closes #67

## Test plan

- [x] 6 unit tests for `EntityStore.get_no_match_artists()` (filters by status, respects limit, returns correct tuples)
- [x] 9 unit tests for `_reconcile_discogs_aliases()` (alias matches, name variation matches, alias precedence, case insensitivity, no cache, empty input, mixed sources)
- [x] 11 unit tests for `reconcile_aliases()` (report structure, discogs_artist_id update, style persistence, reconciliation log with `alias_lookup` method, status transitions, skip logic, batch sizing, no cache fallback)
- [x] All 377 unit tests pass
- [x] ruff format and mypy clean on changed files