### PR TITLE
Add Wikidata reconciliation by Discogs ID

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ SQLite ──→ api (FastAPI + aiosqlite) ──→ JSON responses
 | `semantic_index/discogs_client.py` | Two-tier Discogs client: discogs-cache PostgreSQL with library-metadata-lookup API fallback. |
 | `semantic_index/wikidata_client.py` | Wikidata SPARQL client: batched lookups by Discogs ID (P1953), influence relationships (P737), label hierarchy (P749/P355), and name search via wbsearchentities API. |
 | `semantic_index/entity_store.py` | Persistent entity store for reconciled artist identities: schema creation/migration, CRUD, artist upsert, reconciliation log, artist styles. Creates the artist table from scratch on a fresh database or migrates an existing one. |
-| `semantic_index/reconciliation.py` | Bulk Discogs matching for unreconciled artists via discogs-cache release_artist table, with member/group fallback via artist_member table. |
+| `semantic_index/reconciliation.py` | Bulk Discogs matching for unreconciled artists via discogs-cache release_artist table, with member/group fallback via artist_member table. Wikidata reconciliation by Discogs ID (P1953) to populate entity QIDs. |
 | `semantic_index/discogs_enrichment.py` | Aggregate Discogs metadata (styles, personnel, labels, compilations) per artist. |
 | `semantic_index/discogs_edges.py` | Compute Discogs-derived edges: shared personnel, shared style (Jaccard), label family, compilation co-appearance. |
 | `semantic_index/graph_export.py` | Build NetworkX graph and export GEXF. |

--- a/semantic_index/entity_store.py
+++ b/semantic_index/entity_store.py
@@ -539,6 +539,28 @@ class EntityStore:
         return [row[0] for row in rows]
 
     # ------------------------------------------------------------------
+    # Wikidata Reconciliation Queries
+    # ------------------------------------------------------------------
+
+    def get_artists_needing_wikidata(self) -> list[tuple[int, str, int]]:
+        """Return artists with a Discogs ID that lack a Wikidata QID.
+
+        An artist "needs Wikidata" when it has ``discogs_artist_id IS NOT NULL``
+        and either has no linked entity or its entity has no ``wikidata_qid``.
+
+        Returns:
+            List of ``(artist_id, canonical_name, discogs_artist_id)`` tuples.
+        """
+        rows = self._conn.execute(
+            """SELECT a.id, a.canonical_name, a.discogs_artist_id
+               FROM artist a
+               LEFT JOIN entity e ON a.entity_id = e.id
+               WHERE a.discogs_artist_id IS NOT NULL
+               AND (a.entity_id IS NULL OR e.wikidata_qid IS NULL)"""
+        ).fetchall()
+        return [(row[0], row[1], row[2]) for row in rows]
+
+    # ------------------------------------------------------------------
     # Name-to-ID Mapping
     # ------------------------------------------------------------------
 

--- a/semantic_index/reconciliation.py
+++ b/semantic_index/reconciliation.py
@@ -1,21 +1,28 @@
-"""Reconciliation module: bulk Discogs matching for unreconciled artists.
+"""Reconciliation module: bulk Discogs and Wikidata matching for artists.
 
 Queries the entity store for artists with ``reconciliation_status='unreconciled'``,
 matches them against the discogs-cache PostgreSQL ``release_artist`` table in
 batches, persists per-artist styles from ``release_style``, and updates each
 artist's ``discogs_artist_id`` and reconciliation status.
 
+Also provides Wikidata reconciliation by Discogs artist ID: for artists with
+a ``discogs_artist_id``, queries Wikidata for matching P1953 entities and
+populates ``entity.wikidata_qid``.
+
 Usage::
 
     from semantic_index.discogs_client import DiscogsClient
     from semantic_index.entity_store import EntityStore
     from semantic_index.reconciliation import ArtistReconciler
+    from semantic_index.wikidata_client import WikidataClient
 
     store = EntityStore("output/wxyc_artist_graph.db")
     store.initialize()
