### PR TITLE
Add transition player to graph explorer sidebar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,9 +44,10 @@ SQLite ──→ api (FastAPI + aiosqlite) ──→ JSON responses
 | `semantic_index/facet_export.py` | Export play-level data and pre-materialized aggregate tables for dynamic faceted PMI computation. Creates dj, play, artist_month_count, artist_dj_count, month_total, and dj_total tables. |
 | `semantic_index/api/app.py` | FastAPI application factory. Takes a SQLite database path, returns a configured app. |
 | `semantic_index/api/database.py` | Request-scoped SQLite connection dependency for FastAPI. |
-| `semantic_index/api/schemas.py` | Pydantic response models for the Graph API (ArtistSummary, ArtistDetail, EntityArtists, SearchResponse, NeighborsResponse, ExplainResponse, FacetsResponse, DjSummary, NarrativeResponse, CommunitiesResponse, DiscoveryResponse). |
+| `semantic_index/api/schemas.py` | Pydantic response models for the Graph API (ArtistSummary, ArtistDetail, EntityArtists, SearchResponse, NeighborsResponse, ExplainResponse, FacetsResponse, DjSummary, NarrativeResponse, CommunitiesResponse, DiscoveryResponse, PreviewResponse). |
 | `semantic_index/api/routes.py` | Graph API query endpoints: search, artist detail, neighbors by edge type (with optional month/DJ facet filters), explain relationships, entity artist groups, available facets, community metadata, discovery (underplayed sonic fits). |
 | `semantic_index/api/narrative.py` | LLM-generated edge narrative endpoint. Calls Claude Haiku to explain artist relationships in plain English. Caches results in a sidecar SQLite database. Facet-aware. |
+| `semantic_index/api/preview.py` | Audio preview URL endpoint with multi-source fallback (iTunes lookup, Spotify, Bandcamp, Deezer, iTunes search). Caches results in a sidecar SQLite database. Powers the in-card transition player in the graph explorer. |
 | `run_pipeline.py` | CLI entry point wiring the pipeline. |
 
 ### Column Mappings (0-indexed from SQL INSERT order)
@@ -291,6 +292,7 @@ app = create_app("data/wxyc_artist_graph.db")
 | `GET` | `/graph/communities?min_size=5&limit=50` | Louvain community metadata (size, label, top genres, top artists). Gracefully returns empty on databases without the `community` table. |
 | `GET` | `/graph/discovery?limit=25&community_id=&genre=` | Underplayed sonic fits: artists with high acoustic similarity but few DJ transitions, ordered by discovery score descending. Optional community/genre filters. Returns empty on databases without graph metrics. |
 | `GET` | `/graph/artists/{id}/explain/{target_id}/narrative?month=&dj_id=` | LLM-generated natural-language explanation of the relationship between two artists. Uses Claude Haiku. Cached in sidecar SQLite DB. Returns 501 when `ANTHROPIC_API_KEY` is not set. |
+| `GET` | `/graph/artists/{id}/preview` | Audio preview URL for an artist. Multi-source fallback: iTunes lookup (by Apple Music ID) -> Spotify top tracks (by Spotify ID, requires credentials) -> Bandcamp (by bandcamp_id, scrapes track stream) -> Deezer search (by name) -> iTunes search (by name). Cached in sidecar `.preview-cache.db`. |
 
 ### Deployment
 
@@ -305,6 +307,7 @@ Configuration via environment variables:
 - `HOST` — bind address (default: `0.0.0.0`)
 - `PORT` — port (default: `8000`, set automatically by Railway)
 - `ANTHROPIC_API_KEY` — Anthropic API key for narrative generation (optional; narrative endpoint returns 501 when not set)
+- `SPOTIFY_CLIENT_ID` / `SPOTIFY_CLIENT_SECRET` — Spotify API credentials for preview URL lookups (optional; Spotify tier in the preview fallback chain is skipped when not set)
 
 ## Data
 

