### PR TITLE
Add Wikidata SPARQL client

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ SQLite ──→ api (FastAPI + aiosqlite) ──→ JSON responses
 | `semantic_index/node_attributes.py` | Extract and compute per-artist temporal, DJ, and request statistics. |
 | `semantic_index/cross_reference.py` | Extract cross-reference edges from catalog cross-reference tables. |
 | `semantic_index/discogs_client.py` | Two-tier Discogs client: discogs-cache PostgreSQL with library-metadata-lookup API fallback. |
+| `semantic_index/wikidata_client.py` | Wikidata SPARQL client: batched lookups by Discogs ID (P1953), influence relationships (P737), label hierarchy (P749/P355), and name search via wbsearchentities API. |
 | `semantic_index/entity_store.py` | Persistent entity store for reconciled artist identities: schema creation/migration, CRUD, artist upsert, reconciliation log, artist styles. Creates the artist table from scratch on a fresh database or migrates an existing one. |
 | `semantic_index/reconciliation.py` | Bulk Discogs matching for unreconciled artists via discogs-cache release_artist table. |
 | `semantic_index/discogs_enrichment.py` | Aggregate Discogs metadata (styles, personnel, labels, compilations) per artist. |

--- a/semantic_index/models.py
+++ b/semantic_index/models.py
@@ -244,3 +244,39 @@ class ReconciliationReport(BaseModel):
     no_match: int  # Attempts where the lookup returned no result
     errored: int  # Attempts that failed due to an exception
     skipped: int  # Artists already in 'partial' or 'reconciled' status
+
+
+# --- Wikidata models ---
+
+
+class WikidataEntity(BaseModel):
+    """A Wikidata entity with optional Discogs artist ID.
+
+    Returned by SPARQL lookups (P1953 Discogs ID) and name search
+    (wbsearchentities API).
+    """
+
+    qid: str  # e.g. "Q2774"
+    name: str  # rdfs:label
+    description: str | None = None
+    discogs_artist_id: int | None = None  # P1953
+
+
+class WikidataInfluence(BaseModel):
+    """An influence relationship (P737) between two Wikidata entities.
+
+    Represents "source is influenced by target".
+    """
+
+    source_qid: str
+    target_qid: str
+    target_name: str
+
+
+class WikidataLabelHierarchy(BaseModel):
+    """A parent-child label relationship (P749 parent org / P355 subsidiary)."""
+
+    parent_qid: str
+    parent_name: str
+    child_qid: str
+    child_name: str

