### PR TITLE
Add Wikidata name search for unresolved artists

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -37,6 +37,7 @@ from semantic_index.pmi import compute_pmi
 from semantic_index.reconciliation import ArtistReconciler
 from semantic_index.sql_parser import iter_table_rows, load_table_rows
 from semantic_index.sqlite_export import export_sqlite
+from semantic_index.wikidata_client import WikidataClient
 
 log = logging.getLogger(__name__)
 
@@ -108,6 +109,13 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--skip-reconciliation",
         action="store_true",
         help="Skip Discogs reconciliation step (requires --entity-store-path)",
+    )
+    parser.add_argument(
+        "--wikidata-reconciliation",
+        action="store_true",
+        help="Search Wikidata by name for artists with no Discogs match. "
+        "Filtered to musicians (P31=human/musical group, P106=musician). "
+        "Requires --entity-store-path.",
     )
     parser.add_argument(
         "--compute-discogs-edges",
@@ -276,13 +284,14 @@ def run(args: argparse.Namespace) -> None:
         entity_store.bulk_upsert_artists(all_canonical)
 
         # 5d. Reconcile via Discogs (unless skipped or no cache DSN)
+        reconcile_client = DiscogsClient(
+            cache_dsn=args.discogs_cache_dsn,
+            api_base_url=None,
+        )
+        reconciler = ArtistReconciler(entity_store, reconcile_client)
+
         if not args.skip_reconciliation and args.discogs_cache_dsn:
             log.info("Running Discogs reconciliation...")
-            reconcile_client = DiscogsClient(
-                cache_dsn=args.discogs_cache_dsn,
-                api_base_url=None,
-            )
-            reconciler = ArtistReconciler(entity_store, reconcile_client)
             report = reconciler.reconcile_batch()
             log.info(
                 "Reconciliation: %d attempted, %d succeeded, %d no_match, %d errored",
@@ -302,6 +311,19 @@ def run(args: argparse.Namespace) -> None:
             )
         elif not args.skip_reconciliation:
             log.warning("Skipping reconciliation: no discogs-cache DSN available")
+
+        # 5e. Wikidata name search for remaining no_match artists (opt-in)
+        if args.wikidata_reconciliation:
+            log.info("Running Wikidata name search for no_match artists...")
+            wikidata_client = WikidataClient()
+            wikidata_report = reconciler.reconcile_wikidata(wikidata_client)
+            log.info(
+                "Wikidata reconciliation: %d attempted, %d succeeded, %d no_match, %d errored",
+                wikidata_report.attempted,
+                wikidata_report.succeeded,
+                wikidata_report.no_match,
+                wikidata_report.errored,
+            )
 
     # 6. Extract adjacency pairs
     log.info("Extracting adjacency pairs...")

--- a/semantic_index/reconciliation.py
+++ b/semantic_index/reconciliation.py
@@ -28,11 +28,15 @@ Usage::
 from __future__ import annotations
 
 import logging
+from typing import TYPE_CHECKING
 
 from semantic_index.discogs_client import DiscogsClient
 from semantic_index.entity_store import EntityStore
 from semantic_index.models import ReconciliationReport
 from semantic_index.wikidata_client import WikidataClient
+
+if TYPE_CHECKING:
+    from semantic_index.wikidata_client import WikidataClient
 
 logger = logging.getLogger(__name__)
 
@@ -200,89 +204,70 @@ class ArtistReconciler:
             skipped=skipped,
         )
 
-    def reconcile_wikidata(self) -> ReconciliationReport:
-        """Look up Wikidata entities by Discogs artist ID (P1953).
+    def reconcile_wikidata(self, wikidata_client: WikidataClient) -> ReconciliationReport:
+        """Search Wikidata by name for artists with no Discogs match.
 
-        For each artist with a ``discogs_artist_id`` whose entity does not yet
-        have a ``wikidata_qid``, queries Wikidata via SPARQL. On match, creates
-        or updates the entity and links it to the artist.
+        For each ``no_match`` artist, searches Wikidata for musician entities
+        matching the artist name. The top result (if any) is linked via the
+        entity store and logged as a ``wikidata`` / ``name_search`` reconciliation.
 