-    client = DiscogsClient(cache_dsn="postgresql://...", api_base_url=None)
-    reconciler = ArtistReconciler(store, client)
+    discogs = DiscogsClient(cache_dsn="postgresql://...", api_base_url=None)
+    wikidata = WikidataClient()
+    reconciler = ArtistReconciler(store, discogs, wikidata_client=wikidata)
     report = reconciler.reconcile_batch(batch_size=1000)
+    wikidata_report = reconciler.reconcile_wikidata()
 """
 
 from __future__ import annotations
@@ -25,21 +32,29 @@ import logging
 from semantic_index.discogs_client import DiscogsClient
 from semantic_index.entity_store import EntityStore
 from semantic_index.models import ReconciliationReport
+from semantic_index.wikidata_client import WikidataClient
 
 logger = logging.getLogger(__name__)
 
 
 class ArtistReconciler:
-    """Bulk Discogs matching for unreconciled artists.
+    """Bulk Discogs and Wikidata matching for artists.
 
     Args:
         store: Entity store for reading/writing artist data.
         client: Discogs client whose cache connection is used for bulk lookups.
+        wikidata_client: Optional Wikidata client for P1953 lookups.
     """
 
-    def __init__(self, store: EntityStore, client: DiscogsClient) -> None:
+    def __init__(
+        self,
+        store: EntityStore,
+        client: DiscogsClient,
+        wikidata_client: WikidataClient | None = None,
+    ) -> None:
         self._store = store
         self._client = client