--- a/explorer/index.html
+++ b/explorer/index.html
@@ -240,6 +240,53 @@
     svg#graph { width: 100% !important; height: 50vh !important; display: block; }
   }
   .external-links a:hover { border-color: #6a9fb5; }
+
+  /* Transition player */
+  .card-play-btn {
+    background: none; border: none; color: #555; cursor: pointer;
+    font-size: 10px; padding: 0 2px; line-height: 1; transition: color 0.15s;
+  }
+  .card-play-btn:hover { color: #6a9fb5; }
+  .card-play-btn.loading { color: #444; cursor: wait; }
+  .card-play-btn.playing { color: #6a9fb5; }
+  .card-play-btn.disabled { color: #333; cursor: not-allowed; }
+
+  .card-player {
+    margin: 8px 0 4px; padding: 8px 10px;
+    background: rgba(106,159,181,0.06); border-radius: 6px;
+    display: flex; align-items: center; gap: 8px;
+  }
+  .card-player .tp-play-pause {
+    background: none; border: none; color: #6a9fb5; cursor: pointer;
+    font-size: 12px; padding: 0; line-height: 1; flex-shrink: 0;
+    width: 16px; text-align: center;
+  }
+  .card-player .tp-play-pause:hover { color: #8cc4d8; }
+  .card-player .tp-track {
+    flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 4px;
+  }
+  .card-player .tp-names {
+    font-size: 10px; color: #666; display: flex; align-items: center; gap: 4px;
+    white-space: nowrap; overflow: hidden;
+  }
+  .card-player .tp-names .tp-a,
+  .card-player .tp-names .tp-b {
+    overflow: hidden; text-overflow: ellipsis; transition: color 0.3s;
+  }
+  .card-player .tp-names .tp-active { color: #e0e0e0; }
+  .card-player .tp-names .tp-arrow { color: #444; flex-shrink: 0; }
+  .card-player .tp-bar-container {
+    position: relative; height: 4px; background: #222; border-radius: 2px;
+    cursor: pointer; overflow: hidden;
+  }
+  .card-player .tp-bar-fill {
+    position: absolute; top: 0; left: 0; height: 100%; border-radius: 2px;
+    background: linear-gradient(to right, #6a9fb5, #6a9fb5 42%, #9b6ab5 58%, #9b6ab5);
+    width: 0%; transition: width 0.1s linear;
+  }
+  .card-player .tp-time {
+    font-size: 9px; color: #555; flex-shrink: 0; min-width: 28px; text-align: right;
+  }
 </style>
 </head>
 <body>
@@ -547,6 +594,8 @@ function populateSidebar(centerArtist, neighbors) {
   header.querySelector('.artist-meta').textContent =
     `${centerArtist.genre || 'Unknown genre'} · ${centerArtist.total_plays || 0} plays`;
 
+  TransitionPlayer.stop();
+
   const list = document.querySelector('.sidebar-list');
   list.innerHTML = '';
   activeCardId = null;
@@ -630,11 +679,27 @@ function populateSidebar(centerArtist, neighbors) {
       <div class="card-header">
         <span class="neighbor-name">${escapeHtml(n.artist.canonical_name)}</span>
         <a class="navigate-link" title="Go to ${escapeHtml(n.artist.canonical_name)}">&rarr;</a>
+        <button class="card-play-btn" title="Play transition">&#9654;</button>
         <span class="weight-badge">${weightDisplay}</span>
       </div>
       <div class="neighbor-meta">${escapeHtml(n.artist.genre || 'Unknown')} · ${n.artist.total_plays || 0} plays</div>
       <div class="narrative loading">Loading...</div>
     `;
+
+    // Click play button: play/stop transition audio
+    card.querySelector('.card-play-btn').addEventListener('click', (e) => {
+      e.stopPropagation();
+      const btn = e.currentTarget;
+      if (btn.classList.contains('playing')) {
+        TransitionPlayer.stop();
+      } else {
+        TransitionPlayer.playTransition(
+          centerArtist.id, centerArtist.canonical_name,
+          n.artist.id, n.artist.canonical_name,
+          card
+        );
+      }
+    });
 
     // Click navigate arrow: load this artist's neighborhood
     card.querySelector('.navigate-link').addEventListener('click', (e) => {
@@ -707,6 +772,323 @@ function escapeHtml(str) {
   div.textContent = str;
   return div.innerHTML;
 }
+
+// --- Transition Player ---
+
+const TransitionPlayer = (() => {
+  let audioCtx = null;
+  let sourceA = null, sourceB = null;
+  let gainA = null, gainB = null;
+  let bufferA = null, bufferB = null;
+  let startTime = 0;
+  let playing = false;
+  let paused = false;
+  let pauseOffset = 0;
+  let animFrame = null;
+  let activeCard = null;
+  let activePlayerEl = null;
+
+  const SOLO_A = 12;       // seconds of artist A solo
+  const FADE = 4;           // crossfade duration
+  const SOLO_B = 12;        // seconds of artist B solo
+  const TOTAL = SOLO_A + FADE + SOLO_B;  // 28s
+  const CLIP_OFFSET = 5;    // skip first 5s of each 30s preview
+
+  function ensureContext() {
+    if (!audioCtx) audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+    if (audioCtx.state === 'suspended') audioCtx.resume();
+  }
+
+  function stop() {
+    if (sourceA) { try { sourceA.stop(); } catch {} sourceA = null; }
+    if (sourceB) { try { sourceB.stop(); } catch {} sourceB = null; }
+    if (animFrame) { cancelAnimationFrame(animFrame); animFrame = null; }
+    playing = false;
+    paused = false;
+    pauseOffset = 0;
+
+    // Reset UI
+    if (activeCard) {
+      const btn = activeCard.querySelector('.card-play-btn');
+      if (btn) { btn.textContent = '\u25B6'; btn.classList.remove('playing'); }
+    }
+    if (activePlayerEl) {
+      activePlayerEl.remove();
+      activePlayerEl = null;
+    }
+    activeCard = null;
+  }
+
+  function createPlayerEl(card, nameA, nameB) {
+    // Remove any existing player in this card
+    const existing = card.querySelector('.card-player');
+    if (existing) existing.remove();
+
+    const el = document.createElement('div');
+    el.className = 'card-player';
+    el.innerHTML = `
+      <button class="tp-play-pause" title="Pause">&#9646;&#9646;</button>
+      <div class="tp-track">
+        <div class="tp-names">
+          <span class="tp-a tp-active">${escapeHtml(nameA)}</span>
+          <span class="tp-arrow">&rarr;</span>
+          <span class="tp-b">${escapeHtml(nameB)}</span>
+        </div>
+        <div class="tp-bar-container">
+          <div class="tp-bar-fill"></div>
+        </div>
+      </div>
+      <span class="tp-time">0:00</span>
+    `;
+
+    // Insert after neighbor-meta, before narrative
+    const meta = card.querySelector('.neighbor-meta');
+    if (meta && meta.nextSibling) {
+      card.insertBefore(el, meta.nextSibling);
+    } else {
+      card.appendChild(el);
+    }
+
+    // Play/pause button
+    el.querySelector('.tp-play-pause').addEventListener('click', (e) => {
+      e.stopPropagation();
+      if (playing && !paused) {
+        pause();
+      } else if (paused) {
+        resume();
+      }
+    });
+
+    // Click on progress bar to seek
+    el.querySelector('.tp-bar-container').addEventListener('click', (e) => {
+      e.stopPropagation();
+      const rect = e.currentTarget.getBoundingClientRect();
+      const pct = (e.clientX - rect.left) / rect.width;
+      seek(pct * TOTAL);
+    });
+
+    return el;
+  }
+
+  function updateUI(elapsed) {
+    if (!activePlayerEl) return;
+    const pct = Math.min(100, (elapsed / TOTAL) * 100);
+    const fill = activePlayerEl.querySelector('.tp-bar-fill');
+    if (fill) fill.style.width = pct + '%';
+
+    const secs = Math.floor(elapsed);
+    const timeEl = activePlayerEl.querySelector('.tp-time');
+    if (timeEl) timeEl.textContent = `${Math.floor(secs / 60)}:${String(secs % 60).padStart(2, '0')}`;
+
+    // Highlight active artist name
+    const nameA = activePlayerEl.querySelector('.tp-a');
+    const nameB = activePlayerEl.querySelector('.tp-b');
+    if (nameA && nameB) {
+      if (elapsed < SOLO_A) {
+        nameA.classList.add('tp-active');
+        nameB.classList.remove('tp-active');
+      } else if (elapsed < SOLO_A + FADE) {
+        nameA.classList.add('tp-active');
+        nameB.classList.add('tp-active');
+      } else {
+        nameA.classList.remove('tp-active');
+        nameB.classList.add('tp-active');
+      }
+    }
+  }
+
+  function tick() {
+    if (!playing || paused) return;
+    const elapsed = audioCtx.currentTime - startTime;
+    if (elapsed >= TOTAL) {
+      updateUI(TOTAL);
+      stop();
+      return;
+    }
+    updateUI(elapsed);
+    animFrame = requestAnimationFrame(tick);
+  }
+
+  function schedulePlayback(offset = 0) {
+    ensureContext();
+    const now = audioCtx.currentTime;
+    startTime = now - offset;
+
+    // Source A: plays from offset to SOLO_A + FADE (or whatever remains)
+    const aStart = CLIP_OFFSET + offset;
+    const aDuration = Math.max(0, SOLO_A + FADE - offset);
+    if (aDuration > 0 && bufferA) {
+      sourceA = audioCtx.createBufferSource();
+      sourceA.buffer = bufferA;
+      gainA = audioCtx.createGain();
+      sourceA.connect(gainA);
+      gainA.connect(audioCtx.destination);
+
+      // Gain envelope for A: full volume, then fade out during crossfade
+      const fadeStart = Math.max(0, SOLO_A - offset);
+      gainA.gain.setValueAtTime(1.0, now);
+      if (offset < SOLO_A) {
+        gainA.gain.setValueAtTime(1.0, now + fadeStart);
+        gainA.gain.linearRampToValueAtTime(0.0, now + fadeStart + FADE);
+      } else {
+        // Already in fade zone
+        const fadeElapsed = offset - SOLO_A;
+        const currentGain = 1.0 - (fadeElapsed / FADE);
+        gainA.gain.setValueAtTime(Math.max(0, currentGain), now);
+        gainA.gain.linearRampToValueAtTime(0.0, now + (FADE - fadeElapsed));
+      }
+
+      sourceA.start(now, aStart, aDuration);
+    }
+
+    // Source B: starts at SOLO_A, plays through SOLO_A + FADE + SOLO_B
+    const bStartOffset = Math.max(0, SOLO_A - offset);
+    const bClipOffset = offset > SOLO_A ? CLIP_OFFSET + (offset - SOLO_A) : CLIP_OFFSET;
+    const bDuration = Math.max(0, TOTAL - Math.max(offset, SOLO_A));
+    if (bDuration > 0 && bufferB) {
+      sourceB = audioCtx.createBufferSource();
+      sourceB.buffer = bufferB;
+      gainB = audioCtx.createGain();
+      sourceB.connect(gainB);
+      gainB.connect(audioCtx.destination);
+
+      // Gain envelope for B: fade in during crossfade, then full volume
+      if (offset < SOLO_A) {
+        gainB.gain.setValueAtTime(0.0, now + bStartOffset);
+        gainB.gain.linearRampToValueAtTime(1.0, now + bStartOffset + FADE);
+      } else if (offset < SOLO_A + FADE) {
+        const fadeElapsed = offset - SOLO_A;
+        const currentGain = fadeElapsed / FADE;
+        gainB.gain.setValueAtTime(currentGain, now);
+        gainB.gain.linearRampToValueAtTime(1.0, now + (FADE - fadeElapsed));
+      } else {
+        gainB.gain.setValueAtTime(1.0, now);
+      }
+
+      sourceB.start(now + bStartOffset, bClipOffset, bDuration);
+    }
+  }
+
+  function pause() {
+    if (!playing || paused) return;
+    paused = true;
+    pauseOffset = audioCtx.currentTime - startTime;
+    if (sourceA) { try { sourceA.stop(); } catch {} sourceA = null; }
+    if (sourceB) { try { sourceB.stop(); } catch {} sourceB = null; }
+    if (animFrame) { cancelAnimationFrame(animFrame); animFrame = null; }
+
+    if (activePlayerEl) {
+      const btn = activePlayerEl.querySelector('.tp-play-pause');
+      if (btn) btn.innerHTML = '&#9654;';
+    }
+  }
+
+  function resume() {
+    if (!paused) return;
+    paused = false;
+    schedulePlayback(pauseOffset);
+    playing = true;
+
+    if (activePlayerEl) {
+      const btn = activePlayerEl.querySelector('.tp-play-pause');
+      if (btn) btn.innerHTML = '&#9646;&#9646;';
+    }
+    animFrame = requestAnimationFrame(tick);
+  }
+
+  function seek(time) {
+    if (!bufferA && !bufferB) return;
+    const wasPlaying = playing && !paused;
+    if (sourceA) { try { sourceA.stop(); } catch {} sourceA = null; }
+    if (sourceB) { try { sourceB.stop(); } catch {} sourceB = null; }
+    if (animFrame) { cancelAnimationFrame(animFrame); animFrame = null; }
+
+    pauseOffset = Math.max(0, Math.min(time, TOTAL));
+    if (wasPlaying) {
+      paused = false;
+      schedulePlayback(pauseOffset);
+      playing = true;
+      animFrame = requestAnimationFrame(tick);
+    } else {
+      paused = true;
+      updateUI(pauseOffset);
+    }
+  }
+
+  async function playTransition(sourceId, sourceName, targetId, targetName, card) {
+    // Stop any current playback
+    stop();
+
+    const btn = card.querySelector('.card-play-btn');
+    btn.classList.add('loading');
+    btn.textContent = '...';
+
+    activeCard = card;
+
+    try {
+      // Fetch preview URLs for both artists in parallel
+      const [previewA, previewB] = await Promise.all([
+        api(`/graph/artists/${sourceId}/preview`),
+        api(`/graph/artists/${targetId}/preview`),
+      ]);
+
+      const urlA = previewA?.preview_url;
+      const urlB = previewB?.preview_url;
+
+      if (!urlA && !urlB) {
+        btn.classList.remove('loading');
+        btn.classList.add('disabled');
+        btn.textContent = '\u25B6';
+        btn.title = 'No previews available';
+        activeCard = null;
+        return;
+      }
+
+      ensureContext();
+
+      // Fetch and decode audio in parallel
+      const [decA, decB] = await Promise.all([
+        urlA ? fetch(urlA).then(r => r.arrayBuffer()).then(b => audioCtx.decodeAudioData(b)).catch(() => null) : Promise.resolve(null),
+        urlB ? fetch(urlB).then(r => r.arrayBuffer()).then(b => audioCtx.decodeAudioData(b)).catch(() => null) : Promise.resolve(null),
+      ]);
+
+      bufferA = decA;
+      bufferB = decB;
+
+      if (!bufferA && !bufferB) {
+        btn.classList.remove('loading');
+        btn.classList.add('disabled');
+        btn.textContent = '\u25B6';
+        btn.title = 'Audio decode failed';
+        activeCard = null;
+        return;
+      }
+
+      // Set up UI
+      btn.classList.remove('loading');
+      btn.classList.add('playing');
+      btn.textContent = '\u25A0';
+
+      const dispA = previewA?.track_name ? `${sourceName} — ${previewA.track_name}` : sourceName;
+      const dispB = previewB?.track_name ? `${targetName} — ${previewB.track_name}` : targetName;
+      activePlayerEl = createPlayerEl(card, dispA, dispB);
+
+      // Start playback
+      schedulePlayback(0);
+      playing = true;
+      paused = false;
+      animFrame = requestAnimationFrame(tick);
+
+    } catch (err) {
+      console.warn('Transition playback failed:', err);
+      btn.classList.remove('loading');
+      btn.textContent = '\u25B6';
+      activeCard = null;
+    }
+  }
+
+  return { playTransition, stop };
+})();
 
 // --- Edge highlighting ---
 

--- a/semantic_index/api/app.py
+++ b/semantic_index/api/app.py
@@ -12,6 +12,7 @@ from fastapi.staticfiles import StaticFiles
 
 from semantic_index.api.bio import bio_router
 from semantic_index.api.narrative import narrative_router
+from semantic_index.api.preview import preview_router
 from semantic_index.api.routes import router
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
@@ -40,6 +41,7 @@ def create_app(db_path: str, anthropic_api_key: str | None = None) -> FastAPI:
     app.include_router(router)
     app.include_router(narrative_router)
     app.include_router(bio_router)
+    app.include_router(preview_router)
 
     @app.get("/health", include_in_schema=False)
     def health() -> JSONResponse:

--- a/semantic_index/api/preview.py
+++ b/semantic_index/api/preview.py
@@ -1,0 +1,387 @@
+"""Preview endpoint — multi-source audio preview lookup with sidecar caching.
+
+Fetches 30-second preview audio URLs for artists from multiple streaming
+services, with fallback chain: iTunes lookup -> Spotify -> Bandcamp -> Deezer -> iTunes search.
+Results are cached in a sidecar SQLite database.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import sqlite3
+from datetime import UTC, datetime
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, Request
+
+from semantic_index.api.database import get_db
+from semantic_index.api.schemas import PreviewResponse
+
+logger = logging.getLogger(__name__)
+
+preview_router = APIRouter(prefix="/graph", tags=["graph"])
+
+_USER_AGENT = "WXYCSemanticIndex/0.1 (https://wxyc.org; engineering@wxyc.org)"
+
+_CACHE_SCHEMA = """
+CREATE TABLE IF NOT EXISTS preview_cache (
+    artist_id INTEGER PRIMARY KEY,
+    preview_url TEXT,
+    track_name TEXT,
+    artist_name TEXT,
+    artwork_url TEXT,
+    source TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);
+"""
+
+
+def _get_cache_db(db_path: str) -> sqlite3.Connection:
+    """Open a writable connection to the sidecar preview cache database."""
+    cache_path = db_path + ".preview-cache.db"
+    conn = sqlite3.connect(cache_path, check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.executescript(_CACHE_SCHEMA)
+    return conn
+
+
+def _http_get(url: str, **kwargs) -> httpx.Response:
+    """Make an HTTP GET request. Extracted for testability."""
+    with httpx.Client(
+        timeout=10,
+        headers={"User-Agent": _USER_AGENT},
+        follow_redirects=True,
+    ) as client:
+        return client.get(url, **kwargs)
+
+
+def _get_artist_info(db: sqlite3.Connection, artist_id: int) -> dict | None:
+    """Fetch artist name and streaming IDs from the database."""
+    try:
+        row = db.execute(
+            "SELECT a.id, a.canonical_name, "
+            "  e.apple_music_artist_id, e.spotify_artist_id, e.bandcamp_id "
+            "FROM artist a "
+            "LEFT JOIN entity e ON a.entity_id = e.id "
+            "WHERE a.id = ?",
+            (artist_id,),
+        ).fetchone()
+    except sqlite3.OperationalError:
+        # Old schema without entity table
+        row = db.execute(
+            "SELECT id, canonical_name FROM artist WHERE id = ?",
+            (artist_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        return {
+            "id": row["id"],
+            "canonical_name": row["canonical_name"],
+            "apple_music_artist_id": None,
+            "spotify_artist_id": None,
+            "bandcamp_id": None,
+        }
+
+    if row is None:
+        return None
+
+    return {
+        "id": row["id"],
+        "canonical_name": row["canonical_name"],
+        "apple_music_artist_id": row["apple_music_artist_id"],
+        "spotify_artist_id": row["spotify_artist_id"],
+        "bandcamp_id": row["bandcamp_id"],
+    }
+
+
+# -- Source-specific lookup functions --
+
+
+def _try_itunes_lookup(apple_music_artist_id: str) -> dict | None:
+    """Fetch preview via iTunes lookup API using Apple Music artist ID."""
+    try:
+        resp = _http_get(
+            f"https://itunes.apple.com/lookup?id={apple_music_artist_id}&entity=song&limit=5"
+        )
+        if resp.status_code != 200:
+            return None
+        data = resp.json()
+        for result in data.get("results", []):
+            if result.get("wrapperType") == "track" and result.get("previewUrl"):
+                return {
+                    "preview_url": result["previewUrl"],
+                    "track_name": result.get("trackName"),
+                    "artist_name": result.get("artistName"),
+                    "artwork_url": result.get("artworkUrl100"),
+                    "source": "itunes_lookup",
+                }
+    except (httpx.TimeoutException, httpx.HTTPError, Exception):
+        logger.debug("iTunes lookup failed for %s", apple_music_artist_id, exc_info=True)
+    return None
+
+
+def _try_spotify(spotify_artist_id: str, client_id: str, client_secret: str) -> dict | None:
+    """Fetch preview via Spotify top-tracks API using client credentials."""
+    try:
+        # Get access token via client credentials flow
+        with httpx.Client(timeout=10) as client:
+            token_resp = client.post(
+                "https://accounts.spotify.com/api/token",
+                data={"grant_type": "client_credentials"},
+                auth=(client_id, client_secret),
+            )
+            if token_resp.status_code != 200:
+                return None
+            access_token = token_resp.json().get("access_token")
+            if not access_token:
+                return None
+
+            # Fetch top tracks
+            tracks_resp = client.get(
+                f"https://api.spotify.com/v1/artists/{spotify_artist_id}/top-tracks",
+                headers={"Authorization": f"Bearer {access_token}"},
+            )
+            if tracks_resp.status_code != 200:
+                return None
+
+            for track in tracks_resp.json().get("tracks", []):
+                if track.get("preview_url"):
+                    album = track.get("album", {})
+                    images = album.get("images", [])
+                    artwork = images[0]["url"] if images else None
+                    return {
+                        "preview_url": track["preview_url"],
+                        "track_name": track.get("name"),
+                        "artist_name": track.get("artists", [{}])[0].get("name"),
+                        "artwork_url": artwork,
+                        "source": "spotify",
+                    }
+    except (httpx.TimeoutException, httpx.HTTPError, Exception):
+        logger.debug("Spotify lookup failed for %s", spotify_artist_id, exc_info=True)
+    return None
+
+
+def _try_bandcamp(bandcamp_id: str) -> dict | None:
+    """Scrape Bandcamp artist page for a track stream URL."""
+    try:
+        resp = _http_get(f"https://{bandcamp_id}.bandcamp.com")
+        if resp.status_code != 200:
+            return None
+
+        # Find album links on the artist page
+        album_match = re.search(r'<a href="(/album/[^"]+)"', resp.text)
+        album_url = None
+        if album_match:
+            album_url = f"https://{bandcamp_id}.bandcamp.com{album_match.group(1)}"
+        else:
+            # Try the artist page itself (some have tracks directly)
+            album_url = f"https://{bandcamp_id}.bandcamp.com"
+
+        # Fetch the album page for track data
+        if album_url != f"https://{bandcamp_id}.bandcamp.com":
+            resp = _http_get(album_url)
+            if resp.status_code != 200:
+                return None
+
+        # Extract data-tralbum JSON
+        tralbum_match = re.search(r"data-tralbum='([^']*)'", resp.text)
+        if not tralbum_match:
+            # Try double-quote variant
+            tralbum_match = re.search(r'data-tralbum="([^"]*)"', resp.text)
+        if not tralbum_match:
+            return None
+
+        tralbum_raw = tralbum_match.group(1)
+        # Unescape HTML entities
+        tralbum_raw = tralbum_raw.replace("&quot;", '"').replace("&amp;", "&")
+        tralbum = json.loads(tralbum_raw)
+
+        trackinfo = tralbum.get("trackinfo", [])
+        for track in trackinfo:
+            file_info = track.get("file", {})
+            mp3_url = file_info.get("mp3-128")
+            if mp3_url:
+                current = tralbum.get("current", {})
+                return {
+                    "preview_url": mp3_url,
+                    "track_name": track.get("title"),
+                    "artist_name": current.get("artist") or bandcamp_id,
+                    "artwork_url": current.get("art_id"),
+                    "source": "bandcamp",
+                }
+    except (httpx.TimeoutException, httpx.HTTPError, json.JSONDecodeError, Exception):
+        logger.debug("Bandcamp scrape failed for %s", bandcamp_id, exc_info=True)
+    return None
+
+
+def _try_deezer(artist_name: str) -> dict | None:
+    """Search Deezer for a track preview by artist name."""
+    try:
+        resp = _http_get(f'https://api.deezer.com/search?q=artist:"{artist_name}"&limit=5')
+        if resp.status_code != 200:
+            return None
+        data = resp.json()
+        for result in data.get("data", []):
+            if result.get("preview"):
+                album = result.get("album", {})
+                return {
+                    "preview_url": result["preview"],
+                    "track_name": result.get("title"),
+                    "artist_name": result.get("artist", {}).get("name"),
+                    "artwork_url": album.get("cover_medium"),
+                    "source": "deezer",
+                }
+    except (httpx.TimeoutException, httpx.HTTPError, Exception):
+        logger.debug("Deezer search failed for %s", artist_name, exc_info=True)
+    return None
+
+
+def _try_itunes_search(artist_name: str) -> dict | None:
+    """Search iTunes for a track preview by artist name."""
+    try:
+        resp = _http_get(f"https://itunes.apple.com/search?term={artist_name}&entity=song&limit=5")
+        if resp.status_code != 200:
+            return None
+        data = resp.json()
+        for result in data.get("results", []):
+            if result.get("wrapperType") == "track" and result.get("previewUrl"):
+                return {
+                    "preview_url": result["previewUrl"],
+                    "track_name": result.get("trackName"),
+                    "artist_name": result.get("artistName"),
+                    "artwork_url": result.get("artworkUrl100"),
+                    "source": "itunes_search",
+                }
+    except (httpx.TimeoutException, httpx.HTTPError, Exception):
+        logger.debug("iTunes search failed for %s", artist_name, exc_info=True)
+    return None
+
+
+def _lookup_preview(
+    artist_info: dict,
+    spotify_client_id: str | None = None,
+    spotify_client_secret: str | None = None,
+) -> dict:
+    """Run the multi-source fallback chain and return preview data.
+
+    Returns a dict with keys: preview_url, track_name, artist_name, artwork_url, source.
+    """
+    apple_music_id = artist_info.get("apple_music_artist_id")
+    spotify_id = artist_info.get("spotify_artist_id")
+    bandcamp_id = artist_info.get("bandcamp_id")
+    name = artist_info["canonical_name"]
+
+    # 1. iTunes lookup (by Apple Music ID)
+    if apple_music_id:
+        result = _try_itunes_lookup(apple_music_id)
+        if result:
+            return result
+
+    # 2. Spotify top tracks (by Spotify ID, if credentials configured)
+    if spotify_id and spotify_client_id and spotify_client_secret:
+        result = _try_spotify(spotify_id, spotify_client_id, spotify_client_secret)
+        if result:
+            return result
+
+    # 3. Bandcamp (by bandcamp_id)
+    if bandcamp_id:
+        result = _try_bandcamp(bandcamp_id)
+        if result:
+            return result
+
+    # 4. Deezer search (by name)
+    result = _try_deezer(name)
+    if result:
+        return result
+
+    # 5. iTunes search (by name)
+    result = _try_itunes_search(name)
+    if result:
+        return result
+
+    # Nothing found
+    return {
+        "preview_url": None,
+        "track_name": None,
+        "artist_name": None,
+        "artwork_url": None,
+        "source": "none",
+    }
+
+
+@preview_router.get(
+    "/artists/{artist_id}/preview",
+    response_model=PreviewResponse,
+)
+def get_preview(
+    artist_id: int,
+    request: Request,
+    db: sqlite3.Connection = Depends(get_db),
+) -> PreviewResponse:
+    """Return a preview audio URL for an artist.
+
+    Checks sidecar cache first, then runs a multi-source fallback chain:
+    iTunes lookup -> Spotify -> Bandcamp -> Deezer -> iTunes search.
+    """
+    # Verify artist exists and get streaming IDs
+    artist_info = _get_artist_info(db, artist_id)
+    if artist_info is None:
+        raise HTTPException(status_code=404, detail="Artist not found")
+
+    # Check cache
+    cache_db = _get_cache_db(request.app.state.db_path)
+    try:
+        cached = cache_db.execute(
+            "SELECT preview_url, track_name, artist_name, artwork_url, source "
+            "FROM preview_cache WHERE artist_id = ?",
+            (artist_id,),
+        ).fetchone()
+
+        if cached is not None:
+            return PreviewResponse(
+                artist_id=artist_id,
+                preview_url=cached["preview_url"],
+                track_name=cached["track_name"],
+                artist_name=cached["artist_name"],
+                artwork_url=cached["artwork_url"],
+                source=cached["source"],
+                cached=True,
+            )
+
+        # Run fallback chain
+        spotify_client_id = getattr(request.app.state, "spotify_client_id", None)
+        spotify_client_secret = getattr(request.app.state, "spotify_client_secret", None)
+
+        result = _lookup_preview(artist_info, spotify_client_id, spotify_client_secret)
+
+        # Cache the result (including null)
+        cache_db.execute(
+            "INSERT OR REPLACE INTO preview_cache "
+            "(artist_id, preview_url, track_name, artist_name, artwork_url, source, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                artist_id,
+                result["preview_url"],
+                result["track_name"],
+                result["artist_name"],
+                result["artwork_url"],
+                result["source"],
+                datetime.now(UTC).isoformat(),
+            ),
+        )
+        cache_db.commit()
+
+        return PreviewResponse(
+            artist_id=artist_id,
+            preview_url=result["preview_url"],
+            track_name=result["track_name"],
+            artist_name=result["artist_name"],
+            artwork_url=result["artwork_url"],
+            source=result["source"],
+            cached=False,
+        )
+    finally:
+        cache_db.close()

--- a/semantic_index/api/schemas.py
+++ b/semantic_index/api/schemas.py
@@ -169,3 +169,19 @@ class DiscoveryResponse(BaseModel):
     """Response for GET /graph/discovery."""
 
     results: list[DiscoveryEntry]
+
+
+class PreviewResponse(BaseModel):
+    """Response for GET /graph/artists/{id}/preview.
+
+    Returns a preview audio URL for an artist, sourced from iTunes, Spotify,
+    Bandcamp, or Deezer with multi-source fallback. Cached in a sidecar database.
+    """
+
+    artist_id: int
+    preview_url: str | None = None
+    track_name: str | None = None
+    artist_name: str | None = None
+    artwork_url: str | None = None
+    source: str  # 'itunes_lookup' | 'spotify' | 'bandcamp' | 'deezer' | 'itunes_search' | 'none'
+    cached: bool

--- a/tests/unit/test_preview.py
+++ b/tests/unit/test_preview.py
@@ -1,0 +1,393 @@
+"""Tests for the preview endpoint with multi-source fallback and sidecar caching."""
+
+from __future__ import annotations
+
+import sqlite3
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from semantic_index.api.app import create_app
+from semantic_index.entity_store import EntityStore
+from semantic_index.models import ArtistStats
+
+# -- iTunes mock responses --
+
+ITUNES_LOOKUP_RESPONSE = {
+    "resultCount": 2,
+    "results": [
+        {"wrapperType": "artist", "artistId": 15821237, "artistName": "Autechre"},
+        {
+            "wrapperType": "track",
+            "trackName": "Gantz Graf",
+            "artistName": "Autechre",
+            "previewUrl": "https://audio-ssl.itunes.apple.com/autechre_gantz.m4a",
+            "artworkUrl100": "https://is1-ssl.mzstatic.com/autechre_100.jpg",
+        },
+    ],
+}
+
+ITUNES_SEARCH_RESPONSE = {
+    "resultCount": 1,
+    "results": [
+        {
+            "wrapperType": "track",
+            "trackName": "Jenny Ondioline",
+            "artistName": "Stereolab",
+            "previewUrl": "https://audio-ssl.itunes.apple.com/stereolab_jenny.m4a",
+            "artworkUrl100": "https://is1-ssl.mzstatic.com/stereolab_100.jpg",
+        },
+    ],
+}
+
+ITUNES_EMPTY_RESPONSE = {"resultCount": 0, "results": []}
+
+# -- Deezer mock responses --
+
+DEEZER_SEARCH_RESPONSE = {
+    "data": [
+        {
+            "title": "Meinheld",
+            "artist": {"name": "Stereolab"},
+            "preview": "https://cdns-preview-e.dzcdn.net/stereolab_meinheld.mp3",
+            "album": {"cover_medium": "https://api.deezer.com/album/cover.jpg"},
+        },
+    ],
+}
+
+DEEZER_EMPTY_RESPONSE = {"data": []}
+
+# -- Bandcamp mock responses --
+
+BANDCAMP_PAGE_HTML = """
+<html><body>
+<script data-tralbum='{"trackinfo":[{"title":"Untitled","file":{"mp3-128":"https://t4.bcbits.com/stream/autechre_untitled.mp3"}}],"current":{"title":"LP5"}}'></script>
+</body></html>
+"""
+
+BANDCAMP_PAGE_NO_TRACKS = """
+<html><body>
+<script data-tralbum='{"trackinfo":[]}'></script>
+</body></html>
+"""
+
+
+def _build_preview_fixture_db() -> str:
+    """Create a fixture database with entity store tables and streaming IDs."""
+    path = tempfile.mktemp(suffix=".db")
+    store = EntityStore(path)
+    store.initialize()
+
+    # Autechre: has Apple Music ID
+    entity_ae = store.get_or_create_entity("Autechre", "artist", wikidata_qid="Q2774")
+    store.update_entity_streaming_ids(entity_ae.id, apple_music="15821237")
+    store.upsert_artist(
+        "Autechre",
+        genre="Electronic",
+        discogs_artist_id=12,
+        entity_id=entity_ae.id,
+    )
+    store.update_artist_stats(
+        "Autechre",
+        ArtistStats(
+            canonical_name="Autechre",
+            total_plays=633,
+            genre="Electronic",
+            active_first_year=2004,
+            active_last_year=2025,
+            dj_count=45,
+            request_ratio=0.1,
+            show_count=500,
+        ),
+    )
+
+    # Stereolab: no streaming IDs (will test fallbacks)
+    entity_sl = store.get_or_create_entity("Stereolab", "artist", wikidata_qid="Q498895")
+    store.upsert_artist(
+        "Stereolab",
+        genre="Rock",
+        entity_id=entity_sl.id,
+    )
+    store.update_artist_stats(
+        "Stereolab",
+        ArtistStats(
+            canonical_name="Stereolab",
+            total_plays=450,
+            genre="Rock",
+            active_first_year=2003,
+            active_last_year=2024,
+            dj_count=38,
+            request_ratio=0.05,
+            show_count=300,
+        ),
+    )
+
+    # Cat Power: has Bandcamp ID (will test Bandcamp fallback)
+    entity_cp = store.get_or_create_entity("Cat Power", "artist", wikidata_qid="Q228899")
+    store.update_entity_streaming_ids(entity_cp.id, bandcamp="catpower")
+    store.upsert_artist(
+        "Cat Power",
+        genre="Rock",
+        entity_id=entity_cp.id,
+    )
+    store.update_artist_stats(
+        "Cat Power",
+        ArtistStats(
+            canonical_name="Cat Power",
+            total_plays=200,
+            genre="Rock",
+            active_first_year=2005,
+            active_last_year=2023,
+            dj_count=20,
+            request_ratio=0.02,
+            show_count=150,
+        ),
+    )
+
+    store.close()
+    return path
+
+
+@pytest.fixture(scope="module")
+def preview_db_path() -> str:
+    return _build_preview_fixture_db()
+
+
+@pytest_asyncio.fixture()
+async def preview_client(preview_db_path: str) -> AsyncClient:
+    app = create_app(preview_db_path)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+
+
+def _artist_id(db_path: str, name: str) -> int:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    row = conn.execute("SELECT id FROM artist WHERE canonical_name = ?", (name,)).fetchone()
+    conn.close()
+    return row["id"]
+
+
+def _clear_preview_cache(db_path: str, artist_id: int) -> None:
+    cache_path = db_path + ".preview-cache.db"
+    try:
+        cache_conn = sqlite3.connect(cache_path)
+        cache_conn.execute("DELETE FROM preview_cache WHERE artist_id = ?", (artist_id,))
+        cache_conn.commit()
+        cache_conn.close()
+    except sqlite3.OperationalError:
+        pass  # cache table doesn't exist yet
+
+
+class TestPreviewEndpoint:
+    @pytest.mark.asyncio
+    async def test_preview_returns_url_via_itunes_lookup(
+        self, preview_client: AsyncClient, preview_db_path: str
+    ) -> None:
+        """Artist with apple_music_artist_id gets a preview via iTunes lookup."""
+        aid = _artist_id(preview_db_path, "Autechre")
+        _clear_preview_cache(preview_db_path, aid)
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = ITUNES_LOOKUP_RESPONSE
+
+        with patch("semantic_index.api.preview._http_get", return_value=mock_response):
+            resp = await preview_client.get(f"/graph/artists/{aid}/preview")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["preview_url"] == "https://audio-ssl.itunes.apple.com/autechre_gantz.m4a"
+        assert data["track_name"] == "Gantz Graf"
+        assert data["source"] == "itunes_lookup"
+        assert data["artist_id"] == aid
+
+    @pytest.mark.asyncio
+    async def test_preview_caches_result(
+        self, preview_client: AsyncClient, preview_db_path: str
+    ) -> None:
+        """Second request returns cached result without calling external API."""
+        aid = _artist_id(preview_db_path, "Autechre")
+        _clear_preview_cache(preview_db_path, aid)
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = ITUNES_LOOKUP_RESPONSE
+
+        with patch("semantic_index.api.preview._http_get", return_value=mock_response) as mock_get:
+            resp1 = await preview_client.get(f"/graph/artists/{aid}/preview")
+            resp2 = await preview_client.get(f"/graph/artists/{aid}/preview")
+
+        assert resp1.status_code == 200
+        assert resp2.status_code == 200
+        assert resp1.json()["cached"] is False
+        assert resp2.json()["cached"] is True
+        # External API should have been called only once
+        assert mock_get.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_preview_falls_back_to_deezer(
+        self, preview_client: AsyncClient, preview_db_path: str
+    ) -> None:
+        """Artist without streaming IDs falls back to Deezer search."""
+        aid = _artist_id(preview_db_path, "Stereolab")
+        _clear_preview_cache(preview_db_path, aid)
+
+        deezer_response = MagicMock()
+        deezer_response.status_code = 200
+        deezer_response.json.return_value = DEEZER_SEARCH_RESPONSE
+
+        with patch("semantic_index.api.preview._http_get", return_value=deezer_response):
+            resp = await preview_client.get(f"/graph/artists/{aid}/preview")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["preview_url"] == "https://cdns-preview-e.dzcdn.net/stereolab_meinheld.mp3"
+        assert data["source"] == "deezer"
+
+    @pytest.mark.asyncio
+    async def test_preview_falls_back_to_bandcamp(
+        self, preview_client: AsyncClient, preview_db_path: str
+    ) -> None:
+        """Artist with bandcamp_id falls back to Bandcamp track scrape."""
+        aid = _artist_id(preview_db_path, "Cat Power")
+        _clear_preview_cache(preview_db_path, aid)
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = BANDCAMP_PAGE_HTML
+
+        with patch("semantic_index.api.preview._http_get", return_value=mock_response):
+            resp = await preview_client.get(f"/graph/artists/{aid}/preview")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["preview_url"] == "https://t4.bcbits.com/stream/autechre_untitled.mp3"
+        assert data["source"] == "bandcamp"
+
+    @pytest.mark.asyncio
+    async def test_preview_falls_back_to_itunes_search(
+        self, preview_client: AsyncClient, preview_db_path: str
+    ) -> None:
+        """When Deezer returns empty, falls back to iTunes search by name."""
+        aid = _artist_id(preview_db_path, "Stereolab")
+        _clear_preview_cache(preview_db_path, aid)
+
+        call_count = 0
+
+        def mock_get_side_effect(url, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            if "deezer" in url:
+                mock_resp.json.return_value = DEEZER_EMPTY_RESPONSE
+            elif "itunes" in url and "search" in url:
+                mock_resp.json.return_value = ITUNES_SEARCH_RESPONSE
+            else:
+                mock_resp.json.return_value = ITUNES_EMPTY_RESPONSE
+            return mock_resp
+
+        with patch("semantic_index.api.preview._http_get", side_effect=mock_get_side_effect):
+            resp = await preview_client.get(f"/graph/artists/{aid}/preview")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["preview_url"] == "https://audio-ssl.itunes.apple.com/stereolab_jenny.m4a"
+        assert data["source"] == "itunes_search"
+
+    @pytest.mark.asyncio
+    async def test_preview_returns_null_when_no_results(
+        self, preview_client: AsyncClient, preview_db_path: str
+    ) -> None:
+        """All sources return empty — preview_url is null."""
+        aid = _artist_id(preview_db_path, "Stereolab")
+        _clear_preview_cache(preview_db_path, aid)
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = ITUNES_EMPTY_RESPONSE
+
+        def mock_get_all_empty(url, **kwargs):
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            if "deezer" in url:
+                mock_resp.json.return_value = DEEZER_EMPTY_RESPONSE
+            else:
+                mock_resp.json.return_value = ITUNES_EMPTY_RESPONSE
+            return mock_resp
+
+        with patch("semantic_index.api.preview._http_get", side_effect=mock_get_all_empty):
+            resp = await preview_client.get(f"/graph/artists/{aid}/preview")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["preview_url"] is None
+        assert data["source"] == "none"
+
+    @pytest.mark.asyncio
+    async def test_preview_caches_null_result(
+        self, preview_client: AsyncClient, preview_db_path: str
+    ) -> None:
+        """Null results are cached so we don't re-query external APIs."""
+        aid = _artist_id(preview_db_path, "Stereolab")
+        _clear_preview_cache(preview_db_path, aid)
+
+        def mock_get_all_empty(url, **kwargs):
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            if "deezer" in url:
+                mock_resp.json.return_value = DEEZER_EMPTY_RESPONSE
+            else:
+                mock_resp.json.return_value = ITUNES_EMPTY_RESPONSE
+            return mock_resp
+
+        with patch(
+            "semantic_index.api.preview._http_get", side_effect=mock_get_all_empty
+        ) as mock_get:
+            resp1 = await preview_client.get(f"/graph/artists/{aid}/preview")
+            resp2 = await preview_client.get(f"/graph/artists/{aid}/preview")
+
+        assert resp1.json()["cached"] is False
+        assert resp2.json()["cached"] is True
+        assert resp2.json()["preview_url"] is None
+        # External calls should only happen on the first request
+        assert mock_get.call_count > 0
+
+    @pytest.mark.asyncio
+    async def test_preview_404_unknown_artist(self, preview_client: AsyncClient) -> None:
+        """Non-existent artist ID returns 404."""
+        resp = await preview_client.get("/graph/artists/999999/preview")
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_preview_handles_timeout(
+        self, preview_client: AsyncClient, preview_db_path: str
+    ) -> None:
+        """Timeout on one source falls through to next."""
+        aid = _artist_id(preview_db_path, "Stereolab")
+        _clear_preview_cache(preview_db_path, aid)
+
+        def mock_get_with_timeout(url, **kwargs):
+            if "deezer" in url:
+                raise httpx.TimeoutException("Connection timed out")
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            if "itunes" in url and "search" in url:
+                mock_resp.json.return_value = ITUNES_SEARCH_RESPONSE
+            else:
+                mock_resp.json.return_value = ITUNES_EMPTY_RESPONSE
+            return mock_resp
+
+        with patch("semantic_index.api.preview._http_get", side_effect=mock_get_with_timeout):
+            resp = await preview_client.get(f"/graph/artists/{aid}/preview")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["preview_url"] == "https://audio-ssl.itunes.apple.com/stereolab_jenny.m4a"
+        assert data["source"] == "itunes_search"


### PR DESCRIPTION
## Summary

- New `GET /graph/artists/{id}/preview` endpoint with multi-source fallback chain (iTunes lookup, Spotify, Bandcamp scrape, Deezer search, iTunes search) and sidecar SQLite caching
- Per-card inline transition player in the graph explorer: play button on each sidebar card crossfades ~12s of artist A into ~12s of artist B via Web Audio API
- Progress bar with two-tone gradient, artist name highlighting, play/pause/seek controls

Closes #110

## Test plan

- [ ] `pytest tests/unit/test_preview.py` — 9 tests covering iTunes lookup, Deezer fallback, Bandcamp fallback, iTunes search fallback, null caching, 404, and timeout handling
- [ ] `pytest tests/unit/` — full suite (654 tests) passes
- [ ] `mypy` and `ruff` pass on all modified files
- [ ] Manual browser test: click play on a sidebar card, verify crossfade playback between two artists
- [ ] Verify fallback: test with an artist that has no Apple Music ID (should fall through to Deezer/iTunes search)