-        Raises:
-            ValueError: If no WikidataClient was provided at construction time.
+        Args:
+            wikidata_client: WikidataClient instance for name search.
 
         Returns:
             ReconciliationReport with counts.
         """
-        if self._wikidata_client is None:
-            raise ValueError("WikidataClient is required for reconcile_wikidata")
-
         total = self._store._conn.execute("SELECT COUNT(*) FROM artist").fetchone()[0]
-        needing = self._store.get_artists_needing_wikidata()
-        skipped = total - len(needing)
-
-        if not needing:
-            return ReconciliationReport(
-                total=total, attempted=0, succeeded=0, no_match=0, errored=0, skipped=skipped
-            )
-
-        discogs_ids = [discogs_id for _, _, discogs_id in needing]
-        try:
-            wikidata_map = self._wikidata_client.lookup_by_discogs_ids(discogs_ids)
-        except Exception:
-            logger.warning("Wikidata lookup failed", exc_info=True)
-            return ReconciliationReport(
-                total=total,
-                attempted=len(needing),
-                succeeded=0,
-                no_match=0,
-                errored=len(needing),
-                skipped=skipped,
-            )
+        no_match_artists = self._store.get_no_match_artists()
+        skipped = total - len(no_match_artists)
 
         succeeded = 0
         no_match = 0
+        errored = 0
 
-        for artist_id, canonical_name, discogs_id in needing:
-            wd_entity = wikidata_map.get(discogs_id)
-            if wd_entity is None:
+        for artist_id, name in no_match_artists:
+            try:
+                results = wikidata_client.search_musician_by_name(name, limit=5)
+            except Exception:
+                logger.warning(
+                    "Wikidata name search failed for artist %d (%s)", artist_id, name, exc_info=True
+                )
+                errored += 1
+                continue
+
+            if not results:
                 no_match += 1
                 continue
 
-            # Reuse an existing entity with this QID, or create/update one
-            existing = self._store.get_entity_by_qid(wd_entity.qid)
-            if existing is not None:
-                entity_id = existing.id
-            else:
-                row = self._store.get_artist_by_name(canonical_name)
-                raw_eid = row["entity_id"] if row else None
-                current_entity_id: int | None = (
-                    int(raw_eid) if isinstance(raw_eid, (int, float)) else None
-                )
-                if current_entity_id is not None:
-                    self._store.update_entity_qid(current_entity_id, wd_entity.qid)
-                    entity_id = current_entity_id
-                else:
-                    entity = self._store.get_or_create_entity(
-                        wd_entity.name, "artist", wikidata_qid=wd_entity.qid
-                    )
-                    entity_id = entity.id
+            best = results[0]
 
-            self._store.upsert_artist(canonical_name, entity_id=entity_id)
+            # Reuse existing entity if one already has this QID
+            entity = self._store.get_entity_by_qid(best.qid)
+            if entity is None:
+                entity = self._store.get_or_create_entity(
+                    name=best.name,
+                    entity_type="artist",
+                    wikidata_qid=best.qid,
+                )
+
+            self._store.upsert_artist(name, entity_id=entity.id)
             self._store.log_reconciliation(
                 artist_id=artist_id,
                 source="wikidata",
-                external_id=wd_entity.qid,
+                external_id=best.qid,
                 confidence=None,
-                method="discogs_id_lookup",
+                method="name_search",
             )
+            self._store.update_reconciliation_status(artist_id, "reconciled")
             succeeded += 1
 
-        attempted = succeeded + no_match
+        attempted = succeeded + no_match + errored
         logger.info(
-            "Wikidata reconciliation complete: %d attempted, %d succeeded, %d no_match, %d skipped",
+            "Wikidata reconciliation complete: %d attempted, %d succeeded, %d no_match, %d errored, %d skipped",
             attempted,
             succeeded,
             no_match,
+            errored,
             skipped,
         )
         return ReconciliationReport(
@@ -290,7 +275,7 @@ class ArtistReconciler:
             attempted=attempted,
             succeeded=succeeded,
             no_match=no_match,
-            errored=0,
+            errored=errored,
             skipped=skipped,
         )
 

--- a/semantic_index/wikidata_client.py
+++ b/semantic_index/wikidata_client.py
@@ -25,6 +25,31 @@ logger = logging.getLogger(__name__)
 _QID_PATTERN = re.compile(r"^Q\d+$")
 _RATE_INTERVAL = 1.0  # seconds between requests
 
+# Wikidata QIDs for musician-related occupations (P106 values).
+MUSICIAN_OCCUPATIONS: frozenset[str] = frozenset(
+    {
+        "Q639669",  # musician
+        "Q177220",  # singer
+        "Q753110",  # songwriter
+        "Q488205",  # singer-songwriter
+        "Q36834",  # composer
+        "Q855091",  # guitarist
+        "Q386854",  # rapper
+        "Q183945",  # record producer
+        "Q130857",  # disc jockey
+        "Q806349",  # bandleader
+    }
+)
+
+# Wikidata QIDs for musical group types (P31 values).
+MUSICAL_GROUP_TYPES: frozenset[str] = frozenset(
+    {
+        "Q215380",  # musical group/band
+        "Q5741069",  # musical duo
+        "Q56816954",  # music project
+    }
+)
+
 
 def _extract_qid(uri: str) -> str:
     """Extract QID from a Wikidata entity URI.
@@ -343,3 +368,73 @@ class WikidataClient:
             return []
         finally:
             client.close()
