### PR TITLE
Add wikidata-cache support to WikidataClient

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -84,6 +84,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default="https://library-metadata-lookup-staging.up.railway.app",
         help="Base URL for library-metadata-lookup API",
     )
+    parser.add_argument(
+        "--wikidata-cache-dsn",
+        default=os.environ.get("DATABASE_URL_WIKIDATA"),
+        help="PostgreSQL DSN for wikidata-cache (default: DATABASE_URL_WIKIDATA env var)",
+    )
     parser.add_argument("--skip-enrichment", action="store_true", help="Skip Discogs enrichment")
     parser.add_argument(
         "--min-jaccard", type=float, default=0.1, help="Minimum Jaccard for shared style edges"
@@ -443,7 +448,7 @@ def run(args: argparse.Namespace) -> None:
         # 5e. Wikidata name search for remaining no_match artists (opt-in)
         if args.wikidata_reconciliation:
             log.info("Running Wikidata name search for no_match artists...")
-            wikidata_client = WikidataClient()
+            wikidata_client = WikidataClient(cache_dsn=args.wikidata_cache_dsn)
             wikidata_report = reconciler.reconcile_wikidata(wikidata_client)
             log.info(
                 "Wikidata reconciliation: %d attempted, %d succeeded, %d no_match, %d errored",
@@ -576,7 +581,7 @@ def run(args: argparse.Namespace) -> None:
     # 10b. Label hierarchy from Wikidata (optional, requires entity store + enrichments)
     if args.populate_label_hierarchy and entity_store is not None and enrichments:
         log.info("Populating label hierarchy from Wikidata P749/P355...")
-        wikidata_client = WikidataClient()
+        wikidata_client = WikidataClient(cache_dsn=args.wikidata_cache_dsn)
         lh_report = populate_label_hierarchy(entity_store, enrichments, wikidata_client)
         log.info(
             "  %d labels created, %d matched to Wikidata, %d hierarchy edges",
@@ -595,7 +600,7 @@ def run(args: argparse.Namespace) -> None:
         from semantic_index.wikidata_influence import extract_wikidata_influences
 
         log.info("Querying Wikidata P737 influence relationships...")
-        wikidata_client = WikidataClient()
+        wikidata_client = WikidataClient(cache_dsn=args.wikidata_cache_dsn)
 
         # Collect all QIDs from the entity store
         qid_rows = entity_store._conn.execute(

--- a/semantic_index/wikidata_client.py
+++ b/semantic_index/wikidata_client.py
@@ -13,6 +13,7 @@ import re
 import time
 
 import httpx
+import psycopg
 
 from semantic_index.models import (
     WikidataEntity,
@@ -103,12 +104,27 @@ class WikidataClient:
         api_endpoint: str | None = None,
         user_agent: str | None = None,
         batch_size: int = 50,
+        cache_dsn: str | None = None,
     ) -> None:
         self._sparql_endpoint = sparql_endpoint or self._DEFAULT_SPARQL_ENDPOINT
         self._api_endpoint = api_endpoint or self._DEFAULT_API_ENDPOINT
         self._user_agent = user_agent or self._DEFAULT_USER_AGENT
         self._batch_size = batch_size
         self._last_request: float = 0
+        self._cache_dsn = cache_dsn
+        self._cache_conn: psycopg.Connection | None = None
+
+    def _get_cache_conn(self) -> psycopg.Connection | None:
+        """Get or create the wikidata-cache PostgreSQL connection."""
+        if self._cache_dsn is None:
+            return None
+        if self._cache_conn is None or self._cache_conn.closed:
+            try:
+                self._cache_conn = psycopg.connect(self._cache_dsn, autocommit=True)
+            except Exception:
+                logger.warning("Failed to connect to wikidata-cache", exc_info=True)
+                return None
+        return self._cache_conn
 
     def _rate_limit(self) -> None:
         """Sleep to respect Wikidata's rate limit (~1 req/s)."""
@@ -181,8 +197,8 @@ class WikidataClient:
     def lookup_by_discogs_ids(self, discogs_ids: list[int]) -> dict[int, WikidataEntity]:
         """Look up Wikidata entities by Discogs artist ID (P1953).
 
-        Batches the lookup into chunks of ``batch_size`` to avoid SPARQL
-        query timeouts on large input sets.
+        Cache-first: queries the wikidata-cache PostgreSQL if available,
+        then falls back to SPARQL for any IDs not found in the cache.
 
         Args:
             discogs_ids: Discogs artist IDs to look up.
@@ -194,8 +210,49 @@ class WikidataClient:
             return {}
 
         result: dict[int, WikidataEntity] = {}
-        for batch_start in range(0, len(discogs_ids), self._batch_size):
-            batch = discogs_ids[batch_start : batch_start + self._batch_size]
+        remaining_ids = list(discogs_ids)
+
+        # Try cache first
+        conn = self._get_cache_conn()
+        if conn is not None:
+            try:
+                str_ids = [str(did) for did in discogs_ids]
+                rows = conn.execute(
+                    "SELECT e.qid, e.label, e.description, dm.discogs_id "
+                    "FROM discogs_mapping dm "
+                    "JOIN entity e ON dm.qid = e.qid "
+                    "WHERE dm.property = 'P1953' AND dm.discogs_id = ANY(%s)",
+                    (str_ids,),
+                ).fetchall()
+                for qid, label, description, discogs_id_str in rows:
+                    try:
+                        did = int(discogs_id_str)
+                    except (ValueError, TypeError):
+                        continue
+                    result[did] = WikidataEntity(
+                        qid=qid,
+                        name=label or qid,
+                        description=description,
+                        discogs_artist_id=did,
+                    )
+                remaining_ids = [did for did in discogs_ids if did not in result]
+                if remaining_ids:
+                    logger.debug(
+                        "Wikidata cache: %d/%d found, %d remaining for SPARQL",
+                        len(result),
+                        len(discogs_ids),
+                        len(remaining_ids),
+                    )
+            except Exception:
+                logger.warning("Wikidata cache lookup failed", exc_info=True)
+                remaining_ids = list(discogs_ids)
+
+        if not remaining_ids:
+            return result
+
+        # SPARQL fallback for cache misses
+        for batch_start in range(0, len(remaining_ids), self._batch_size):
+            batch = remaining_ids[batch_start : batch_start + self._batch_size]
             values = " ".join(f'"{did}"' for did in batch)
             query = (
                 "SELECT ?item ?itemLabel ?discogsId WHERE {\n"
@@ -284,7 +341,8 @@ class WikidataClient:
     def get_influences(self, qids: list[str]) -> list[WikidataInfluence]:
         """Get influence relationships (P737) for given Wikidata entities.
 
-        Returns edges where "source is influenced by target".
+        Cache-first: queries the wikidata-cache PostgreSQL if available,
+        then falls back to SPARQL for any QIDs not found in the cache.
 
         Args:
             qids: Wikidata QIDs to query for influences (e.g. ``["Q2774"]``).
@@ -297,8 +355,41 @@ class WikidataClient:
             return []
 
         result: list[WikidataInfluence] = []
-        for batch_start in range(0, len(valid_qids), self._batch_size):
-            batch = valid_qids[batch_start : batch_start + self._batch_size]
+        remaining_qids = list(valid_qids)
+
+        # Try cache first
+        conn = self._get_cache_conn()
+        if conn is not None:
+            try:
+                rows = conn.execute(
+                    "SELECT i.source_qid, i.target_qid, COALESCE(e.label, i.target_qid) "
+                    "FROM influence i "
+                    "LEFT JOIN entity e ON i.target_qid = e.qid "
+                    "WHERE i.source_qid = ANY(%s)",
+                    (valid_qids,),
+                ).fetchall()
+                cached_sources: set[str] = set()
+                for source_qid, target_qid, target_name in rows:
+                    result.append(
+                        WikidataInfluence(
+                            source_qid=source_qid,
+                            target_qid=target_qid,
+                            target_name=target_name,
+                        )
+                    )
+                    cached_sources.add(source_qid)
+                # Only query SPARQL for QIDs that had zero cache results
+                remaining_qids = [q for q in valid_qids if q not in cached_sources]
+            except Exception:
+                logger.warning("Wikidata cache get_influences failed", exc_info=True)
+                remaining_qids = list(valid_qids)
+
+        if not remaining_qids:
+            return result
+
+        # SPARQL fallback
+        for batch_start in range(0, len(remaining_qids), self._batch_size):
+            batch = remaining_qids[batch_start : batch_start + self._batch_size]
             values = " ".join(f"wd:{qid}" for qid in batch)
             query = (
                 "SELECT ?source ?target ?targetLabel WHERE {\n"

--- a/tests/unit/test_wikidata_client.py
+++ b/tests/unit/test_wikidata_client.py
@@ -670,3 +670,113 @@ class TestSearchMusicianByName:
         """Verify the filter constants are available for inspection."""
         assert "Q639669" in MUSICIAN_OCCUPATIONS  # musician
         assert "Q215380" in MUSICAL_GROUP_TYPES  # musical group/band
+
+
+def _make_cache_client(mock_conn: MagicMock) -> WikidataClient:
+    """Create a WikidataClient with a mocked cache connection."""
+    mock_conn.closed = False
+    client = WikidataClient()
+    client._cache_dsn = "mock"
+    client._cache_conn = mock_conn
+    return client
+
+
+class TestCacheFirstLookupByDiscogsIds:
+    """Tests for cache-first Discogs artist ID lookups."""
+
+    def test_cache_hit_skips_sparql(self):
+        """When the cache has the answer, SPARQL is never called."""
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value.fetchall.return_value = [
+            ("Q247237", "Autechre", "British electronic music duo", "41"),
+        ]
+
+        client = _make_cache_client(mock_conn)
+
+        with patch("httpx.Client") as http_mock:
+            result = client.lookup_by_discogs_ids([41])
+
+        assert 41 in result
+        assert result[41].qid == "Q247237"
+        assert result[41].name == "Autechre"
+        # SPARQL should not have been called
+        http_mock.assert_not_called()
+
+    def test_cache_miss_falls_back_to_sparql(self):
+        """IDs not in the cache are looked up via SPARQL."""
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value.fetchall.return_value = []
+
+        sparql_resp = MagicMock()
+        sparql_resp.json.return_value = _sparql_response(
+            [
+                {
+                    "item": _uri("Q334652"),
+                    "itemLabel": _literal("Stereolab"),
+                    "discogsId": _literal("388"),
+                },
+            ]
+        )
+        sparql_resp.status_code = 200
+        mock_http = MagicMock()
+        mock_http.get.return_value = sparql_resp
+
+        client = _make_cache_client(mock_conn)
+
+        with patch("httpx.Client", return_value=mock_http):
+            result = client.lookup_by_discogs_ids([388])
+
+        assert 388 in result
+        assert result[388].qid == "Q334652"
+
+    def test_no_cache_dsn_uses_sparql_only(self):
+        """Without cache_dsn, behaves exactly as before (SPARQL only)."""
+        sparql_resp = MagicMock()
+        sparql_resp.json.return_value = _sparql_response(
+            [
+                {
+                    "item": _uri("Q247237"),
+                    "itemLabel": _literal("Autechre"),
+                    "discogsId": _literal("41"),
+                },
+            ]
+        )
+        sparql_resp.status_code = 200
+        mock_http = MagicMock()
+        mock_http.get.return_value = sparql_resp
+
+        with patch("httpx.Client", return_value=mock_http):
+            client = WikidataClient()  # no cache_dsn
+            result = client.lookup_by_discogs_ids([41])
+
+        assert 41 in result
+        assert result[41].qid == "Q247237"
+
+
+class TestCacheFirstGetInfluences:
+    """Tests for cache-first influence lookups."""
+
+    def test_cache_hit_returns_influences(self):
+        """Influences from the cache are returned without SPARQL."""
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value.fetchall.return_value = [
+            ("Q247237", "Q49835", "Kraftwerk"),
+            ("Q247237", "Q192540", "Aphex Twin"),
+        ]
+
+        client = _make_cache_client(mock_conn)
+
+        with patch("httpx.Client") as http_mock:
+            result = client.get_influences(["Q247237"])
+
+        assert len(result) == 2
+        assert result[0].source_qid == "Q247237"
+        assert result[0].target_qid == "Q49835"
+        assert result[0].target_name == "Kraftwerk"
+        http_mock.assert_not_called()
+
+    def test_empty_qids_returns_empty(self):
+        """Empty input returns empty without any queries."""
+        client = WikidataClient()
+        result = client.get_influences([])
+        assert result == []


### PR DESCRIPTION
## Summary

- WikidataClient gains an optional `cache_dsn` parameter for cache-first lookups against a local wikidata-cache PostgreSQL
- `lookup_by_discogs_ids()` and `get_influences()` query the cache first, falling back to SPARQL for misses
- Pipeline gains `--wikidata-cache-dsn` flag (defaults to `DATABASE_URL_WIKIDATA` env var)

## Test plan

- [x] 549 unit tests pass (5 new cache-first tests)
- [x] ruff check + format clean
- [ ] CI (lint, typecheck, test)

Closes #90