+        self._wikidata_client = wikidata_client
 
     def reconcile_batch(self, batch_size: int = 1000) -> ReconciliationReport:
         """Query unreconciled artists and process in batches.
@@ -182,6 +197,100 @@ class ArtistReconciler:
             succeeded=succeeded,
             no_match=no_match,
             errored=errored,
+            skipped=skipped,
+        )
+
+    def reconcile_wikidata(self) -> ReconciliationReport:
+        """Look up Wikidata entities by Discogs artist ID (P1953).
+
+        For each artist with a ``discogs_artist_id`` whose entity does not yet
+        have a ``wikidata_qid``, queries Wikidata via SPARQL. On match, creates
+        or updates the entity and links it to the artist.
+
+        Raises:
+            ValueError: If no WikidataClient was provided at construction time.
+
+        Returns:
+            ReconciliationReport with counts.
+        """
+        if self._wikidata_client is None:
+            raise ValueError("WikidataClient is required for reconcile_wikidata")
+
+        total = self._store._conn.execute("SELECT COUNT(*) FROM artist").fetchone()[0]
+        needing = self._store.get_artists_needing_wikidata()
+        skipped = total - len(needing)
+
+        if not needing:
+            return ReconciliationReport(
+                total=total, attempted=0, succeeded=0, no_match=0, errored=0, skipped=skipped
+            )
+
+        discogs_ids = [discogs_id for _, _, discogs_id in needing]
+        try:
+            wikidata_map = self._wikidata_client.lookup_by_discogs_ids(discogs_ids)
+        except Exception:
+            logger.warning("Wikidata lookup failed", exc_info=True)
+            return ReconciliationReport(
+                total=total,
+                attempted=len(needing),
+                succeeded=0,
+                no_match=0,
+                errored=len(needing),
+                skipped=skipped,
+            )
+
+        succeeded = 0
+        no_match = 0
+
+        for artist_id, canonical_name, discogs_id in needing:
+            wd_entity = wikidata_map.get(discogs_id)
+            if wd_entity is None:
+                no_match += 1
+                continue
+
+            # Reuse an existing entity with this QID, or create/update one
+            existing = self._store.get_entity_by_qid(wd_entity.qid)
+            if existing is not None:
+                entity_id = existing.id
+            else:
+                row = self._store.get_artist_by_name(canonical_name)
+                raw_eid = row["entity_id"] if row else None
+                current_entity_id: int | None = (
+                    int(raw_eid) if isinstance(raw_eid, (int, float)) else None
+                )
+                if current_entity_id is not None:
+                    self._store.update_entity_qid(current_entity_id, wd_entity.qid)
+                    entity_id = current_entity_id
+                else:
+                    entity = self._store.get_or_create_entity(
+                        wd_entity.name, "artist", wikidata_qid=wd_entity.qid
+                    )
+                    entity_id = entity.id
+
+            self._store.upsert_artist(canonical_name, entity_id=entity_id)
+            self._store.log_reconciliation(
+                artist_id=artist_id,
+                source="wikidata",
+                external_id=wd_entity.qid,
+                confidence=None,
+                method="discogs_id_lookup",
+            )
+            succeeded += 1
+
+        attempted = succeeded + no_match
+        logger.info(
+            "Wikidata reconciliation complete: %d attempted, %d succeeded, %d no_match, %d skipped",
+            attempted,
+            succeeded,
+            no_match,
+            skipped,
+        )
+        return ReconciliationReport(
+            total=total,
+            attempted=attempted,
+            succeeded=succeeded,
+            no_match=no_match,
+            errored=0,
             skipped=skipped,
         )
 

--- a/tests/unit/test_entity_store.py
+++ b/tests/unit/test_entity_store.py
@@ -327,6 +327,85 @@ class TestAlreadyMigrated:
         store.close()
 
 
+class TestGetArtistsNeedingWikidata:
+    """Tests for get_artists_needing_wikidata() query method."""
+
+    def test_returns_artists_with_discogs_id_and_no_entity(self, tmp_path):
+        db_path = str(tmp_path / "test.db")
+        store = EntityStore(db_path)
+        store.initialize()
+        store.upsert_artist("Autechre", discogs_artist_id=2774)
+        store.upsert_artist("Stereolab", discogs_artist_id=10272)
+
+        result = store.get_artists_needing_wikidata()
+        names = {name for _, name, _ in result}
+        assert names == {"Autechre", "Stereolab"}
+        store.close()
+
+    def test_returns_artists_with_entity_missing_qid(self, tmp_path):
+        db_path = str(tmp_path / "test.db")
+        store = EntityStore(db_path)
+        store.initialize()
+        entity = store.get_or_create_entity("Autechre", "artist")
+        store.upsert_artist("Autechre", discogs_artist_id=2774, entity_id=entity.id)
+
+        result = store.get_artists_needing_wikidata()
+        assert len(result) == 1
+        assert result[0][1] == "Autechre"
+        assert result[0][2] == 2774
+        store.close()
+
+    def test_excludes_artists_with_entity_that_has_qid(self, tmp_path):
+        db_path = str(tmp_path / "test.db")
+        store = EntityStore(db_path)
+        store.initialize()
+        entity = store.get_or_create_entity("Autechre", "artist", wikidata_qid="Q2774")
+        store.upsert_artist("Autechre", discogs_artist_id=2774, entity_id=entity.id)
+
+        result = store.get_artists_needing_wikidata()
+        assert result == []
+        store.close()
+
+    def test_excludes_artists_without_discogs_id(self, tmp_path):
+        db_path = str(tmp_path / "test.db")
+        store = EntityStore(db_path)
+        store.initialize()
+        store.upsert_artist("Unknown Band")
+
+        result = store.get_artists_needing_wikidata()
+        assert result == []
+        store.close()
+
+    def test_returns_discogs_artist_id_in_tuple(self, tmp_path):
+        db_path = str(tmp_path / "test.db")
+        store = EntityStore(db_path)
+        store.initialize()
+        aid = store.upsert_artist("Cat Power", discogs_artist_id=88)
+
+        result = store.get_artists_needing_wikidata()
+        assert len(result) == 1
+        assert result[0] == (aid, "Cat Power", 88)
+        store.close()
+
+    def test_mixed_artists(self, tmp_path):
+        """Only artists needing Wikidata are returned."""
+        db_path = str(tmp_path / "test.db")
+        store = EntityStore(db_path)
+        store.initialize()
+        # Has discogs ID, no entity -> needs wikidata
+        store.upsert_artist("Autechre", discogs_artist_id=2774)
+        # Has discogs ID, entity with QID -> already done
+        entity = store.get_or_create_entity("Stereolab", "artist", wikidata_qid="Q650826")
+        store.upsert_artist("Stereolab", discogs_artist_id=10272, entity_id=entity.id)
+        # No discogs ID -> not eligible
+        store.upsert_artist("Unknown Band")
+
+        result = store.get_artists_needing_wikidata()
+        names = {name for _, name, _ in result}
+        assert names == {"Autechre"}
+        store.close()
+
+
 class TestContextManager:
     """EntityStore supports the context manager protocol."""
 

--- a/tests/unit/test_reconciliation.py
+++ b/tests/unit/test_reconciliation.py
@@ -7,8 +7,9 @@ import pytest
 
 from semantic_index.discogs_client import DiscogsClient
 from semantic_index.entity_store import EntityStore
-from semantic_index.models import ReconciliationReport
+from semantic_index.models import ReconciliationReport, WikidataEntity
 from semantic_index.reconciliation import ArtistReconciler
+from semantic_index.wikidata_client import WikidataClient
 
 # The old artist schema — matches sqlite_export._SCHEMA artist table
 _OLD_ARTIST_SCHEMA = """