+
+    def search_musician_by_name(self, name: str, limit: int = 10) -> list[WikidataEntity]:
+        """Search for Wikidata entities by name, filtered to musicians.
+
+        Two-step process: first finds candidates via ``wbsearchentities``,
+        then validates them with a SPARQL query checking P31 (instance of)
+        and P106 (occupation) to keep only humans with musician occupations
+        or musical groups/duos.
+
+        Args:
+            name: Search string (artist name).
+            limit: Maximum candidates to retrieve from search (capped at 50).
+
+        Returns:
+            List of WikidataEntity instances that are musicians, in search
+            relevance order.
+        """
+        candidates = self.search_by_name(name, limit=limit)
+        if not candidates:
+            return []
+
+        candidate_qids = [c.qid for c in candidates]
+        musician_qids = self._filter_musicians(candidate_qids)
+        if not musician_qids:
+            return []
+
+        return [c for c in candidates if c.qid in musician_qids]
+
+    def _filter_musicians(self, qids: list[str]) -> set[str]:
+        """Filter QIDs to those that are musicians or musical groups.
+
+        Uses a SPARQL query to check:
+        - Human (P31=Q5) with a musician-related occupation (P106), OR
+        - Musical group/duo/project (P31 in MUSICAL_GROUP_TYPES).
+
+        Args:
+            qids: Candidate Wikidata QIDs to filter.
+
+        Returns:
+            Set of QIDs that pass the musician filter.
+        """
+        valid_qids = self._validate_qids(qids)
+        if not valid_qids:
+            return set()
+
+        values = " ".join(f"wd:{qid}" for qid in valid_qids)
+        occupations = " ".join(f"wd:{qid}" for qid in MUSICIAN_OCCUPATIONS)
+        group_types = " ".join(f"wd:{qid}" for qid in MUSICAL_GROUP_TYPES)
+
+        query = (
+            "SELECT DISTINCT ?item WHERE {\n"
+            f"  VALUES ?item {{ {values} }}\n"
+            "  {\n"
+            "    ?item wdt:P31 wd:Q5 .\n"
+            f"    VALUES ?occupation {{ {occupations} }}\n"
+            "    ?item wdt:P106 ?occupation .\n"
+            "  }\n"
+            "  UNION\n"
+            "  {\n"
+            f"    VALUES ?groupType {{ {group_types} }}\n"
+            "    ?item wdt:P31 ?groupType .\n"
+            "  }\n"
+            "}"
+        )
+        try:
+            bindings = self._sparql_query(query)
+            return {_extract_qid(_binding_value(b, "item") or "") for b in bindings}
+        except Exception:
+            logger.warning("SPARQL musician filter failed for %s", qids, exc_info=True)
+            return set()

--- a/tests/unit/test_reconciliation.py
+++ b/tests/unit/test_reconciliation.py
@@ -708,194 +708,212 @@ class TestReconcileMembers:
 # ---------------------------------------------------------------------------
 
 
+def _make_mock_wikidata_client(
+    results_by_name: dict[str, list[WikidataEntity]],
+) -> WikidataClient:
+    """Build a mock WikidataClient whose search_musician_by_name returns preset results.
+
+    Args:
+        results_by_name: Maps artist name (case-insensitive) to WikidataEntity list.
+    """
+    mock = MagicMock(spec=WikidataClient)
+    lower_map = {k.lower(): v for k, v in results_by_name.items()}
+    mock.search_musician_by_name.side_effect = lambda name, **kw: lower_map.get(name.lower(), [])
+    return mock
+
+
 class TestReconcileWikidata:
-    def test_creates_entity_and_populates_qid(self, store: EntityStore):
-        """Artists with discogs_artist_id get entities with wikidata_qid."""
-        store.upsert_artist("Autechre", discogs_artist_id=2774)
+    def test_returns_reconciliation_report(self, store: EntityStore):
+        aid1 = store.upsert_artist("Autechre")
+        aid2 = store.upsert_artist("Cat Power")
+        store.update_reconciliation_status(aid1, "no_match")
+        store.update_reconciliation_status(aid2, "no_match")
 
-        wikidata_client = MagicMock(spec=WikidataClient)
-        wikidata_client.lookup_by_discogs_ids.return_value = {
-            2774: WikidataEntity(qid="Q2774", name="Autechre", discogs_artist_id=2774),
-        }
+        wikidata = _make_mock_wikidata_client(
+            {"Autechre": [WikidataEntity(qid="Q2774", name="Autechre")]}
+        )
+        reconciler = ArtistReconciler(store, DiscogsClient(cache_dsn=None, api_base_url=None))
 
