### PR TITLE
Add label hierarchy population from Wikidata P749/P355

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,8 @@ SQLite ──→ api (FastAPI + aiosqlite) ──→ JSON responses
 | `semantic_index/discogs_client.py` | Two-tier Discogs client: discogs-cache PostgreSQL with library-metadata-lookup API fallback. |
 | `semantic_index/wikidata_client.py` | Wikidata SPARQL client: batched lookups by Discogs ID (P1953), influence relationships (P737), label hierarchy (P749/P355), and name search via wbsearchentities API. |
 | `semantic_index/entity_store.py` | Persistent entity store for reconciled artist identities: schema creation/migration, CRUD, artist upsert, reconciliation log, artist styles. Creates the artist table from scratch on a fresh database or migrates an existing one. |
-| `semantic_index/reconciliation.py` | Bulk Discogs matching for unreconciled artists via discogs-cache release_artist table, with member/group fallback via artist_member table. Wikidata reconciliation by Discogs ID (P1953) to populate entity QIDs. |
+| `semantic_index/reconciliation.py` | Bulk Discogs matching for unreconciled artists via discogs-cache release_artist table, with member/group fallback via artist_member table. |
+| `semantic_index/label_hierarchy.py` | Populate label and label_hierarchy tables from Wikidata P749/P355 relationships via Discogs label ID (P1902) lookups. |
 | `semantic_index/discogs_enrichment.py` | Aggregate Discogs metadata (styles, personnel, labels, compilations) per artist. |
 | `semantic_index/discogs_edges.py` | Compute Discogs-derived edges: shared personnel, shared style (Jaccard), label family, compilation co-appearance. |
 | `semantic_index/graph_export.py` | Build NetworkX graph and export GEXF. |
@@ -157,6 +158,7 @@ python run_pipeline.py dump.sql --entity-store-path output/wxyc_artist_graph.db 
 - `--entity-store-path PATH` — Path to entity store SQLite database. Creates it if needed.
 - `--skip-reconciliation` — Skip Discogs reconciliation step.
 - `--compute-discogs-edges` — Compute Discogs-derived edges (shared personnel, styles, labels, compilations). Off by default.