@@ -699,4 +700,202 @@ class TestReconcileMembers:
         report = reconciler.reconcile_members()
         assert report.attempted == 1
         assert report.no_match == 1
+        assert report.succeeded == 0
+
+
+# ---------------------------------------------------------------------------
+# reconcile_wikidata
+# ---------------------------------------------------------------------------
+
+
+class TestReconcileWikidata:
+    def test_creates_entity_and_populates_qid(self, store: EntityStore):
+        """Artists with discogs_artist_id get entities with wikidata_qid."""
+        store.upsert_artist("Autechre", discogs_artist_id=2774)
+
+        wikidata_client = MagicMock(spec=WikidataClient)
+        wikidata_client.lookup_by_discogs_ids.return_value = {
+            2774: WikidataEntity(qid="Q2774", name="Autechre", discogs_artist_id=2774),
+        }
+
+        client = DiscogsClient(cache_dsn=None, api_base_url=None)
+        reconciler = ArtistReconciler(store, client, wikidata_client=wikidata_client)
+
+        report = reconciler.reconcile_wikidata()
+        assert report.succeeded == 1
+        assert report.no_match == 0
+
+        row = store.get_artist_by_name("Autechre")
+        assert row is not None
+        assert row["entity_id"] is not None
+
+        entity = store._conn.execute(
+            "SELECT wikidata_qid, name FROM entity WHERE id = ?", (row["entity_id"],)
+        ).fetchone()
+        assert entity[0] == "Q2774"
+        assert entity[1] == "Autechre"
+
+    def test_updates_existing_entity_qid(self, store: EntityStore):
+        """If artist already has an entity without QID, updates it."""
+        entity = store.get_or_create_entity("Autechre", "artist")
+        store.upsert_artist("Autechre", discogs_artist_id=2774, entity_id=entity.id)
+
+        wikidata_client = MagicMock(spec=WikidataClient)
+        wikidata_client.lookup_by_discogs_ids.return_value = {
+            2774: WikidataEntity(qid="Q2774", name="Autechre", discogs_artist_id=2774),
+        }
+
+        client = DiscogsClient(cache_dsn=None, api_base_url=None)
+        reconciler = ArtistReconciler(store, client, wikidata_client=wikidata_client)
+
+        report = reconciler.reconcile_wikidata()
+        assert report.succeeded == 1
+
+        updated_entity = store.get_entity_by_qid("Q2774")
+        assert updated_entity is not None
+        assert updated_entity.id == entity.id
+
+    def test_no_match_counted(self, store: EntityStore):
+        """Artists whose discogs ID has no Wikidata match are counted as no_match."""
+        store.upsert_artist("Autechre", discogs_artist_id=2774)
+
+        wikidata_client = MagicMock(spec=WikidataClient)
+        wikidata_client.lookup_by_discogs_ids.return_value = {}
+
+        client = DiscogsClient(cache_dsn=None, api_base_url=None)
+        reconciler = ArtistReconciler(store, client, wikidata_client=wikidata_client)
+
+        report = reconciler.reconcile_wikidata()
+        assert report.attempted == 1
+        assert report.succeeded == 0
+        assert report.no_match == 1
+
+    def test_skips_artists_already_with_qid(self, store: EntityStore):
+        """Artists whose entity already has a QID are skipped."""
+        entity = store.get_or_create_entity("Autechre", "artist", wikidata_qid="Q2774")
+        store.upsert_artist("Autechre", discogs_artist_id=2774, entity_id=entity.id)
+        store.upsert_artist("Stereolab", discogs_artist_id=10272)
+
+        wikidata_client = MagicMock(spec=WikidataClient)
+        wikidata_client.lookup_by_discogs_ids.return_value = {
+            10272: WikidataEntity(qid="Q650826", name="Stereolab", discogs_artist_id=10272),
+        }
+
+        client = DiscogsClient(cache_dsn=None, api_base_url=None)
+        reconciler = ArtistReconciler(store, client, wikidata_client=wikidata_client)
+
+        report = reconciler.reconcile_wikidata()
+        assert report.skipped == 1
+        assert report.attempted == 1
+        assert report.succeeded == 1
+
+    def test_skips_artists_without_discogs_id(self, store: EntityStore):
+        """Artists without discogs_artist_id are not attempted."""
+        store.upsert_artist("Unknown Band")
+        store.upsert_artist("Autechre", discogs_artist_id=2774)
+
+        wikidata_client = MagicMock(spec=WikidataClient)
+        wikidata_client.lookup_by_discogs_ids.return_value = {
+            2774: WikidataEntity(qid="Q2774", name="Autechre", discogs_artist_id=2774),
+        }
+
+        client = DiscogsClient(cache_dsn=None, api_base_url=None)
+        reconciler = ArtistReconciler(store, client, wikidata_client=wikidata_client)
+
+        report = reconciler.reconcile_wikidata()
+        assert report.total == 2
+        assert report.attempted == 1
+        assert report.succeeded == 1
+        assert report.skipped == 1
+
+    def test_logs_reconciliation_event(self, store: EntityStore):
+        aid = store.upsert_artist("Autechre", discogs_artist_id=2774)
+
+        wikidata_client = MagicMock(spec=WikidataClient)
+        wikidata_client.lookup_by_discogs_ids.return_value = {
+            2774: WikidataEntity(qid="Q2774", name="Autechre", discogs_artist_id=2774),
+        }
+
+        client = DiscogsClient(cache_dsn=None, api_base_url=None)
+        reconciler = ArtistReconciler(store, client, wikidata_client=wikidata_client)
+
+        reconciler.reconcile_wikidata()
+        history = store.get_reconciliation_history(aid)
+        assert len(history) == 1
+        assert history[0].source == "wikidata"
+        assert history[0].external_id == "Q2774"
+        assert history[0].method == "discogs_id_lookup"
+
+    def test_multiple_artists(self, store: EntityStore):
+        store.upsert_artist("Autechre", discogs_artist_id=2774)
+        store.upsert_artist("Stereolab", discogs_artist_id=10272)
+        store.upsert_artist("Father John Misty", discogs_artist_id=555)
+
+        wikidata_client = MagicMock(spec=WikidataClient)
+        wikidata_client.lookup_by_discogs_ids.return_value = {
+            2774: WikidataEntity(qid="Q2774", name="Autechre", discogs_artist_id=2774),
+            10272: WikidataEntity(qid="Q650826", name="Stereolab", discogs_artist_id=10272),
+        }
+
+        client = DiscogsClient(cache_dsn=None, api_base_url=None)
+        reconciler = ArtistReconciler(store, client, wikidata_client=wikidata_client)
+
+        report = reconciler.reconcile_wikidata()
+        assert report.total == 3
+        assert report.attempted == 3
+        assert report.succeeded == 2
+        assert report.no_match == 1
+
+    def test_reuses_existing_entity_by_qid(self, store: EntityStore):
+        """If an entity already exists with the matching QID, reuses it."""
+        existing = store.get_or_create_entity(
+            "Autechre (electronic duo)", "artist", wikidata_qid="Q2774"
+        )
+        store.upsert_artist("Autechre", discogs_artist_id=2774)
+
+        wikidata_client = MagicMock(spec=WikidataClient)
+        wikidata_client.lookup_by_discogs_ids.return_value = {
+            2774: WikidataEntity(qid="Q2774", name="Autechre", discogs_artist_id=2774),
+        }
+
+        client = DiscogsClient(cache_dsn=None, api_base_url=None)
+        reconciler = ArtistReconciler(store, client, wikidata_client=wikidata_client)
+
+        reconciler.reconcile_wikidata()
+        row = store.get_artist_by_name("Autechre")
+        assert row["entity_id"] == existing.id
+
+    def test_no_wikidata_client_raises(self, store: EntityStore):
+        """reconcile_wikidata raises ValueError when no WikidataClient is configured."""
+        store.upsert_artist("Autechre", discogs_artist_id=2774)
+        client = DiscogsClient(cache_dsn=None, api_base_url=None)
+        reconciler = ArtistReconciler(store, client)
+
+        with pytest.raises(ValueError, match="WikidataClient"):
+            reconciler.reconcile_wikidata()
+
+    def test_empty_artist_table(self, store: EntityStore):
+        wikidata_client = MagicMock(spec=WikidataClient)
+        client = DiscogsClient(cache_dsn=None, api_base_url=None)
+        reconciler = ArtistReconciler(store, client, wikidata_client=wikidata_client)
+
+        report = reconciler.reconcile_wikidata()
+        assert report.total == 0
+        assert report.attempted == 0
+        assert report.succeeded == 0
+        # lookup_by_discogs_ids should not be called with no IDs
+        wikidata_client.lookup_by_discogs_ids.assert_not_called()
+
+    def test_wikidata_error_counts_as_errored(self, store: EntityStore):
+        store.upsert_artist("Autechre", discogs_artist_id=2774)
+
+        wikidata_client = MagicMock(spec=WikidataClient)
+        wikidata_client.lookup_by_discogs_ids.side_effect = Exception("SPARQL timeout")
+
+        client = DiscogsClient(cache_dsn=None, api_base_url=None)
+        reconciler = ArtistReconciler(store, client, wikidata_client=wikidata_client)
+
+        report = reconciler.reconcile_wikidata()
+        assert report.attempted == 1
+        assert report.errored == 1
         assert report.succeeded == 0


### PR DESCRIPTION
## Summary

- Adds `EntityStore.get_artists_needing_wikidata()` — query for artists with a Discogs ID whose entity lacks a Wikidata QID (no entity, or entity with NULL wikidata_qid)
- Adds `ArtistReconciler.reconcile_wikidata()` — batch SPARQL lookup via P1953, creates/updates entities with QIDs, links them to artists, and logs reconciliation events
- `ArtistReconciler` now accepts an optional `wikidata_client` parameter (backward-compatible)

Closes #70

## Test plan

- [x] 6 unit tests for `EntityStore.get_artists_needing_wikidata()` covering: no entity, entity missing QID, entity with QID (excluded), no discogs ID (excluded), mixed
- [x] 11 unit tests for `reconcile_wikidata()` covering: entity creation, entity QID update, no match, skip already-done, skip no-discogs-id, reconciliation logging, multiple artists, entity reuse by QID, no client raises, empty table, SPARQL error
- [x] All 384 existing unit tests pass
- [x] ruff check + format clean
- [x] mypy clean (excluding pre-existing api/ import issues)