-        client = DiscogsClient(cache_dsn=None, api_base_url=None)
-        reconciler = ArtistReconciler(store, client, wikidata_client=wikidata_client)
-
-        report = reconciler.reconcile_wikidata()
+        report = reconciler.reconcile_wikidata(wikidata)
+        assert isinstance(report, ReconciliationReport)
+        assert report.total == 2
+        assert report.attempted == 2
         assert report.succeeded == 1
-        assert report.no_match == 0
+        assert report.no_match == 1
+        assert report.errored == 0
+        assert report.skipped == 0
 
+    def test_creates_entity_with_qid(self, store: EntityStore):
+        aid = store.upsert_artist("Autechre")
+        store.update_reconciliation_status(aid, "no_match")
+
+        wikidata = _make_mock_wikidata_client(
+            {"Autechre": [WikidataEntity(qid="Q2774", name="Autechre")]}
+        )
+        reconciler = ArtistReconciler(store, DiscogsClient(cache_dsn=None, api_base_url=None))
+
+        reconciler.reconcile_wikidata(wikidata)
+        entity = store.get_entity_by_qid("Q2774")
+        assert entity is not None
+        assert entity.name == "Autechre"
+        assert entity.entity_type == "artist"
+
+    def test_links_artist_to_entity(self, store: EntityStore):
+        aid = store.upsert_artist("Autechre")
+        store.update_reconciliation_status(aid, "no_match")
+
+        wikidata = _make_mock_wikidata_client(
+            {"Autechre": [WikidataEntity(qid="Q2774", name="Autechre")]}
+        )
+        reconciler = ArtistReconciler(store, DiscogsClient(cache_dsn=None, api_base_url=None))
+
+        reconciler.reconcile_wikidata(wikidata)
         row = store.get_artist_by_name("Autechre")
         assert row is not None
         assert row["entity_id"] is not None
-
-        entity = store._conn.execute(
-            "SELECT wikidata_qid, name FROM entity WHERE id = ?", (row["entity_id"],)
-        ).fetchone()
-        assert entity[0] == "Q2774"
-        assert entity[1] == "Autechre"
-
-    def test_updates_existing_entity_qid(self, store: EntityStore):
-        """If artist already has an entity without QID, updates it."""
-        entity = store.get_or_create_entity("Autechre", "artist")
-        store.upsert_artist("Autechre", discogs_artist_id=2774, entity_id=entity.id)
-
-        wikidata_client = MagicMock(spec=WikidataClient)
-        wikidata_client.lookup_by_discogs_ids.return_value = {
-            2774: WikidataEntity(qid="Q2774", name="Autechre", discogs_artist_id=2774),
-        }
-
-        client = DiscogsClient(cache_dsn=None, api_base_url=None)
-        reconciler = ArtistReconciler(store, client, wikidata_client=wikidata_client)
-
-        report = reconciler.reconcile_wikidata()
-        assert report.succeeded == 1
-
-        updated_entity = store.get_entity_by_qid("Q2774")
-        assert updated_entity is not None
-        assert updated_entity.id == entity.id
-
-    def test_no_match_counted(self, store: EntityStore):
-        """Artists whose discogs ID has no Wikidata match are counted as no_match."""
-        store.upsert_artist("Autechre", discogs_artist_id=2774)
-
-        wikidata_client = MagicMock(spec=WikidataClient)
-        wikidata_client.lookup_by_discogs_ids.return_value = {}
-
-        client = DiscogsClient(cache_dsn=None, api_base_url=None)
-        reconciler = ArtistReconciler(store, client, wikidata_client=wikidata_client)
-
-        report = reconciler.reconcile_wikidata()
-        assert report.attempted == 1
-        assert report.succeeded == 0
-        assert report.no_match == 1
-
-    def test_skips_artists_already_with_qid(self, store: EntityStore):
-        """Artists whose entity already has a QID are skipped."""
-        entity = store.get_or_create_entity("Autechre", "artist", wikidata_qid="Q2774")
-        store.upsert_artist("Autechre", discogs_artist_id=2774, entity_id=entity.id)
-        store.upsert_artist("Stereolab", discogs_artist_id=10272)
-
-        wikidata_client = MagicMock(spec=WikidataClient)
-        wikidata_client.lookup_by_discogs_ids.return_value = {
-            10272: WikidataEntity(qid="Q650826", name="Stereolab", discogs_artist_id=10272),
-        }
-
-        client = DiscogsClient(cache_dsn=None, api_base_url=None)
-        reconciler = ArtistReconciler(store, client, wikidata_client=wikidata_client)
-
-        report = reconciler.reconcile_wikidata()
-        assert report.skipped == 1
-        assert report.attempted == 1
-        assert report.succeeded == 1
-
-    def test_skips_artists_without_discogs_id(self, store: EntityStore):
-        """Artists without discogs_artist_id are not attempted."""
-        store.upsert_artist("Unknown Band")
-        store.upsert_artist("Autechre", discogs_artist_id=2774)
-
-        wikidata_client = MagicMock(spec=WikidataClient)
-        wikidata_client.lookup_by_discogs_ids.return_value = {
-            2774: WikidataEntity(qid="Q2774", name="Autechre", discogs_artist_id=2774),
-        }
-
-        client = DiscogsClient(cache_dsn=None, api_base_url=None)
-        reconciler = ArtistReconciler(store, client, wikidata_client=wikidata_client)
-
-        report = reconciler.reconcile_wikidata()
-        assert report.total == 2
-        assert report.attempted == 1
-        assert report.succeeded == 1
-        assert report.skipped == 1
+        # Verify it points to the right entity
+        entity = store.get_entity_by_qid("Q2774")
+        assert row["entity_id"] == entity.id
 
     def test_logs_reconciliation_event(self, store: EntityStore):