+- `--populate-label-hierarchy` — Populate label and label_hierarchy tables from Wikidata P749/P355. Requires `--entity-store-path` and enrichment data.
 
 ## Graph API
 

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -27,6 +27,7 @@ from semantic_index.discogs_edges import (
 from semantic_index.discogs_enrichment import DiscogsEnricher
 from semantic_index.entity_store import EntityStore
 from semantic_index.graph_export import build_graph, export_gexf, print_top_neighbors
+from semantic_index.label_hierarchy import populate_label_hierarchy
 from semantic_index.models import (
     FlowsheetEntry,
     LibraryCode,
@@ -114,6 +115,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help="Compute Discogs-derived edges (shared personnel, styles, labels, compilations). "
         "Off by default.",
+    )
+    parser.add_argument(
+        "--populate-label-hierarchy",
+        action="store_true",
+        help="Populate label and label_hierarchy tables from Wikidata P749/P355. "
+        "Requires --entity-store-path and enrichment data.",
     )
     return parser.parse_args(argv)
 
@@ -348,6 +355,7 @@ def run(args: argparse.Namespace) -> None:
     ss_edges = []
     lf_edges = []
     comp_edges = []
+    lh_report = None
 
     if not args.skip_enrichment and (args.discogs_cache_dsn or args.api_base_url):
         log.info("Setting up Discogs client...")
@@ -376,6 +384,25 @@ def run(args: argparse.Namespace) -> None:
             log.info("  %d compilation edges", len(comp_edges))
     elif not args.skip_enrichment:
         log.warning("Skipping Discogs enrichment: no cache DSN or API URL available")
+
+    # 10b. Label hierarchy from Wikidata (optional, requires entity store + enrichments)
+    if args.populate_label_hierarchy and entity_store is not None and enrichments:
+        from semantic_index.wikidata_client import WikidataClient
+
+        log.info("Populating label hierarchy from Wikidata P749/P355...")
+        wikidata_client = WikidataClient()
+        lh_report = populate_label_hierarchy(entity_store, enrichments, wikidata_client)
+        log.info(
+            "  %d labels created, %d matched to Wikidata, %d hierarchy edges",
+            lh_report.labels_created,
+            lh_report.labels_matched,
+            lh_report.hierarchy_edges,
+        )
+    elif args.populate_label_hierarchy:
+        if entity_store is None:
+            log.warning("Skipping label hierarchy: requires --entity-store-path")
+        elif not enrichments:
+            log.warning("Skipping label hierarchy: no enrichment data available")
 
     # 11. Print top neighbors for spotlight artists
     print_top_neighbors(edges, SPOTLIGHT_ARTISTS, n=20)
@@ -438,6 +465,10 @@ def run(args: argparse.Namespace) -> None:
             print(f"  Shared style edges:      {len(ss_edges):>12,}")
             print(f"  Label family edges:      {len(lf_edges):>12,}")
             print(f"  Compilation edges:       {len(comp_edges):>12,}")
+    if lh_report is not None:
+        print(f"  Labels created:          {lh_report.labels_created:>12,}")
+        print(f"  Labels matched (WD):     {lh_report.labels_matched:>12,}")
+        print(f"  Label hierarchy edges:   {lh_report.hierarchy_edges:>12,}")
     print(f"  Graph nodes:             {graph.number_of_nodes():>12,}")
     print(f"  Graph edges:             {graph.number_of_edges():>12,}")
     print(f"  GEXF output:             {gexf_path}")

--- a/semantic_index/entity_store.py
+++ b/semantic_index/entity_store.py
@@ -539,26 +539,121 @@ class EntityStore:
         return [row[0] for row in rows]
 
     # ------------------------------------------------------------------
-    # Wikidata Reconciliation Queries
+    # Label CRUD
     # ------------------------------------------------------------------
 
-    def get_artists_needing_wikidata(self) -> list[tuple[int, str, int]]:
-        """Return artists with a Discogs ID that lack a Wikidata QID.
+    def get_or_create_label(
+        self,
+        name: str,
+        *,
+        discogs_label_id: int | None = None,
+        wikidata_qid: str | None = None,
+    ) -> int:
+        """Return an existing label by name, or create a new one.
 
-        An artist "needs Wikidata" when it has ``discogs_artist_id IS NOT NULL``
-        and either has no linked entity or its entity has no ``wikidata_qid``.
+        On conflict (name), existing discogs_label_id is not overwritten.
+        If a wikidata_qid is provided, an entity row is also created/linked.
+
+        Args:
+            name: Label name (unique key).
+            discogs_label_id: Optional Discogs label ID.
+            wikidata_qid: Optional Wikidata QID. Creates an entity if provided.
 
         Returns:
-            List of ``(artist_id, canonical_name, discogs_artist_id)`` tuples.
+            The label row's integer primary key.
+        """
+        row = self._conn.execute("SELECT id FROM label WHERE name = ?", (name,)).fetchone()
+        if row is not None:
+            return int(row[0])
+
+        entity_id = None
+        if wikidata_qid:
+            entity = self.get_or_create_entity(name, "label", wikidata_qid=wikidata_qid)
+            entity_id = entity.id
+
+        cur = self._conn.execute(
+            "INSERT INTO label (name, discogs_label_id, entity_id) VALUES (?, ?, ?)",
+            (name, discogs_label_id, entity_id),
+        )
+        self._conn.commit()
+        return int(cur.lastrowid)  # type: ignore[arg-type]
+
+    def update_label_qid(self, label_id: int, wikidata_qid: str) -> None:
+        """Set the Wikidata QID for a label by creating/linking an entity.
+
+        Args:
+            label_id: The label's primary key.
+            wikidata_qid: The Wikidata QID to assign.
+
+        Raises:
+            ValueError: If no label with the given id exists.
+        """
+        row = self._conn.execute(
+            "SELECT id, name, entity_id FROM label WHERE id = ?", (label_id,)
+        ).fetchone()
+        if row is None:
+            raise ValueError(f"No label with id {label_id}")
+
+        label_name = row[1]
+        existing_entity_id = row[2]
+
+        if existing_entity_id is not None:
+            # Update the existing entity's QID
+            self._conn.execute(
+                "UPDATE entity SET wikidata_qid = COALESCE(wikidata_qid, ?), "
+                "updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') WHERE id = ?",
+                (wikidata_qid, existing_entity_id),
+            )
+        else:
+            entity = self.get_or_create_entity(label_name, "label", wikidata_qid=wikidata_qid)
+            self._conn.execute(
+                "UPDATE label SET entity_id = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') WHERE id = ?",
+                (entity.id, label_id),
+            )
+        self._conn.commit()
+
+    def insert_label_hierarchy(
+        self, parent_label_id: int, child_label_id: int, source: str = "wikidata"
+    ) -> None:
+        """Insert a parent-child label relationship (idempotent).
+
+        Args:
+            parent_label_id: The parent label's primary key.
+            child_label_id: The child label's primary key.
+            source: Source of the relationship (default: 'wikidata').
+        """
+        self._conn.execute(
+            "INSERT OR IGNORE INTO label_hierarchy (parent_label_id, child_label_id, source) VALUES (?, ?, ?)",
+            (parent_label_id, child_label_id, source),
+        )
+        self._conn.commit()
+
+    def get_labels_with_discogs_id(self) -> list[tuple[int, str, int]]:
+        """Return all labels that have a Discogs label ID.
+
+        Returns:
+            List of (label_id, name, discogs_label_id) tuples.
         """
         rows = self._conn.execute(
-            """SELECT a.id, a.canonical_name, a.discogs_artist_id
-               FROM artist a
-               LEFT JOIN entity e ON a.entity_id = e.id
-               WHERE a.discogs_artist_id IS NOT NULL
-               AND (a.entity_id IS NULL OR e.wikidata_qid IS NULL)"""
+            "SELECT id, name, discogs_label_id FROM label WHERE discogs_label_id IS NOT NULL"
         ).fetchall()
         return [(row[0], row[1], row[2]) for row in rows]
+
+    def get_label_by_name(self, name: str) -> dict[str, object] | None:
+        """Look up a label row by name.
+
+        Args:
+            name: The label name.
+
+        Returns:
+            A dict of column name -> value, or None if not found.
+        """
+        self._conn.row_factory = sqlite3.Row
+        row = self._conn.execute("SELECT * FROM label WHERE name = ?", (name,)).fetchone()
+        self._conn.row_factory = None
+        if row is None:
+            return None
+        return dict(row)
 
     # ------------------------------------------------------------------
     # Name-to-ID Mapping

--- a/semantic_index/label_hierarchy.py
+++ b/semantic_index/label_hierarchy.py
@@ -1,0 +1,143 @@
+"""Populate label and label_hierarchy tables from Wikidata P749/P355.
+
+Collects unique labels from Discogs enrichment data, resolves their Wikidata
+QIDs via Discogs label ID (P1902) lookups, queries Wikidata for parent
+organization (P749) and subsidiary (P355) relationships, and persists the
+results into the entity store's ``label`` and ``label_hierarchy`` tables.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from semantic_index.models import LabelHierarchyReport
+
+if TYPE_CHECKING:
+    from semantic_index.entity_store import EntityStore
+    from semantic_index.models import ArtistEnrichment
+    from semantic_index.wikidata_client import WikidataClient
+
+logger = logging.getLogger(__name__)
+
+
+def populate_label_hierarchy(
+    entity_store: EntityStore,
+    enrichments: dict[str, ArtistEnrichment],
+    wikidata_client: WikidataClient,
+) -> LabelHierarchyReport:
+    """Populate label and label_hierarchy tables from enrichment data and Wikidata.
+
+    Steps:
+        1. Collect unique labels (name + Discogs label ID) from enrichments.
+        2. Insert them into the entity store's ``label`` table.
+        3. Look up Wikidata QIDs for labels with Discogs IDs (via P1902).
+        4. Link matched QIDs to label rows.
+        5. Query Wikidata for P749/P355 hierarchy relationships.
+        6. Insert hierarchy edges (creating parent/child labels as needed).
+
+    Args:
+        entity_store: The EntityStore managing the SQLite database.
+        enrichments: Discogs enrichment data keyed by canonical artist name.
+        wikidata_client: WikidataClient for SPARQL lookups.
+
+    Returns:
+        A LabelHierarchyReport summarizing what was created.
+    """
+    if not enrichments:
+        return LabelHierarchyReport(labels_created=0, labels_matched=0, hierarchy_edges=0)
+
+    # Step 1: Collect unique labels from enrichments
+    # Map label_name -> discogs_label_id (first non-None wins)
+    unique_labels: dict[str, int | None] = {}
+    for enrich in enrichments.values():
+        for label in enrich.labels:
+            if label.name not in unique_labels:
+                unique_labels[label.name] = label.label_id
+            elif unique_labels[label.name] is None and label.label_id is not None:
+                unique_labels[label.name] = label.label_id
+
+    logger.info("Collected %d unique labels from enrichments", len(unique_labels))
+
+    # Step 2: Insert labels into entity store
+    label_name_to_id: dict[str, int] = {}
+    for name, discogs_id in unique_labels.items():
+        label_name_to_id[name] = entity_store.get_or_create_label(name, discogs_label_id=discogs_id)
+
+    labels_created = len(label_name_to_id)
+
+    # Step 3: Look up Wikidata QIDs for labels with Discogs IDs
+    discogs_ids = [did for did in unique_labels.values() if did is not None]
+    qid_map = wikidata_client.lookup_labels_by_discogs_ids(discogs_ids)
+    logger.info("Wikidata matched %d / %d labels with Discogs IDs", len(qid_map), len(discogs_ids))
+
+    # Step 4: Link QIDs to label rows
+    # Build discogs_id -> label_name reverse map
+    discogs_to_name: dict[int, str] = {}
+    for name, did in unique_labels.items():
+        if did is not None:
+            discogs_to_name[did] = name
+
+    qid_to_label_name: dict[str, str] = {}
+    for discogs_id, wd_entity in qid_map.items():
+        label_name = discogs_to_name.get(discogs_id)
+        if label_name is None:
+            continue
+        label_id = label_name_to_id[label_name]
+        entity_store.update_label_qid(label_id, wd_entity.qid)
+        qid_to_label_name[wd_entity.qid] = label_name
+
+    labels_matched = len(qid_map)
+
+    # Step 5: Query Wikidata for hierarchy relationships
+    matched_qids = list(qid_to_label_name.keys())
+    if not matched_qids:
+        logger.info("No labels matched to Wikidata; skipping hierarchy query")
+        return LabelHierarchyReport(
+            labels_created=labels_created,
+            labels_matched=labels_matched,
+            hierarchy_edges=0,
+        )
+
+    hierarchy = wikidata_client.get_label_hierarchy(matched_qids)
+    logger.info("Wikidata returned %d hierarchy relationships", len(hierarchy))
+
+    # Step 6: Insert hierarchy edges
+    hierarchy_edges = 0
+    for rel in hierarchy:
+        # Ensure parent label exists
+        parent_name = rel.parent_name
+        if parent_name not in label_name_to_id:
+            label_name_to_id[parent_name] = entity_store.get_or_create_label(
+                parent_name, wikidata_qid=rel.parent_qid
+            )
+        else:
+            entity_store.update_label_qid(label_name_to_id[parent_name], rel.parent_qid)
+
+        # Ensure child label exists
+        child_name = rel.child_name
+        if child_name not in label_name_to_id:
+            label_name_to_id[child_name] = entity_store.get_or_create_label(
+                child_name, wikidata_qid=rel.child_qid
+            )
+        else:
+            entity_store.update_label_qid(label_name_to_id[child_name], rel.child_qid)
+
+        entity_store.insert_label_hierarchy(
+            label_name_to_id[parent_name],
+            label_name_to_id[child_name],
+        )
+        hierarchy_edges += 1
+
+    logger.info(
+        "Label hierarchy: %d labels, %d matched, %d edges",
+        labels_created,
+        labels_matched,
+        hierarchy_edges,
+    )
+
+    return LabelHierarchyReport(
+        labels_created=labels_created,
+        labels_matched=labels_matched,
+        hierarchy_edges=hierarchy_edges,
+    )

--- a/semantic_index/models.py
+++ b/semantic_index/models.py
@@ -280,3 +280,11 @@ class WikidataLabelHierarchy(BaseModel):
     parent_name: str
     child_qid: str
     child_name: str
+
+
+class LabelHierarchyReport(BaseModel):
+    """Summary of a label hierarchy population run."""
+
+    labels_created: int  # Unique labels inserted into the label table
+    labels_matched: int  # Labels matched to Wikidata QIDs
+    hierarchy_edges: int  # Parent-child relationships inserted

--- a/semantic_index/wikidata_client.py
+++ b/semantic_index/wikidata_client.py
@@ -189,6 +189,58 @@ class WikidataClient:
 
         return result
 
+    def lookup_labels_by_discogs_ids(
+        self, discogs_label_ids: list[int]
+    ) -> dict[int, WikidataEntity]:
+        """Look up Wikidata entities by Discogs label ID (P1902).
+
+        Batches the lookup into chunks of ``batch_size`` to avoid SPARQL
+        query timeouts on large input sets.
+
+        Args:
+            discogs_label_ids: Discogs label IDs to look up.
+
+        Returns:
+            Dict mapping discogs_label_id -> WikidataEntity for each found match.
+        """
+        if not discogs_label_ids:
+            return {}
+
+        result: dict[int, WikidataEntity] = {}
+        for batch_start in range(0, len(discogs_label_ids), self._batch_size):
+            batch = discogs_label_ids[batch_start : batch_start + self._batch_size]
+            values = " ".join(f'"{lid}"' for lid in batch)
+            query = (
+                "SELECT ?item ?itemLabel ?discogsLabelId WHERE {\n"
+                f"  VALUES ?discogsLabelId {{ {values} }}\n"
+                "  ?item wdt:P1902 ?discogsLabelId .\n"
+                '  SERVICE wikibase:label { bd:serviceParam wikibase:language "en" . }\n'
+                "}"
+            )
+            try:
+                bindings = self._sparql_query(query)
+                for b in bindings:
+                    qid = _extract_qid(_binding_value(b, "item") or "")
+                    name = _binding_value(b, "itemLabel") or qid
+                    label_id_str = _binding_value(b, "discogsLabelId")
+                    if label_id_str is not None:
+                        try:
+                            lid = int(label_id_str)
+                        except (ValueError, TypeError):
+                            continue
+                        result[lid] = WikidataEntity(
+                            qid=qid,
+                            name=name,
+                        )
+            except Exception:
+                logger.warning(
+                    "SPARQL lookup_labels_by_discogs_ids failed for batch starting at %d",
+                    batch_start,
+                    exc_info=True,
+                )
+
+        return result
+
     def get_influences(self, qids: list[str]) -> list[WikidataInfluence]:
         """Get influence relationships (P737) for given Wikidata entities.
 

--- a/tests/unit/test_entity_store_labels.py
+++ b/tests/unit/test_entity_store_labels.py
@@ -1,0 +1,174 @@
+"""Tests for EntityStore label and label_hierarchy CRUD operations."""
+
+import sqlite3
+
+import pytest
+
+from semantic_index.entity_store import EntityStore
+
+# The old artist schema — matches sqlite_export._SCHEMA artist table
+_OLD_ARTIST_SCHEMA = """
+CREATE TABLE artist (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    canonical_name TEXT NOT NULL UNIQUE,
+    genre TEXT,
+    total_plays INTEGER NOT NULL DEFAULT 0,
+    active_first_year INTEGER,
+    active_last_year INTEGER,
+    dj_count INTEGER NOT NULL DEFAULT 0,
+    request_ratio REAL NOT NULL DEFAULT 0.0,
+    show_count INTEGER NOT NULL DEFAULT 0,
+    discogs_artist_id INTEGER
+);
+"""
+
+
+@pytest.fixture()
+def store(tmp_path) -> EntityStore:
+    """An initialized EntityStore with a pre-migrated artist table."""
+    db_path = str(tmp_path / "test.db")
+    conn = sqlite3.connect(db_path)
+    conn.executescript(_OLD_ARTIST_SCHEMA)
+    conn.close()
+    s = EntityStore(db_path)
+    s.initialize()
+    return s
+
+
+class TestGetOrCreateLabel:
+    def test_creates_new_label(self, store: EntityStore):
+        label_id = store.get_or_create_label("Warp Records")
+        assert isinstance(label_id, int)
+        row = store._conn.execute("SELECT name FROM label WHERE id = ?", (label_id,)).fetchone()
+        assert row[0] == "Warp Records"
+
+    def test_returns_existing_label(self, store: EntityStore):
+        first = store.get_or_create_label("Warp Records")
+        second = store.get_or_create_label("Warp Records")
+        assert first == second
+
+    def test_with_discogs_label_id(self, store: EntityStore):
+        label_id = store.get_or_create_label("Warp Records", discogs_label_id=23528)
+        row = store._conn.execute(
+            "SELECT discogs_label_id FROM label WHERE id = ?", (label_id,)
+        ).fetchone()
+        assert row[0] == 23528
+
+    def test_with_wikidata_qid_creates_entity(self, store: EntityStore):
+        label_id = store.get_or_create_label(
+            "Warp Records", discogs_label_id=23528, wikidata_qid="Q1312934"
+        )
+        row = store._conn.execute(
+            "SELECT entity_id FROM label WHERE id = ?", (label_id,)
+        ).fetchone()
+        assert row[0] is not None
+        # Entity should exist with the QID
+        entity = store.get_entity_by_qid("Q1312934")
+        assert entity is not None
+        assert entity.name == "Warp Records"
+        assert entity.entity_type == "label"
+
+    def test_does_not_overwrite_existing_discogs_id(self, store: EntityStore):
+        store.get_or_create_label("Warp Records", discogs_label_id=23528)
+        store.get_or_create_label("Warp Records", discogs_label_id=99999)
+        row = store._conn.execute(
+            "SELECT discogs_label_id FROM label WHERE name = 'Warp Records'"
+        ).fetchone()
+        assert row[0] == 23528
+
+
+class TestUpdateLabelQid:
+    def test_updates_qid(self, store: EntityStore):
+        label_id = store.get_or_create_label("Sub Pop")
+        store.update_label_qid(label_id, "Q843988")
+        row = store._conn.execute(
+            "SELECT entity_id FROM label WHERE id = ?", (label_id,)
+        ).fetchone()
+        assert row[0] is not None
+        entity = store.get_entity_by_qid("Q843988")
+        assert entity is not None
+        assert entity.entity_type == "label"
+
+    def test_nonexistent_label_raises(self, store: EntityStore):
+        with pytest.raises(ValueError, match="No label with id"):
+            store.update_label_qid(9999, "Q12345")
+
+    def test_idempotent_for_same_qid(self, store: EntityStore):
+        label_id = store.get_or_create_label("Drag City")
+        store.update_label_qid(label_id, "Q1254087")
+        store.update_label_qid(label_id, "Q1254087")  # Should not raise
+        entity = store.get_entity_by_qid("Q1254087")
+        assert entity is not None
+
+
+class TestInsertLabelHierarchy:
+    def test_inserts_relationship(self, store: EntityStore):
+        parent_id = store.get_or_create_label("Universal Music Group")
+        child_id = store.get_or_create_label("Warp Records")
+        store.insert_label_hierarchy(parent_id, child_id)
+        row = store._conn.execute(
+            "SELECT parent_label_id, child_label_id, source FROM label_hierarchy"
+        ).fetchone()
+        assert row[0] == parent_id
+        assert row[1] == child_id
+        assert row[2] == "wikidata"
+
+    def test_custom_source(self, store: EntityStore):
+        parent_id = store.get_or_create_label("Universal Music Group")
+        child_id = store.get_or_create_label("Sub Pop")
+        store.insert_label_hierarchy(parent_id, child_id, source="discogs")
+        row = store._conn.execute(
+            "SELECT source FROM label_hierarchy WHERE parent_label_id = ? AND child_label_id = ?",
+            (parent_id, child_id),
+        ).fetchone()
+        assert row[0] == "discogs"
+
+    def test_idempotent(self, store: EntityStore):
+        parent_id = store.get_or_create_label("Universal Music Group")
+        child_id = store.get_or_create_label("Warp Records")
+        store.insert_label_hierarchy(parent_id, child_id)
+        store.insert_label_hierarchy(parent_id, child_id)  # Should not raise
+        count = store._conn.execute("SELECT COUNT(*) FROM label_hierarchy").fetchone()[0]
+        assert count == 1
+
+    def test_multiple_children(self, store: EntityStore):
+        parent_id = store.get_or_create_label("Universal Music Group")
+        child1 = store.get_or_create_label("Warp Records")
+        child2 = store.get_or_create_label("Sub Pop")
+        store.insert_label_hierarchy(parent_id, child1)
+        store.insert_label_hierarchy(parent_id, child2)
+        count = store._conn.execute(
+            "SELECT COUNT(*) FROM label_hierarchy WHERE parent_label_id = ?",
+            (parent_id,),
+        ).fetchone()[0]
+        assert count == 2
+
+
+class TestGetLabelsWithDiscogsId:
+    def test_returns_labels_with_discogs_ids(self, store: EntityStore):
+        store.get_or_create_label("Warp Records", discogs_label_id=23528)
+        store.get_or_create_label("Sub Pop", discogs_label_id=1594)
+        store.get_or_create_label("Self-Released")  # No Discogs ID
+        labels = store.get_labels_with_discogs_id()
+        assert len(labels) == 2
+        ids = {lid for lid, _, _ in labels}
+        names = {name for _, name, _ in labels}
+        assert names == {"Warp Records", "Sub Pop"}
+        assert all(isinstance(lid, int) for lid in ids)
+
+    def test_empty_when_no_labels(self, store: EntityStore):
+        labels = store.get_labels_with_discogs_id()
+        assert labels == []
+
+
+class TestGetLabelByName:
+    def test_found(self, store: EntityStore):
+        store.get_or_create_label("Matador Records", discogs_label_id=2064)
+        label = store.get_label_by_name("Matador Records")
+        assert label is not None
+        assert label["name"] == "Matador Records"
+        assert label["discogs_label_id"] == 2064
+
+    def test_not_found(self, store: EntityStore):
+        label = store.get_label_by_name("Nonexistent Label")
+        assert label is None

--- a/tests/unit/test_label_hierarchy.py
+++ b/tests/unit/test_label_hierarchy.py
@@ -1,0 +1,223 @@
+"""Tests for the label hierarchy population module."""
+
+import sqlite3
+from unittest.mock import MagicMock
+
+import pytest
+
+from semantic_index.entity_store import EntityStore
+from semantic_index.label_hierarchy import populate_label_hierarchy
+from semantic_index.models import (
+    ArtistEnrichment,
+    LabelInfo,
+    WikidataEntity,
+    WikidataLabelHierarchy,
+)
+
+# Old artist schema for EntityStore migration
+_OLD_ARTIST_SCHEMA = """
+CREATE TABLE artist (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    canonical_name TEXT NOT NULL UNIQUE,
+    genre TEXT,
+    total_plays INTEGER NOT NULL DEFAULT 0,
+    active_first_year INTEGER,
+    active_last_year INTEGER,
+    dj_count INTEGER NOT NULL DEFAULT 0,
+    request_ratio REAL NOT NULL DEFAULT 0.0,
+    show_count INTEGER NOT NULL DEFAULT 0,
+    discogs_artist_id INTEGER
+);
+"""
+
+
+@pytest.fixture()
+def store(tmp_path) -> EntityStore:
+    db_path = str(tmp_path / "test.db")
+    conn = sqlite3.connect(db_path)
+    conn.executescript(_OLD_ARTIST_SCHEMA)
+    conn.close()
+    s = EntityStore(db_path)
+    s.initialize()
+    return s
+
+
+def _make_enrichments(
+    labels: dict[str, list[tuple[str, int | None]]],
+) -> dict[str, ArtistEnrichment]:
+    """Build enrichments dict. labels maps artist_name -> [(label_name, discogs_label_id), ...]."""
+    result = {}
+    for artist_name, label_list in labels.items():
+        result[artist_name] = ArtistEnrichment(
+            canonical_name=artist_name,
+            labels=[LabelInfo(name=n, label_id=lid) for n, lid in label_list],
+        )
+    return result
+
+
+class TestPopulateLabelHierarchy:
+    def test_creates_labels_from_enrichments(self, store: EntityStore):
+        enrichments = _make_enrichments(
+            {
+                "Autechre": [("Warp Records", 23528)],
+                "Father John Misty": [("Sub Pop", 1594)],
+            }
+        )
+        wikidata_client = MagicMock()
+        wikidata_client.lookup_labels_by_discogs_ids.return_value = {}
+        wikidata_client.get_label_hierarchy.return_value = []
+
+        populate_label_hierarchy(store, enrichments, wikidata_client)
+
+        warp = store.get_label_by_name("Warp Records")
+        assert warp is not None
+        assert warp["discogs_label_id"] == 23528
+
+        subpop = store.get_label_by_name("Sub Pop")
+        assert subpop is not None
+        assert subpop["discogs_label_id"] == 1594
+
+    def test_links_wikidata_qids_to_labels(self, store: EntityStore):
+        enrichments = _make_enrichments({"Autechre": [("Warp Records", 23528)]})
+        wikidata_client = MagicMock()
+        wikidata_client.lookup_labels_by_discogs_ids.return_value = {
+            23528: WikidataEntity(qid="Q1312934", name="Warp Records"),
+        }
+        wikidata_client.get_label_hierarchy.return_value = []
+
+        populate_label_hierarchy(store, enrichments, wikidata_client)
+
+        warp = store.get_label_by_name("Warp Records")
+        assert warp is not None
+        assert warp["entity_id"] is not None
+        entity = store.get_entity_by_qid("Q1312934")
+        assert entity is not None
+        assert entity.name == "Warp Records"
+
+    def test_populates_hierarchy(self, store: EntityStore):
+        enrichments = _make_enrichments(
+            {
+                "Autechre": [("Warp Records", 23528)],
+                "Father John Misty": [("Sub Pop", 1594)],
+            }
+        )
+        wikidata_client = MagicMock()
+        wikidata_client.lookup_labels_by_discogs_ids.return_value = {
+            23528: WikidataEntity(qid="Q1312934", name="Warp Records"),
+            1594: WikidataEntity(qid="Q843988", name="Sub Pop"),
+        }
+        wikidata_client.get_label_hierarchy.return_value = [
+            WikidataLabelHierarchy(
+                parent_qid="Q21077",
+                parent_name="Universal Music Group",
+                child_qid="Q1312934",
+                child_name="Warp Records",
+            ),
+            WikidataLabelHierarchy(
+                parent_qid="Q21077",
+                parent_name="Universal Music Group",
+                child_qid="Q843988",
+                child_name="Sub Pop",
+            ),
+        ]
+
+        populate_label_hierarchy(store, enrichments, wikidata_client)
+
+        # Parent label should be auto-created
+        umg = store.get_label_by_name("Universal Music Group")
+        assert umg is not None
+
+        # Hierarchy rows should exist
+        rows = store._conn.execute("SELECT COUNT(*) FROM label_hierarchy").fetchone()
+        assert rows[0] == 2
+
+    def test_skips_labels_without_discogs_id(self, store: EntityStore):
+        enrichments = _make_enrichments({"Autechre": [("Self-Released", None)]})
+        wikidata_client = MagicMock()
+        wikidata_client.lookup_labels_by_discogs_ids.return_value = {}
+        wikidata_client.get_label_hierarchy.return_value = []
+
+        populate_label_hierarchy(store, enrichments, wikidata_client)
+
+        # Label should still be created but no Discogs lookup attempted
+        label = store.get_label_by_name("Self-Released")
+        assert label is not None
+        assert label["discogs_label_id"] is None
+        # Should have called with empty list (no Discogs IDs to look up)
+        wikidata_client.lookup_labels_by_discogs_ids.assert_called_once_with([])
+
+    def test_empty_enrichments(self, store: EntityStore):
+        wikidata_client = MagicMock()
+        populate_label_hierarchy(store, {}, wikidata_client)
+        wikidata_client.lookup_labels_by_discogs_ids.assert_not_called()
+        wikidata_client.get_label_hierarchy.assert_not_called()
+
+    def test_deduplicates_labels_across_artists(self, store: EntityStore):
+        enrichments = _make_enrichments(
+            {
+                "Autechre": [("Warp Records", 23528)],
+                "Boards of Canada": [("Warp Records", 23528)],
+            }
+        )
+        wikidata_client = MagicMock()
+        wikidata_client.lookup_labels_by_discogs_ids.return_value = {}
+        wikidata_client.get_label_hierarchy.return_value = []
+
+        populate_label_hierarchy(store, enrichments, wikidata_client)
+
+        count = store._conn.execute(
+            "SELECT COUNT(*) FROM label WHERE name = 'Warp Records'"
+        ).fetchone()[0]
+        assert count == 1
+
+    def test_hierarchy_parent_from_outside_enrichments(self, store: EntityStore):
+        """Parent labels not in enrichments should still be created."""
+        enrichments = _make_enrichments({"Autechre": [("Warp Records", 23528)]})
+        wikidata_client = MagicMock()
+        wikidata_client.lookup_labels_by_discogs_ids.return_value = {
+            23528: WikidataEntity(qid="Q1312934", name="Warp Records"),
+        }
+        wikidata_client.get_label_hierarchy.return_value = [
+            WikidataLabelHierarchy(
+                parent_qid="Q21077",
+                parent_name="Universal Music Group",
+                child_qid="Q1312934",
+                child_name="Warp Records",
+            ),
+        ]
+
+        populate_label_hierarchy(store, enrichments, wikidata_client)
+
+        umg = store.get_label_by_name("Universal Music Group")
+        assert umg is not None
+        entity = store.get_entity_by_qid("Q21077")
+        assert entity is not None
+        assert entity.entity_type == "label"
+
+    def test_returns_report(self, store: EntityStore):
+        enrichments = _make_enrichments(
+            {
+                "Autechre": [("Warp Records", 23528)],
+                "Father John Misty": [("Sub Pop", 1594)],
+                "Jessica Pratt": [("Drag City", 1218)],
+            }
+        )
+        wikidata_client = MagicMock()
+        wikidata_client.lookup_labels_by_discogs_ids.return_value = {
+            23528: WikidataEntity(qid="Q1312934", name="Warp Records"),
+            1594: WikidataEntity(qid="Q843988", name="Sub Pop"),
+        }
+        wikidata_client.get_label_hierarchy.return_value = [
+            WikidataLabelHierarchy(
+                parent_qid="Q21077",
+                parent_name="Universal Music Group",
+                child_qid="Q1312934",
+                child_name="Warp Records",
+            ),
+        ]
+
+        report = populate_label_hierarchy(store, enrichments, wikidata_client)
+
+        assert report.labels_created == 3
+        assert report.labels_matched == 2  # Warp + Sub Pop got QIDs
+        assert report.hierarchy_edges == 1

--- a/tests/unit/test_wikidata_client.py
+++ b/tests/unit/test_wikidata_client.py
@@ -162,6 +162,86 @@ class TestGetInfluences:
         assert result[0].source_qid == "Q2774"
 
 
+class TestLookupLabelsByDiscogsIds:
+    """Tests for Discogs label ID (P1902) lookups."""
+
+    def test_single_label_returns_entity(self):
+        mock_response = MagicMock()
+        mock_response.json.return_value = _sparql_response(
+            [
+                {
+                    "item": _uri("Q1312934"),
+                    "itemLabel": _literal("Warp Records"),
+                    "discogsLabelId": _literal("23528"),
+                },
+            ]
+        )
+        mock_client = MagicMock()
+        mock_client.get.return_value = mock_response
+
+        with patch("httpx.Client", return_value=mock_client):
+            client = WikidataClient()
+            result = client.lookup_labels_by_discogs_ids([23528])
+
+        assert 23528 in result
+        assert result[23528].qid == "Q1312934"
+        assert result[23528].name == "Warp Records"
+
+    def test_multiple_labels(self):
+        mock_response = MagicMock()
+        mock_response.json.return_value = _sparql_response(
+            [
+                {
+                    "item": _uri("Q1312934"),
+                    "itemLabel": _literal("Warp Records"),
+                    "discogsLabelId": _literal("23528"),
+                },
+                {
+                    "item": _uri("Q843988"),
+                    "itemLabel": _literal("Sub Pop"),
+                    "discogsLabelId": _literal("1594"),
+                },
+            ]
+        )
+        mock_client = MagicMock()
+        mock_client.get.return_value = mock_response
+
+        with patch("httpx.Client", return_value=mock_client):
+            client = WikidataClient()
+            result = client.lookup_labels_by_discogs_ids([23528, 1594])
+
+        assert len(result) == 2
+        assert result[23528].name == "Warp Records"
+        assert result[1594].name == "Sub Pop"
+
+    def test_empty_input_returns_empty(self):
+        client = WikidataClient()
+        result = client.lookup_labels_by_discogs_ids([])
+        assert result == {}
+
+    def test_not_found_returns_empty(self):
+        mock_response = MagicMock()
+        mock_response.json.return_value = _sparql_response([])
+        mock_client = MagicMock()
+        mock_client.get.return_value = mock_response
+
+        with patch("httpx.Client", return_value=mock_client):
+            client = WikidataClient()
+            result = client.lookup_labels_by_discogs_ids([99999])
+
+        assert result == {}
+
+    def test_sparql_error_returns_empty(self):
+        mock_client = MagicMock()
+        mock_client.get.side_effect = Exception("Timeout")
+
+        with patch("httpx.Client", return_value=mock_client):
+            client = WikidataClient()
+            result = client.lookup_labels_by_discogs_ids([23528])
+
+        assert result == {}
+
+
 class TestGetLabelHierarchy:
     """Tests for label hierarchy (P749/P355) queries."""
 


### PR DESCRIPTION
## Summary

- Add `WikidataClient.lookup_labels_by_discogs_ids()` for batched Wikidata SPARQL lookups using Discogs label ID property P1902
- Add label CRUD methods to `EntityStore`: `get_or_create_label`, `update_label_qid`, `insert_label_hierarchy`, `get_labels_with_discogs_id`, `get_label_by_name`
- Add `semantic_index/label_hierarchy.py` orchestration module that collects unique labels from enrichment data, resolves Wikidata QIDs, queries P749/P355 hierarchy, and persists results
- Add `--populate-label-hierarchy` pipeline flag (requires `--entity-store-path` and enrichment data)

Closes #73

## Test plan

- [x] 5 unit tests for `WikidataClient.lookup_labels_by_discogs_ids()` (single label, multiple, empty, not found, SPARQL error)
- [x] 16 unit tests for `EntityStore` label CRUD (get_or_create_label, update_label_qid, insert_label_hierarchy, get_labels_with_discogs_id, get_label_by_name)
- [x] 8 unit tests for `populate_label_hierarchy()` orchestration (creates labels, links QIDs, populates hierarchy, handles edge cases, returns report)
- [x] All 396 unit tests pass
- [x] ruff check clean
- [x] ruff format clean
- [x] mypy clean