--- a/semantic_index/wikidata_client.py
+++ b/semantic_index/wikidata_client.py
@@ -1,0 +1,345 @@
+"""Wikidata SPARQL client for entity lookups and knowledge graph queries.
+
+Batched SPARQL queries for property lookups (Discogs artist ID via P1953,
+influences via P737, label hierarchy via P749/P355) and entity name search
+via the MediaWiki wbsearchentities API.
+
+The client respects Wikidata's rate limit (~1 request/second) and splits
+large lookups into batches to avoid SPARQL query timeouts.
+"""
+
+import logging
+import re
+import time
+
+import httpx
+
+from semantic_index.models import (
+    WikidataEntity,
+    WikidataInfluence,
+    WikidataLabelHierarchy,
+)
+
+logger = logging.getLogger(__name__)
+
+_QID_PATTERN = re.compile(r"^Q\d+$")
+_RATE_INTERVAL = 1.0  # seconds between requests
+
+
+def _extract_qid(uri: str) -> str:
+    """Extract QID from a Wikidata entity URI.
+
+    Args:
+        uri: Full entity URI, e.g. ``http://www.wikidata.org/entity/Q2774``.
+
+    Returns:
+        The QID portion, e.g. ``Q2774``.
+    """
+    return uri.rsplit("/", 1)[-1]
+
+
+def _binding_value(binding: dict, key: str) -> str | None:
+    """Extract a string value from a SPARQL result binding.
+
+    Args:
+        binding: A single result binding dict from a SPARQL JSON response.
+        key: The variable name to extract.
+
+    Returns:
+        The value string, or None if the key is absent.
+    """
+    if key in binding:
+        result: str = binding[key]["value"]
+        return result
+    return None
+
+
+class WikidataClient:
+    """Client for Wikidata SPARQL queries and entity search.
+
+    Uses the Wikidata Query Service SPARQL endpoint for property-based
+    batch lookups (Discogs ID, influences, label hierarchy) and the
+    MediaWiki wbsearchentities API for name search.
+
+    Args:
+        sparql_endpoint: SPARQL endpoint URL. Defaults to Wikidata Query Service.
+        api_endpoint: MediaWiki API URL. Defaults to Wikidata API.
+        user_agent: User-Agent header (required by Wikidata).
+        batch_size: Max entities per SPARQL VALUES clause.
+    """
+
+    _DEFAULT_SPARQL_ENDPOINT = "https://query.wikidata.org/sparql"
+    _DEFAULT_API_ENDPOINT = "https://www.wikidata.org/w/api.php"
+    _DEFAULT_USER_AGENT = "WXYCSemanticIndex/0.1 (https://wxyc.org; engineering@wxyc.org)"
+
+    def __init__(
+        self,
+        sparql_endpoint: str | None = None,
+        api_endpoint: str | None = None,
+        user_agent: str | None = None,
+        batch_size: int = 50,
+    ) -> None:
+        self._sparql_endpoint = sparql_endpoint or self._DEFAULT_SPARQL_ENDPOINT
+        self._api_endpoint = api_endpoint or self._DEFAULT_API_ENDPOINT
+        self._user_agent = user_agent or self._DEFAULT_USER_AGENT
+        self._batch_size = batch_size
+        self._last_request: float = 0
+
+    def _rate_limit(self) -> None:
+        """Sleep to respect Wikidata's rate limit (~1 req/s)."""
+        elapsed = time.time() - self._last_request
+        if elapsed < _RATE_INTERVAL:
+            time.sleep(_RATE_INTERVAL - elapsed)
+        self._last_request = time.time()
+
+    def _sparql_query(self, query: str) -> list[dict]:
+        """Execute a SPARQL query and return result bindings.
+
+        Args:
+            query: SPARQL query string.
+
+        Returns:
+            List of binding dicts from the SPARQL JSON response.
+
+        Raises:
+            httpx.HTTPStatusError: On non-2xx response.
+            Exception: On network or parse errors.
+        """
+        self._rate_limit()
+        client = httpx.Client(
+            timeout=60,
+            headers={
+                "User-Agent": self._user_agent,
+                "Accept": "application/sparql-results+json",
+            },
+        )
+        try:
+            resp = client.get(self._sparql_endpoint, params={"query": query})
+            resp.raise_for_status()
+            bindings: list[dict] = resp.json()["results"]["bindings"]
+            return bindings
+        finally:
+            client.close()
+
+    def _validate_qids(self, qids: list[str]) -> list[str]:
+        """Validate and filter QIDs, logging warnings for invalid ones.
+
+        Args:
+            qids: List of candidate QID strings.
+
+        Returns:
+            List of valid QIDs matching the ``Q\\d+`` pattern.
+        """
+        valid = []
+        for qid in qids:
+            if _QID_PATTERN.match(qid):
+                valid.append(qid)
+            else:
+                logger.warning("Invalid QID skipped: %r", qid)
+        return valid
+
+    def lookup_by_discogs_ids(self, discogs_ids: list[int]) -> dict[int, WikidataEntity]:
+        """Look up Wikidata entities by Discogs artist ID (P1953).
+
+        Batches the lookup into chunks of ``batch_size`` to avoid SPARQL
+        query timeouts on large input sets.
+
+        Args:
+            discogs_ids: Discogs artist IDs to look up.
+
+        Returns:
+            Dict mapping discogs_id -> WikidataEntity for each found match.
+        """
+        if not discogs_ids:
+            return {}
+
+        result: dict[int, WikidataEntity] = {}
+        for batch_start in range(0, len(discogs_ids), self._batch_size):
+            batch = discogs_ids[batch_start : batch_start + self._batch_size]
+            values = " ".join(f'"{did}"' for did in batch)
+            query = (
+                "SELECT ?item ?itemLabel ?discogsId WHERE {\n"
+                f"  VALUES ?discogsId {{ {values} }}\n"
+                "  ?item wdt:P1953 ?discogsId .\n"
+                '  SERVICE wikibase:label { bd:serviceParam wikibase:language "en" . }\n'
+                "}"
+            )
+            try:
+                bindings = self._sparql_query(query)
+                for b in bindings:
+                    qid = _extract_qid(_binding_value(b, "item") or "")
+                    name = _binding_value(b, "itemLabel") or qid
+                    discogs_id_str = _binding_value(b, "discogsId")
+                    if discogs_id_str is not None:
+                        try:
+                            did = int(discogs_id_str)
+                        except (ValueError, TypeError):
+                            continue
+                        result[did] = WikidataEntity(
+                            qid=qid,
+                            name=name,
+                            discogs_artist_id=did,
+                        )
+            except Exception:
+                logger.warning(
+                    "SPARQL lookup_by_discogs_ids failed for batch starting at %d",
+                    batch_start,
+                    exc_info=True,
+                )
+
+        return result
+
+    def get_influences(self, qids: list[str]) -> list[WikidataInfluence]:
+        """Get influence relationships (P737) for given Wikidata entities.
+
+        Returns edges where "source is influenced by target".
+
+        Args:
+            qids: Wikidata QIDs to query for influences (e.g. ``["Q2774"]``).
+
+        Returns:
+            List of WikidataInfluence relationships.
+        """
+        valid_qids = self._validate_qids(qids)
+        if not valid_qids:
+            return []
+
+        result: list[WikidataInfluence] = []
+        for batch_start in range(0, len(valid_qids), self._batch_size):
+            batch = valid_qids[batch_start : batch_start + self._batch_size]
+            values = " ".join(f"wd:{qid}" for qid in batch)
+            query = (
+                "SELECT ?source ?target ?targetLabel WHERE {\n"
+                f"  VALUES ?source {{ {values} }}\n"
+                "  ?source wdt:P737 ?target .\n"
+                '  SERVICE wikibase:label { bd:serviceParam wikibase:language "en" . }\n'
+                "}"
+            )
+            try:
+                bindings = self._sparql_query(query)
+                for b in bindings:
+                    source_qid = _extract_qid(_binding_value(b, "source") or "")
+                    target_qid = _extract_qid(_binding_value(b, "target") or "")
+                    target_name = _binding_value(b, "targetLabel") or target_qid
+                    result.append(
+                        WikidataInfluence(
+                            source_qid=source_qid,
+                            target_qid=target_qid,
+                            target_name=target_name,
+                        )
+                    )
+            except Exception:
+                logger.warning(
+                    "SPARQL get_influences failed for batch starting at %d",
+                    batch_start,
+                    exc_info=True,
+                )
+
+        return result
+
+    def get_label_hierarchy(self, qids: list[str]) -> list[WikidataLabelHierarchy]:
+        """Get label parent-child relationships (P749 parent org, P355 subsidiary).
+
+        Queries both directions: finds parents of the given QIDs (via P749)
+        and children of the given QIDs (via P355).
+
+        Args:
+            qids: Wikidata QIDs for labels (e.g. ``["Q1312934"]`` for Warp Records).
+
+        Returns:
+            List of WikidataLabelHierarchy relationships.
+        """
+        valid_qids = self._validate_qids(qids)
+        if not valid_qids:
+            return []
+
+        result: list[WikidataLabelHierarchy] = []
+        for batch_start in range(0, len(valid_qids), self._batch_size):
+            batch = valid_qids[batch_start : batch_start + self._batch_size]
+            values = " ".join(f"wd:{qid}" for qid in batch)
+            query = (
+                "SELECT ?child ?childLabel ?parent ?parentLabel WHERE {\n"
+                f"  VALUES ?entity {{ {values} }}\n"
+                "  {\n"
+                "    BIND(?entity AS ?child)\n"
+                "    ?entity wdt:P749 ?parent .\n"
+                "  }\n"
+                "  UNION\n"
+                "  {\n"
+                "    BIND(?entity AS ?parent)\n"
+                "    ?entity wdt:P355 ?child .\n"
+                "  }\n"
+                '  SERVICE wikibase:label { bd:serviceParam wikibase:language "en" . }\n'
+                "}"
+            )
+            try:
+                bindings = self._sparql_query(query)
+                for b in bindings:
+                    child_qid = _extract_qid(_binding_value(b, "child") or "")
+                    child_name = _binding_value(b, "childLabel") or child_qid
+                    parent_qid = _extract_qid(_binding_value(b, "parent") or "")
+                    parent_name = _binding_value(b, "parentLabel") or parent_qid
+                    result.append(
+                        WikidataLabelHierarchy(
+                            parent_qid=parent_qid,
+                            parent_name=parent_name,
+                            child_qid=child_qid,
+                            child_name=child_name,
+                        )
+                    )
+            except Exception:
+                logger.warning(
+                    "SPARQL get_label_hierarchy failed for batch starting at %d",
+                    batch_start,
+                    exc_info=True,
+                )
+
+        return result
+
+    def search_by_name(self, name: str, limit: int = 10) -> list[WikidataEntity]:
+        """Search for Wikidata entities by name.
+
+        Uses the MediaWiki wbsearchentities API for efficient text search.
+
+        Args:
+            name: Search string.
+            limit: Maximum results (capped at 50 by the API).
+
+        Returns:
+            List of matching WikidataEntity instances.
+        """
+        if not name.strip():
+            return []
+
+        self._rate_limit()
+        client = httpx.Client(
+            timeout=30,
+            headers={"User-Agent": self._user_agent},
+        )
+        try:
+            resp = client.get(
+                self._api_endpoint,
+                params={
+                    "action": "wbsearchentities",
+                    "search": name,
+                    "language": "en",
+                    "type": "item",
+                    "limit": min(limit, 50),
+                    "format": "json",
+                },
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            return [
+                WikidataEntity(
+                    qid=item["id"],
+                    name=item.get("label", item["id"]),
+                    description=item.get("description"),
+                )
+                for item in data.get("search", [])
+            ]
+        except Exception:
+            logger.warning("Wikidata name search failed for %r", name, exc_info=True)
+            return []
+        finally:
+            client.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,9 @@ from semantic_index.models import (
     LibraryRelease,
     PersonnelCredit,
     ResolvedEntry,
+    WikidataEntity,
+    WikidataInfluence,
+    WikidataLabelHierarchy,
 )
 
 
@@ -171,3 +174,36 @@ def make_entity(
     Uses a fixed id=1 since the real id is assigned by SQLite AUTOINCREMENT.
     """
     return Entity(id=1, name=name, entity_type=entity_type, wikidata_qid=wikidata_qid)
+
+
+def make_wikidata_entity(
+    qid: str = "Q2774",
+    name: str = "Autechre",
+    description: str | None = "British electronic music duo",
+    discogs_artist_id: int | None = 2774,
+) -> WikidataEntity:
+    return WikidataEntity(
+        qid=qid, name=name, description=description, discogs_artist_id=discogs_artist_id
+    )
+
+
+def make_wikidata_influence(
+    source_qid: str = "Q2774",
+    target_qid: str = "Q484641",
+    target_name: str = "Kraftwerk",
+) -> WikidataInfluence:
+    return WikidataInfluence(source_qid=source_qid, target_qid=target_qid, target_name=target_name)
+
+
+def make_wikidata_label_hierarchy(
+    parent_qid: str = "Q21077",
+    parent_name: str = "Universal Music Group",
+    child_qid: str = "Q1312934",
+    child_name: str = "Warp Records",
+) -> WikidataLabelHierarchy:
+    return WikidataLabelHierarchy(
+        parent_qid=parent_qid,
+        parent_name=parent_name,
+        child_qid=child_qid,
+        child_name=child_name,
+    )

--- a/tests/unit/test_wikidata_client.py
+++ b/tests/unit/test_wikidata_client.py
@@ -1,0 +1,435 @@
+"""Tests for the Wikidata SPARQL client."""
+
+from unittest.mock import MagicMock, patch
+
+from semantic_index.wikidata_client import WikidataClient
+
+
+def _sparql_response(bindings: list[dict]) -> dict:
+    """Build a mock SPARQL JSON response."""
+    return {"results": {"bindings": bindings}}
+
+
+def _uri(qid: str) -> dict:
+    """Build a SPARQL URI binding value."""
+    return {"type": "uri", "value": f"http://www.wikidata.org/entity/{qid}"}
+
+
+def _literal(value: str) -> dict:
+    """Build a SPARQL literal binding value."""
+    return {"type": "literal", "value": value}
+
+
+class TestLookupByDiscogsIds:
+    """Tests for Discogs artist ID (P1953) lookups."""
+
+    def test_single_id_returns_entity(self):
+        mock_response = MagicMock()
+        mock_response.json.return_value = _sparql_response(
+            [
+                {
+                    "item": _uri("Q2774"),
+                    "itemLabel": _literal("Autechre"),
+                    "discogsId": _literal("2774"),
+                },
+            ]
+        )
+        mock_client = MagicMock()
+        mock_client.get.return_value = mock_response
+
+        with patch("httpx.Client", return_value=mock_client):
+            client = WikidataClient()
+            result = client.lookup_by_discogs_ids([2774])
+
+        assert 2774 in result
+        assert result[2774].qid == "Q2774"
+        assert result[2774].name == "Autechre"
+        assert result[2774].discogs_artist_id == 2774
+
+    def test_multiple_ids_returns_all(self):
+        mock_response = MagicMock()
+        mock_response.json.return_value = _sparql_response(
+            [
+                {
+                    "item": _uri("Q2774"),
+                    "itemLabel": _literal("Autechre"),
+                    "discogsId": _literal("2774"),
+                },
+                {
+                    "item": _uri("Q650826"),
+                    "itemLabel": _literal("Stereolab"),
+                    "discogsId": _literal("10272"),
+                },
+            ]
+        )
+        mock_client = MagicMock()
+        mock_client.get.return_value = mock_response
+
+        with patch("httpx.Client", return_value=mock_client):
+            client = WikidataClient()
+            result = client.lookup_by_discogs_ids([2774, 10272])
+
+        assert len(result) == 2
+        assert result[2774].name == "Autechre"
+        assert result[10272].name == "Stereolab"
+
+    def test_not_found_returns_empty(self):
+        mock_response = MagicMock()
+        mock_response.json.return_value = _sparql_response([])
+        mock_client = MagicMock()
+        mock_client.get.return_value = mock_response
+
+        with patch("httpx.Client", return_value=mock_client):
+            client = WikidataClient()
+            result = client.lookup_by_discogs_ids([99999])
+
+        assert result == {}
+
+    def test_empty_input_returns_empty(self):
+        client = WikidataClient()
+        result = client.lookup_by_discogs_ids([])
+        assert result == {}
+
+
+class TestGetInfluences:
+    """Tests for influence relationship (P737) queries."""
+
+    def test_returns_influences(self):
+        mock_response = MagicMock()
+        mock_response.json.return_value = _sparql_response(
+            [
+                {
+                    "source": _uri("Q2774"),
+                    "target": _uri("Q484641"),
+                    "targetLabel": _literal("Kraftwerk"),
+                },
+                {
+                    "source": _uri("Q2774"),
+                    "target": _uri("Q193815"),
+                    "targetLabel": _literal("Brian Eno"),
+                },
+            ]
+        )
+        mock_client = MagicMock()
+        mock_client.get.return_value = mock_response
+
+        with patch("httpx.Client", return_value=mock_client):
+            client = WikidataClient()
+            result = client.get_influences(["Q2774"])
+
+        assert len(result) == 2
+        assert result[0].source_qid == "Q2774"
+        assert result[0].target_qid == "Q484641"
+        assert result[0].target_name == "Kraftwerk"
+
+    def test_no_influences_returns_empty(self):
+        mock_response = MagicMock()
+        mock_response.json.return_value = _sparql_response([])
+        mock_client = MagicMock()
+        mock_client.get.return_value = mock_response
+
+        with patch("httpx.Client", return_value=mock_client):
+            client = WikidataClient()
+            result = client.get_influences(["Q2774"])
+
+        assert result == []
+
+    def test_empty_input_returns_empty(self):
+        client = WikidataClient()
+        result = client.get_influences([])
+        assert result == []
+
+    def test_invalid_qid_skipped(self):
+        mock_response = MagicMock()
+        mock_response.json.return_value = _sparql_response(
+            [
+                {
+                    "source": _uri("Q2774"),
+                    "target": _uri("Q484641"),
+                    "targetLabel": _literal("Kraftwerk"),
+                },
+            ]
+        )
+        mock_client = MagicMock()
+        mock_client.get.return_value = mock_response
+
+        with patch("httpx.Client", return_value=mock_client):
+            client = WikidataClient()
+            result = client.get_influences(["Q2774", "INVALID", "not-a-qid"])
+
+        # Only Q2774 was queried; invalid QIDs were filtered out
+        assert len(result) == 1
+        assert result[0].source_qid == "Q2774"
+
+
+class TestGetLabelHierarchy:
+    """Tests for label hierarchy (P749/P355) queries."""
+
+    def test_returns_parent_via_p749(self):
+        mock_response = MagicMock()
+        mock_response.json.return_value = _sparql_response(
+            [
+                {
+                    "child": _uri("Q1312934"),
+                    "childLabel": _literal("Warp Records"),
+                    "parent": _uri("Q21077"),
+                    "parentLabel": _literal("Universal Music Group"),
+                },
+            ]
+        )
+        mock_client = MagicMock()
+        mock_client.get.return_value = mock_response
+
+        with patch("httpx.Client", return_value=mock_client):
+            client = WikidataClient()
+            result = client.get_label_hierarchy(["Q1312934"])
+
+        assert len(result) == 1
+        assert result[0].child_qid == "Q1312934"
+        assert result[0].child_name == "Warp Records"
+        assert result[0].parent_qid == "Q21077"
+        assert result[0].parent_name == "Universal Music Group"
+
+    def test_returns_child_via_p355(self):
+        mock_response = MagicMock()
+        mock_response.json.return_value = _sparql_response(
+            [
+                {
+                    "child": _uri("Q843988"),
+                    "childLabel": _literal("Sub Pop"),
+                    "parent": _uri("Q21077"),
+                    "parentLabel": _literal("Universal Music Group"),
+                },
+            ]
+        )
+        mock_client = MagicMock()
+        mock_client.get.return_value = mock_response
+
+        with patch("httpx.Client", return_value=mock_client):
+            client = WikidataClient()
+            result = client.get_label_hierarchy(["Q21077"])
+
+        assert len(result) == 1
+        assert result[0].parent_qid == "Q21077"
+        assert result[0].child_qid == "Q843988"
+        assert result[0].child_name == "Sub Pop"
+
+    def test_no_hierarchy_returns_empty(self):
+        mock_response = MagicMock()
+        mock_response.json.return_value = _sparql_response([])
+        mock_client = MagicMock()
+        mock_client.get.return_value = mock_response
+
+        with patch("httpx.Client", return_value=mock_client):
+            client = WikidataClient()
+            result = client.get_label_hierarchy(["Q12345"])
+
+        assert result == []
+
+    def test_empty_input_returns_empty(self):
+        client = WikidataClient()
+        result = client.get_label_hierarchy([])
+        assert result == []
+
+
+class TestSearchByName:
+    """Tests for entity name search via wbsearchentities API."""
+
+    def test_returns_matching_entities(self):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "search": [
+                {
+                    "id": "Q2774",
+                    "label": "Autechre",
+                    "description": "British electronic music duo",
+                },
+            ],
+        }
+        mock_client = MagicMock()
+        mock_client.get.return_value = mock_response
+
+        with patch("httpx.Client", return_value=mock_client):
+            client = WikidataClient()
+            result = client.search_by_name("Autechre")
+
+        assert len(result) == 1
+        assert result[0].qid == "Q2774"
+        assert result[0].name == "Autechre"
+        assert result[0].description == "British electronic music duo"
+
+    def test_no_results_returns_empty(self):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"search": []}
+        mock_client = MagicMock()
+        mock_client.get.return_value = mock_response
+
+        with patch("httpx.Client", return_value=mock_client):
+            client = WikidataClient()
+            result = client.search_by_name("xyznonexistent")
+
+        assert result == []
+
+    def test_blank_name_returns_empty(self):
+        client = WikidataClient()
+        result = client.search_by_name("   ")
+        assert result == []
+
+    def test_limit_capped_at_50(self):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"search": []}
+        mock_client = MagicMock()
+        mock_client.get.return_value = mock_response
+
+        with patch("httpx.Client", return_value=mock_client):
+            client = WikidataClient()
+            client.search_by_name("Autechre", limit=100)
+
+        assert mock_client.get.call_args.kwargs["params"]["limit"] == 50
+
+    def test_multiple_results_ordered(self):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "search": [
+                {"id": "Q218981", "label": "Cat Power", "description": "American singer"},
+                {"id": "Q999999", "label": "Cat Power Band", "description": "tribute act"},
+            ],
+        }
+        mock_client = MagicMock()
+        mock_client.get.return_value = mock_response
+
+        with patch("httpx.Client", return_value=mock_client):
+            client = WikidataClient()
+            result = client.search_by_name("Cat Power")
+
+        assert len(result) == 2
+        assert result[0].qid == "Q218981"
+        assert result[1].name == "Cat Power Band"
+
+
+class TestBatching:
+    """Tests for batch splitting with large input."""
+
+    def test_large_batch_splits_into_chunks(self):
+        mock_response = MagicMock()
+        mock_response.json.return_value = _sparql_response([])
+        mock_client = MagicMock()
+        mock_client.get.return_value = mock_response
+
+        with patch("httpx.Client", return_value=mock_client):
+            client = WikidataClient(batch_size=3)
+            client.lookup_by_discogs_ids([1, 2, 3, 4, 5])
+
+        # Should have made 2 SPARQL requests (batch of 3 + batch of 2)
+        assert mock_client.get.call_count == 2
+
+    def test_influences_batch_splitting(self):
+        mock_response = MagicMock()
+        mock_response.json.return_value = _sparql_response([])
+        mock_client = MagicMock()
+        mock_client.get.return_value = mock_response
+
+        with patch("httpx.Client", return_value=mock_client):
+            client = WikidataClient(batch_size=2)
+            client.get_influences(["Q1", "Q2", "Q3"])
+
+        assert mock_client.get.call_count == 2
+
+    def test_results_aggregated_across_batches(self):
+        response_batch1 = MagicMock()
+        response_batch1.json.return_value = _sparql_response(
+            [
+                {
+                    "item": _uri("Q2774"),
+                    "itemLabel": _literal("Autechre"),
+                    "discogsId": _literal("2774"),
+                },
+            ]
+        )
+        response_batch2 = MagicMock()
+        response_batch2.json.return_value = _sparql_response(
+            [
+                {
+                    "item": _uri("Q650826"),
+                    "itemLabel": _literal("Stereolab"),
+                    "discogsId": _literal("10272"),
+                },
+            ]
+        )
+        mock_client = MagicMock()
+        mock_client.get.side_effect = [response_batch1, response_batch2]
+
+        with patch("httpx.Client", return_value=mock_client):
+            client = WikidataClient(batch_size=1)
+            result = client.lookup_by_discogs_ids([2774, 10272])
+
+        assert len(result) == 2
+        assert result[2774].name == "Autechre"
+        assert result[10272].name == "Stereolab"
+
+
+class TestGracefulDegradation:
+    """Tests for error handling."""
+
+    def test_sparql_error_returns_empty_dict(self):
+        mock_client = MagicMock()
+        mock_client.get.side_effect = Exception("Connection refused")
+
+        with patch("httpx.Client", return_value=mock_client):
+            client = WikidataClient()
+            result = client.lookup_by_discogs_ids([2774])
+
+        assert result == {}
+
+    def test_sparql_error_returns_empty_list_for_influences(self):
+        mock_client = MagicMock()
+        mock_client.get.side_effect = Exception("Timeout")
+
+        with patch("httpx.Client", return_value=mock_client):
+            client = WikidataClient()
+            result = client.get_influences(["Q2774"])
+
+        assert result == []
+
+    def test_sparql_error_returns_empty_list_for_hierarchy(self):
+        mock_client = MagicMock()
+        mock_client.get.side_effect = Exception("Server error")
+
+        with patch("httpx.Client", return_value=mock_client):
+            client = WikidataClient()
+            result = client.get_label_hierarchy(["Q1312934"])
+
+        assert result == []
+
+    def test_search_error_returns_empty(self):
+        mock_client = MagicMock()
+        mock_client.get.side_effect = Exception("Network error")
+
+        with patch("httpx.Client", return_value=mock_client):
+            client = WikidataClient()
+            result = client.search_by_name("Autechre")
+
+        assert result == []
+
+    def test_partial_batch_failure_preserves_successful_results(self):
+        """If one batch fails, results from successful batches are still returned."""
+        good_response = MagicMock()
+        good_response.json.return_value = _sparql_response(
+            [
+                {
+                    "item": _uri("Q2774"),
+                    "itemLabel": _literal("Autechre"),
+                    "discogsId": _literal("2774"),
+                },
+            ]
+        )
+        mock_client = MagicMock()
+        mock_client.get.side_effect = [good_response, Exception("Timeout")]
+
+        with patch("httpx.Client", return_value=mock_client):
+            client = WikidataClient(batch_size=1)
+            result = client.lookup_by_discogs_ids([2774, 10272])
+
+        # First batch succeeded, second failed
+        assert len(result) == 1
+        assert 2774 in result


### PR DESCRIPTION
## Summary

- New `wikidata_client.py` module with `WikidataClient` class for batched Wikidata queries
- SPARQL lookups for Discogs artist ID (P1953), influence relationships (P737), and label hierarchy (P749/P355)
- Entity name search via the MediaWiki wbsearchentities API
- Wikidata models (`WikidataEntity`, `WikidataInfluence`, `WikidataLabelHierarchy`) added to `models.py`
- 25 unit tests covering happy paths, batching, QID validation, and graceful error degradation

Closes #69

## Test plan

- [x] All 25 new unit tests pass (`pytest tests/unit/test_wikidata_client.py -v`)
- [x] Full test suite passes (377 tests)
- [x] ruff check passes on all changed files
- [x] ruff format passes on all changed files
- [x] mypy passes on `wikidata_client.py` and `models.py`