-        aid = store.upsert_artist("Autechre", discogs_artist_id=2774)
+        aid = store.upsert_artist("Stereolab")
+        store.update_reconciliation_status(aid, "no_match")
 
-        wikidata_client = MagicMock(spec=WikidataClient)
-        wikidata_client.lookup_by_discogs_ids.return_value = {
-            2774: WikidataEntity(qid="Q2774", name="Autechre", discogs_artist_id=2774),
-        }
+        wikidata = _make_mock_wikidata_client(
+            {"Stereolab": [WikidataEntity(qid="Q650826", name="Stereolab")]}
+        )
+        reconciler = ArtistReconciler(store, DiscogsClient(cache_dsn=None, api_base_url=None))
 
-        client = DiscogsClient(cache_dsn=None, api_base_url=None)
-        reconciler = ArtistReconciler(store, client, wikidata_client=wikidata_client)
-
-        reconciler.reconcile_wikidata()
+        reconciler.reconcile_wikidata(wikidata)
         history = store.get_reconciliation_history(aid)
         assert len(history) == 1
         assert history[0].source == "wikidata"
-        assert history[0].external_id == "Q2774"
-        assert history[0].method == "discogs_id_lookup"
+        assert history[0].external_id == "Q650826"
+        assert history[0].method == "name_search"
 
-    def test_multiple_artists(self, store: EntityStore):
-        store.upsert_artist("Autechre", discogs_artist_id=2774)
-        store.upsert_artist("Stereolab", discogs_artist_id=10272)
-        store.upsert_artist("Father John Misty", discogs_artist_id=555)
+    def test_updates_status_to_reconciled(self, store: EntityStore):
+        aid = store.upsert_artist("Cat Power")
+        store.update_reconciliation_status(aid, "no_match")
 
-        wikidata_client = MagicMock(spec=WikidataClient)
-        wikidata_client.lookup_by_discogs_ids.return_value = {
-            2774: WikidataEntity(qid="Q2774", name="Autechre", discogs_artist_id=2774),
-            10272: WikidataEntity(qid="Q650826", name="Stereolab", discogs_artist_id=10272),
-        }
+        wikidata = _make_mock_wikidata_client(
+            {"Cat Power": [WikidataEntity(qid="Q218981", name="Cat Power")]}
+        )
+        reconciler = ArtistReconciler(store, DiscogsClient(cache_dsn=None, api_base_url=None))
 
-        client = DiscogsClient(cache_dsn=None, api_base_url=None)
-        reconciler = ArtistReconciler(store, client, wikidata_client=wikidata_client)
+        reconciler.reconcile_wikidata(wikidata)
+        row = store._conn.execute(
+            "SELECT reconciliation_status FROM artist WHERE id = ?", (aid,)
+        ).fetchone()
+        assert row[0] == "reconciled"
 
-        report = reconciler.reconcile_wikidata()
+    def test_unmatched_stays_no_match(self, store: EntityStore):
+        aid = store.upsert_artist("Unknown Band")
+        store.update_reconciliation_status(aid, "no_match")
+
+        wikidata = _make_mock_wikidata_client({})
+        reconciler = ArtistReconciler(store, DiscogsClient(cache_dsn=None, api_base_url=None))
+
+        reconciler.reconcile_wikidata(wikidata)
+        row = store._conn.execute(
+            "SELECT reconciliation_status FROM artist WHERE id = ?", (aid,)
+        ).fetchone()
+        assert row[0] == "no_match"
+
+    def test_only_processes_no_match_artists(self, store: EntityStore):
+        """Reconciled and unreconciled artists are skipped."""
+        aid_reconciled = store.upsert_artist("Autechre", discogs_artist_id=42)
+        store.update_reconciliation_status(aid_reconciled, "reconciled")
+        store.upsert_artist("Stereolab")  # stays unreconciled
+        aid_no_match = store.upsert_artist("Cat Power")
+        store.update_reconciliation_status(aid_no_match, "no_match")
+
+        wikidata = _make_mock_wikidata_client(
+            {"Cat Power": [WikidataEntity(qid="Q218981", name="Cat Power")]}
+        )
+        reconciler = ArtistReconciler(store, DiscogsClient(cache_dsn=None, api_base_url=None))
+
+        report = reconciler.reconcile_wikidata(wikidata)
         assert report.total == 3
-        assert report.attempted == 3
-        assert report.succeeded == 2
-        assert report.no_match == 1
+        assert report.skipped == 2
+        assert report.attempted == 1
+        assert report.succeeded == 1
+
+    def test_takes_first_result(self, store: EntityStore):
+        """Uses the top search result (best relevance) when multiple candidates pass."""
+        aid = store.upsert_artist("Cat Power")
+        store.update_reconciliation_status(aid, "no_match")
+
+        wikidata = _make_mock_wikidata_client(
+            {
+                "Cat Power": [
+                    WikidataEntity(qid="Q218981", name="Cat Power"),
+                    WikidataEntity(qid="Q999999", name="Cat Power Trio"),
+                ]
+            }
+        )
+        reconciler = ArtistReconciler(store, DiscogsClient(cache_dsn=None, api_base_url=None))
+
+        reconciler.reconcile_wikidata(wikidata)
+        entity = store.get_entity_by_qid("Q218981")
+        assert entity is not None
+        # The second candidate should not have been created
+        assert store.get_entity_by_qid("Q999999") is None
+
+    def test_empty_no_match_set(self, store: EntityStore):
+        store.upsert_artist("Autechre")  # unreconciled, not no_match
+        wikidata = _make_mock_wikidata_client({})
+        reconciler = ArtistReconciler(store, DiscogsClient(cache_dsn=None, api_base_url=None))
+
+        report = reconciler.reconcile_wikidata(wikidata)
+        assert report.total == 1
+        assert report.attempted == 0
+        assert report.succeeded == 0
+        assert report.skipped == 1
 
     def test_reuses_existing_entity_by_qid(self, store: EntityStore):
-        """If an entity already exists with the matching QID, reuses it."""
-        existing = store.get_or_create_entity(
-            "Autechre (electronic duo)", "artist", wikidata_qid="Q2774"
+        """If an entity with the QID already exists, links to it instead of creating a new one."""
+        existing = store.get_or_create_entity("Autechre", "artist", wikidata_qid="Q2774")
+        aid = store.upsert_artist("Autechre")
+        store.update_reconciliation_status(aid, "no_match")
+
+        wikidata = _make_mock_wikidata_client(
+            {"Autechre": [WikidataEntity(qid="Q2774", name="Autechre")]}
         )
-        store.upsert_artist("Autechre", discogs_artist_id=2774)
+        reconciler = ArtistReconciler(store, DiscogsClient(cache_dsn=None, api_base_url=None))
 
-        wikidata_client = MagicMock(spec=WikidataClient)
-        wikidata_client.lookup_by_discogs_ids.return_value = {
-            2774: WikidataEntity(qid="Q2774", name="Autechre", discogs_artist_id=2774),
-        }
-
-        client = DiscogsClient(cache_dsn=None, api_base_url=None)
-        reconciler = ArtistReconciler(store, client, wikidata_client=wikidata_client)
-
-        reconciler.reconcile_wikidata()
+        reconciler.reconcile_wikidata(wikidata)
         row = store.get_artist_by_name("Autechre")
         assert row["entity_id"] == existing.id
 
-    def test_no_wikidata_client_raises(self, store: EntityStore):
-        """reconcile_wikidata raises ValueError when no WikidataClient is configured."""
-        store.upsert_artist("Autechre", discogs_artist_id=2774)
-        client = DiscogsClient(cache_dsn=None, api_base_url=None)
-        reconciler = ArtistReconciler(store, client)
+    def test_multiple_artists_matched(self, store: EntityStore):
+        aid1 = store.upsert_artist("Autechre")
+        aid2 = store.upsert_artist("Father John Misty")
+        aid3 = store.upsert_artist("Jessica Pratt")
+        for aid in (aid1, aid2, aid3):
+            store.update_reconciliation_status(aid, "no_match")
 
-        with pytest.raises(ValueError, match="WikidataClient"):
-            reconciler.reconcile_wikidata()
+        wikidata = _make_mock_wikidata_client(
+            {
+                "Autechre": [WikidataEntity(qid="Q2774", name="Autechre")],
+                "Father John Misty": [WikidataEntity(qid="Q17070647", name="Father John Misty")],
+            }
+        )
+        reconciler = ArtistReconciler(store, DiscogsClient(cache_dsn=None, api_base_url=None))
 
-    def test_empty_artist_table(self, store: EntityStore):
-        wikidata_client = MagicMock(spec=WikidataClient)
-        client = DiscogsClient(cache_dsn=None, api_base_url=None)
-        reconciler = ArtistReconciler(store, client, wikidata_client=wikidata_client)
+        report = reconciler.reconcile_wikidata(wikidata)
+        assert report.succeeded == 2
+        assert report.no_match == 1
 
-        report = reconciler.reconcile_wikidata()
-        assert report.total == 0
-        assert report.attempted == 0
-        assert report.succeeded == 0
-        # lookup_by_discogs_ids should not be called with no IDs
-        wikidata_client.lookup_by_discogs_ids.assert_not_called()
+    def test_search_exception_counts_as_errored(self, store: EntityStore):
+        """If search_musician_by_name raises, the artist is counted as errored."""
+        aid = store.upsert_artist("Autechre")
+        store.update_reconciliation_status(aid, "no_match")
 
-    def test_wikidata_error_counts_as_errored(self, store: EntityStore):
-        store.upsert_artist("Autechre", discogs_artist_id=2774)
+        wikidata = MagicMock(spec=WikidataClient)
+        wikidata.search_musician_by_name.side_effect = Exception("Network error")
+        reconciler = ArtistReconciler(store, DiscogsClient(cache_dsn=None, api_base_url=None))
 
-        wikidata_client = MagicMock(spec=WikidataClient)
-        wikidata_client.lookup_by_discogs_ids.side_effect = Exception("SPARQL timeout")
-
-        client = DiscogsClient(cache_dsn=None, api_base_url=None)
-        reconciler = ArtistReconciler(store, client, wikidata_client=wikidata_client)
-
-        report = reconciler.reconcile_wikidata()
+        report = reconciler.reconcile_wikidata(wikidata)
         assert report.attempted == 1
         assert report.errored == 1
         assert report.succeeded == 0

--- a/tests/unit/test_wikidata_client.py
+++ b/tests/unit/test_wikidata_client.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import MagicMock, patch
 
-from semantic_index.wikidata_client import WikidataClient
+from semantic_index.wikidata_client import MUSICAL_GROUP_TYPES, MUSICIAN_OCCUPATIONS, WikidataClient
 
 
 def _sparql_response(bindings: list[dict]) -> dict:
@@ -433,3 +433,160 @@ class TestGracefulDegradation:
         # First batch succeeded, second failed
         assert len(result) == 1
         assert 2774 in result
+
+
+class TestSearchMusicianByName:
+    """Tests for musician-filtered name search (search + SPARQL P31/P106 validation)."""
+
+    def _make_search_response(self, items: list[dict]) -> dict:
+        """Build a mock wbsearchentities API response."""
+        return {"search": items}
+
+    def _make_filter_response(self, qids: list[str]) -> MagicMock:
+        """Build a mock SPARQL response that returns the given QIDs as musicians."""
+        resp = MagicMock()
+        resp.json.return_value = _sparql_response(
+            [{"item": _uri(qid), "itemLabel": _literal(qid)} for qid in qids]
+        )
+        return resp
+
+    def test_returns_musician_entity(self):
+        """A search result that passes the musician filter is returned."""
+        search_resp = MagicMock()
+        search_resp.json.return_value = self._make_search_response(
+            [{"id": "Q2774", "label": "Autechre", "description": "British electronic music duo"}]
+        )
+        filter_resp = self._make_filter_response(["Q2774"])
+
+        mock_client = MagicMock()
+        # First call: wbsearchentities; second call: SPARQL filter
+        mock_client.get.side_effect = [search_resp, filter_resp]
+
+        with patch("httpx.Client", return_value=mock_client):
+            client = WikidataClient()
+            result = client.search_musician_by_name("Autechre")
+
+        assert len(result) == 1
+        assert result[0].qid == "Q2774"
+        assert result[0].name == "Autechre"
+
+    def test_filters_out_non_musician(self):
+        """Search results that don't pass the musician filter are excluded."""
+        search_resp = MagicMock()
+        search_resp.json.return_value = self._make_search_response(
+            [
+                {"id": "Q218981", "label": "Cat Power", "description": "American singer"},
+                {"id": "Q999999", "label": "Cat Power (film)", "description": "2024 documentary"},
+            ]
+        )
+        # Only Q218981 passes the musician filter
+        filter_resp = self._make_filter_response(["Q218981"])
+
+        mock_client = MagicMock()
+        mock_client.get.side_effect = [search_resp, filter_resp]
+
+        with patch("httpx.Client", return_value=mock_client):
+            client = WikidataClient()
+            result = client.search_musician_by_name("Cat Power")
+
+        assert len(result) == 1
+        assert result[0].qid == "Q218981"
+
+    def test_no_search_results_returns_empty(self):
+        """If wbsearchentities returns nothing, result is empty without SPARQL call."""
+        search_resp = MagicMock()
+        search_resp.json.return_value = self._make_search_response([])
+
+        mock_client = MagicMock()
+        mock_client.get.return_value = search_resp
+
+        with patch("httpx.Client", return_value=mock_client):
+            client = WikidataClient()
+            result = client.search_musician_by_name("xyznonexistent")
+
+        assert result == []
+        # Only the search call, no SPARQL filter call
+        assert mock_client.get.call_count == 1
+
+    def test_no_musicians_among_results_returns_empty(self):
+        """If none of the search results are musicians, result is empty."""
+        search_resp = MagicMock()
+        search_resp.json.return_value = self._make_search_response(
+            [{"id": "Q12345", "label": "Stereolab", "description": "a place"}]
+        )
+        filter_resp = self._make_filter_response([])
+
+        mock_client = MagicMock()
+        mock_client.get.side_effect = [search_resp, filter_resp]
+
+        with patch("httpx.Client", return_value=mock_client):
+            client = WikidataClient()
+            result = client.search_musician_by_name("Stereolab")
+
+        assert result == []
+
+    def test_blank_name_returns_empty(self):
+        """Blank names skip both search and SPARQL."""
+        client = WikidataClient()
+        result = client.search_musician_by_name("   ")
+        assert result == []
+
+    def test_preserves_search_order(self):
+        """Results maintain the original search relevance order."""
+        search_resp = MagicMock()
+        search_resp.json.return_value = self._make_search_response(
+            [
+                {"id": "Q218981", "label": "Cat Power", "description": "American singer"},
+                {"id": "Q777777", "label": "Cat Power Trio", "description": "jazz trio"},
+            ]
+        )
+        # Both pass the filter, but SPARQL may return them in any order
+        filter_resp = self._make_filter_response(["Q777777", "Q218981"])
+
+        mock_client = MagicMock()
+        mock_client.get.side_effect = [search_resp, filter_resp]
+
+        with patch("httpx.Client", return_value=mock_client):
+            client = WikidataClient()
+            result = client.search_musician_by_name("Cat Power")
+
+        assert len(result) == 2
+        assert result[0].qid == "Q218981"  # original search order preserved
+        assert result[1].qid == "Q777777"
+
+    def test_sparql_error_returns_empty(self):
+        """If the SPARQL filter fails, gracefully return empty."""
+        search_resp = MagicMock()
+        search_resp.json.return_value = self._make_search_response(
+            [{"id": "Q2774", "label": "Autechre", "description": "duo"}]
+        )
+
+        mock_client = MagicMock()
+        # Search succeeds, then SPARQL filter raises
+        mock_client.get.side_effect = [search_resp, Exception("SPARQL timeout")]
+
+        with patch("httpx.Client", return_value=mock_client):
+            client = WikidataClient()
+            result = client.search_musician_by_name("Autechre")
+
+        assert result == []
+
+    def test_limit_passed_to_search(self):
+        """The limit parameter is forwarded to wbsearchentities."""
+        search_resp = MagicMock()
+        search_resp.json.return_value = self._make_search_response([])
+        mock_client = MagicMock()
+        mock_client.get.return_value = search_resp
+
+        with patch("httpx.Client", return_value=mock_client):
+            client = WikidataClient()
+            client.search_musician_by_name("Autechre", limit=5)
+
+        # The search call should have limit=5
+        search_call = mock_client.get.call_args_list[0]
+        assert search_call.kwargs["params"]["limit"] == 5
+
+    def test_constants_exported(self):
+        """Verify the filter constants are available for inspection."""
+        assert "Q639669" in MUSICIAN_OCCUPATIONS  # musician
+        assert "Q215380" in MUSICAL_GROUP_TYPES  # musical group/band


### PR DESCRIPTION
## Summary

- Adds `WikidataClient.search_musician_by_name()` — two-step musician-filtered search: `wbsearchentities` finds candidates, then a SPARQL query validates P31 (instance of human/musical group/duo) and P106 (musician-related occupation) to filter out non-musician entities
- Adds `ArtistReconciler.reconcile_wikidata()` — processes `no_match` artists by searching Wikidata, creating entity store entries with QIDs, and logging reconciliation events with source=`wikidata`, method=`name_search`
- Opt-in via `--wikidata-reconciliation` CLI flag in `run_pipeline.py`, runs after Discogs reconciliation tiers

## Test plan

- [x] 9 unit tests for `search_musician_by_name` (musician returned, non-musicians filtered, no results, blank input, order preservation, SPARQL error, limit forwarding, constants exported)
- [x] 12 unit tests for `reconcile_wikidata` (report counts, entity creation, artist linking, reconciliation log, status updates, only no_match processed, first result taken, existing entity reuse, multiple matches, error handling)
- [x] All 388 unit tests pass
- [x] ruff check + ruff format pass
- [x] mypy passes (pre-existing fastapi stub errors only)

Closes #71