### PR TITLE
Replace local normalization and table names with wxyc_etl imports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,8 @@ jobs:
           python-version: "3.12"
       - uses: dtolnay/rust-toolchain@stable
       - run: pip install maturin
-      - run: cd _wxyc-etl/wxyc-etl-python && maturin build --release && pip install target/wheels/*.whl
+      - run: cd _wxyc-etl/wxyc-etl-python && maturin build --release
+      - run: pip install _wxyc-etl/target/wheels/*.whl
       - run: pip install -e ".[api,dev]"
       - run: mypy semantic_index/
 
@@ -50,6 +51,7 @@ jobs:
           python-version: "3.12"
       - uses: dtolnay/rust-toolchain@stable
       - run: pip install maturin
-      - run: cd _wxyc-etl/wxyc-etl-python && maturin build --release && pip install target/wheels/*.whl
+      - run: cd _wxyc-etl/wxyc-etl-python && maturin build --release
+      - run: pip install _wxyc-etl/target/wheels/*.whl
       - run: pip install -e ".[api,dev]"
       - run: pytest tests/unit/ -v --cov=semantic_index --cov-report=term-missing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          repository: WXYC/wxyc-etl
+          path: _wxyc-etl
+          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - uses: dtolnay/rust-toolchain@stable
+      - run: pip install maturin
+      - run: cd _wxyc-etl/wxyc-etl-python && maturin build --release && pip install target/wheels/*.whl
       - run: pip install -e ".[api,dev]"
       - run: mypy semantic_index/
 
@@ -32,8 +40,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          repository: WXYC/wxyc-etl
+          path: _wxyc-etl
+          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - uses: dtolnay/rust-toolchain@stable
+      - run: pip install maturin
+      - run: cd _wxyc-etl/wxyc-etl-python && maturin build --release && pip install target/wheels/*.whl
       - run: pip install -e ".[api,dev]"
       - run: pytest tests/unit/ -v --cov=semantic_index --cov-report=term-missing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,12 +23,12 @@ SQLite ──→ api (FastAPI + aiosqlite) ──→ JSON responses
 |--------|---------------|
 | `semantic_index/sql_parser.py` | Parse MySQL INSERT statements from SQL dump files. Streaming interface for large files. |
 | `semantic_index/models.py` | Pydantic data models for all pipeline entities. |
-| `semantic_index/artist_resolver.py` | Multi-tier artist name resolution: FK chain, name match, normalized, fuzzy (Jaro-Winkler), Discogs, raw fallback. |
+| `semantic_index/artist_resolver.py` | Multi-tier artist name resolution: FK chain, name match, normalized (via `wxyc_etl.text.normalize_artist_name` + local bracket/the/& transforms), fuzzy (Jaro-Winkler), Discogs, raw fallback. Uses `wxyc_etl.text.split_artist_name` for alias splitting. |
 | `semantic_index/adjacency.py` | Extract consecutive artist pairs within radio shows. |
 | `semantic_index/pmi.py` | Compute Pointwise Mutual Information for artist co-occurrences. |
 | `semantic_index/node_attributes.py` | Extract and compute per-artist temporal, DJ, and request statistics. |
 | `semantic_index/cross_reference.py` | Extract cross-reference edges from catalog cross-reference tables. |
-| `semantic_index/discogs_client.py` | Two-tier Discogs client: discogs-cache PostgreSQL with library-metadata-lookup API fallback. |
+| `semantic_index/discogs_client.py` | Two-tier Discogs client: discogs-cache PostgreSQL with library-metadata-lookup API fallback. Uses `wxyc_etl.schema` constants for all discogs-cache table names. |
 | `semantic_index/wikidata_client.py` | Wikidata SPARQL client: batched lookups by Discogs ID (P1953), influence relationships (P737), label hierarchy (P749/P355), streaming service IDs (P1902 Spotify, P2850 Apple Music, P3283 Bandcamp), and name search via wbsearchentities API. |
 | `semantic_index/entity_store.py` | Persistent entity store for reconciled artist identities: schema creation/migration, CRUD, artist upsert, reconciliation log, artist styles, entity deduplication by shared Wikidata QID. Creates the artist table from scratch on a fresh database or migrates an existing one. |
 | `semantic_index/reconciliation.py` | Bulk Discogs matching for unreconciled artists via discogs-cache release_artist table, with member/group fallback via artist_member table. |
@@ -38,7 +38,7 @@ SQLite ──→ api (FastAPI + aiosqlite) ──→ JSON responses
 | `semantic_index/discogs_edges.py` | Compute Discogs-derived edges: shared personnel, shared style (Jaccard), label family, compilation co-appearance. |
 | `semantic_index/acousticbrainz.py` | Load AcousticBrainz high-level features from extracted data dump, aggregate per-artist audio profiles, compute cosine similarity edges. |
 | `semantic_index/musicbrainz_client.py` | MusicBrainz cache client: artist name matching and recording MBID resolution via `mb_artist_recording` materialized view. |
-| `semantic_index/graph_metrics.py` | Compute and persist Louvain communities, betweenness centrality, PageRank, and discovery scores to the SQLite database. Idempotent post-processing step runnable standalone or as a pipeline step. |
+| `semantic_index/graph_metrics.py` | Compute and persist Louvain communities, betweenness centrality, PageRank, and discovery scores to the SQLite database. Uses `wxyc_etl.text.is_compilation_artist` to filter compilation entries. Idempotent post-processing step runnable standalone or as a pipeline step. |
 | `semantic_index/graph_export.py` | Build NetworkX graph and export GEXF. |
 | `semantic_index/sqlite_export.py` | Build and export SQLite graph database with enrichment and edge tables. Supports optional entity store integration for persistent artist identities. |
 | `semantic_index/facet_export.py` | Export play-level data and pre-materialized aggregate tables for dynamic faceted PMI computation. Creates dj, play, artist_month_count, artist_dj_count, month_total, and dj_total tables. |
@@ -221,6 +221,17 @@ pytest                          # unit tests only
 pytest -m integration           # needs fixture dump
 pytest -m slow                  # needs production dump
 ```
+
+### Shared Dependencies (wxyc-etl)
+
+The pipeline uses `wxyc-etl` (a Rust/PyO3 package) for shared text normalization, compilation detection, and schema constants:
+
+- **`wxyc_etl.text.normalize_artist_name(name)`** -- NFKD decomposition + diacritics stripping + lowercase + trim. Used as the base layer in `artist_resolver._normalize()`, which adds semantic-index-specific transforms (bracket removal, "the " strip, `&` -> `and`).
+- **`wxyc_etl.text.is_compilation_artist(name)`** -- Compilation/VA detection covering "Various Artists", "V/A", "v.a.", "Soundtrack", "Compilation". Replaces the old narrow `is_various_artists()` in `utils.py`.
+- **`wxyc_etl.text.split_artist_name(name)`** -- Context-free multi-artist splitting on `, `, ` / `, ` + `. Used in `artist_resolver._normalized_forms()`.
+- **`wxyc_etl.schema.*`** -- Table name constants (`RELEASE_TABLE`, `RELEASE_ARTIST_TABLE`, `RELEASE_LABEL_TABLE`, `RELEASE_STYLE_TABLE`, `RELEASE_TRACK_TABLE`, `RELEASE_TRACK_ARTIST_TABLE`) for all discogs-cache SQL queries in `discogs_client.py` and `reconciliation.py`.
+
+Summary tables (`artist_style_summary`, `artist_personnel_summary`, `artist_label_summary`, `artist_compilation_summary`) are materialized views created by discogs-cache and are not part of the wxyc-etl schema constants.
 
 ### Code Style
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ The API is deployed to Railway. Configuration lives in `railway.toml`:
 
 Railway sets the `PORT` environment variable automatically. Set `DB_PATH` to point to the SQLite database file (e.g. via a Railway volume mount or persistent storage).
 
+## Dependencies
+
+The pipeline depends on `wxyc-etl`, a shared Rust/PyO3 package providing text normalization (`normalize_artist_name`, `is_compilation_artist`, `split_artist_name`) and discogs-cache schema constants. All discogs-cache table names in SQL queries come from `wxyc_etl.schema` constants rather than hardcoded strings. See [CLAUDE.md](CLAUDE.md) for the full list of shared functions used.
+
 ## Development
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "rapidfuzz>=3.0.0",
     "psycopg[binary]>=3.1",
     "httpx>=0.25",
+    "wxyc-etl>=0.1.0",
 ]
 
 [project.optional-dependencies]
@@ -51,6 +52,7 @@ target-version = ['py312']
 [tool.ruff]
 line-length = 100
 target-version = "py312"
+exclude = ["scripts/", ".claude/"]
 
 [tool.ruff.lint]
 select = ["E", "W", "F", "I", "N", "UP", "B", "C4"]
@@ -66,6 +68,11 @@ warn_return_any = true
 warn_unused_configs = true
 check_untyped_defs = true
 strict_optional = true
+
+[[tool.mypy.overrides]]
+module = "wxyc_etl.*"
+ignore_missing_imports = true
+follow_untyped_imports = true
 
 [tool.pytest.ini_options]
 markers = [

--- a/semantic_index/artist_resolver.py
+++ b/semantic_index/artist_resolver.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING
 
 from rapidfuzz import process as rfprocess
 from rapidfuzz.distance import JaroWinkler
+from wxyc_etl.text import normalize_artist_name, split_artist_name  # type: ignore[import-untyped]
 
 from semantic_index.models import FlowsheetEntry, LibraryCode, LibraryRelease, ResolvedEntry
 
@@ -47,10 +48,11 @@ _BRACKET_RE = re.compile(r"\s*\[.*?\]\s*$")
 def _normalize(name: str) -> str:
     """Normalize an artist name for matching.
 
-    Strips leading 'the ', normalizes '&' → 'and', removes trailing
-    bracketed disambiguators like '[Scotland]'.
+    Uses wxyc_etl.text.normalize_artist_name for NFKD decomposition, diacritics
+    stripping, lowercasing, and trimming. Then applies semantic-index-specific
+    transforms: bracket removal, leading 'the ' strip, '&' -> 'and'.
     """
-    s = name.strip().lower()
+    s = normalize_artist_name(name)
     s = _BRACKET_RE.sub("", s)
     if s.startswith("the "):
         s = s[4:]
@@ -61,20 +63,30 @@ def _normalize(name: str) -> str:
 def _normalized_forms(name: str) -> list[str]:
     """Generate all normalized forms of a catalog name for index matching.
 
-    Returns the base normalized form plus alias parts from ' / ' and ' aka '
-    separators. E.g., "J Dilla / Jay Dee" → ["j dilla / jay dee", "j dilla", "jay dee"].
+    Returns the base normalized form plus alias parts from context-free splitting
+    (via wxyc_etl.text.split_artist_name for `, `, ` / `, and ` + ` separators)
+    and ` aka ` separators. E.g., "J Dilla / Jay Dee" -> ["j dilla / jay dee",
+    "j dilla", "jay dee"].
     """
     base = _normalize(name)
     forms = [base]
 
+    # Use wxyc_etl split_artist_name for `, `, ` / `, and ` + ` separators
+    parts = split_artist_name(name)
+    if parts is not None:
+        for part in parts:
+            normalized_part = _normalize(part)
+            if normalized_part and normalized_part != base:
+                forms.append(normalized_part)
+
+    # Also handle ` aka ` separator (not covered by split_artist_name)
     lowered = name.strip().lower()
-    for sep in (" / ", " aka "):
-        if sep in lowered:
-            parts = lowered.split(sep)
-            for part in parts:
-                normalized_part = _normalize(part)
-                if normalized_part and normalized_part != base:
-                    forms.append(normalized_part)
+    if " aka " in lowered:
+        aka_parts = lowered.split(" aka ")
+        for part in aka_parts:
+            normalized_part = _normalize(part)
+            if normalized_part and normalized_part != base and normalized_part not in forms:
+                forms.append(normalized_part)
 
     return forms
 

--- a/semantic_index/discogs_client.py
+++ b/semantic_index/discogs_client.py
@@ -12,6 +12,14 @@ import time
 
 import httpx
 import psycopg
+from wxyc_etl.schema import (  # type: ignore[import-untyped]
+    RELEASE_ARTIST_TABLE,
+    RELEASE_LABEL_TABLE,
+    RELEASE_STYLE_TABLE,
+    RELEASE_TABLE,
+    RELEASE_TRACK_ARTIST_TABLE,
+    RELEASE_TRACK_TABLE,
+)
 
 from semantic_index.models import (
     CompilationEdge,
@@ -117,11 +125,11 @@ class DiscogsClient:
         try:
             # Try primary artist credits first
             rows = conn.execute(
-                """
+                f"""
                 SELECT DISTINCT release_id
-                FROM release_artist
+                FROM {RELEASE_ARTIST_TABLE}
                 WHERE lower(artist_name) = lower(%s) AND extra = 0
-                """,
+                """,  # noqa: S608
                 (artist_name,),
             ).fetchall()
             if rows:
@@ -129,11 +137,11 @@ class DiscogsClient:
 
             # Fall back to per-track credits
             rows = conn.execute(
-                """
+                f"""
                 SELECT DISTINCT release_id
-                FROM release_track_artist
+                FROM {RELEASE_TRACK_ARTIST_TABLE}
                 WHERE lower(artist_name) = lower(%s)
-                """,
+                """,  # noqa: S608
                 (artist_name,),
             ).fetchall()
             return [row[0] for row in rows]
@@ -254,7 +262,7 @@ class DiscogsClient:
         result: dict[str, dict] = {}
 
         rows = execute(
-            "SELECT ra.artist_name, ra.release_id FROM release_artist ra WHERE ra.extra = 0 AND lower(ra.artist_name) = ANY(%s)",
+            f"SELECT ra.artist_name, ra.release_id FROM {RELEASE_ARTIST_TABLE} ra WHERE ra.extra = 0 AND lower(ra.artist_name) = ANY(%s)",  # noqa: S608
             (batch,),
         ).fetchall()
 
@@ -267,7 +275,7 @@ class DiscogsClient:
             return {}
 
         style_rows = execute(
-            "SELECT release_id, style FROM release_style WHERE release_id = ANY(%s)",
+            f"SELECT release_id, style FROM {RELEASE_STYLE_TABLE} WHERE release_id = ANY(%s)",  # noqa: S608
             (all_release_ids,),
         ).fetchall()
         release_styles: dict[int, list[str]] = {}
@@ -275,7 +283,7 @@ class DiscogsClient:
             release_styles.setdefault(rid, []).append(style)
 
         extra_rows = execute(
-            "SELECT release_id, artist_name, role FROM release_artist WHERE extra = 1 AND release_id = ANY(%s)",
+            f"SELECT release_id, artist_name, role FROM {RELEASE_ARTIST_TABLE} WHERE extra = 1 AND release_id = ANY(%s)",  # noqa: S608
             (all_release_ids,),
         ).fetchall()
         release_extras: dict[int, list[tuple[str, str | None]]] = {}
@@ -283,7 +291,7 @@ class DiscogsClient:
             release_extras.setdefault(rid, []).append((name, role))
 
         label_rows = execute(
-            "SELECT release_id, label_id, label_name FROM release_label WHERE release_id = ANY(%s)",
+            f"SELECT release_id, label_id, label_name FROM {RELEASE_LABEL_TABLE} WHERE release_id = ANY(%s)",  # noqa: S608
             (all_release_ids,),
         ).fetchall()
         release_labels: dict[int, list[tuple[int | None, str]]] = {}
@@ -291,7 +299,7 @@ class DiscogsClient:
             release_labels.setdefault(rid, []).append((label_id, label_name))
 
         track_artist_rows = execute(
-            "SELECT release_id, artist_name FROM release_track_artist WHERE release_id = ANY(%s)",
+            f"SELECT release_id, artist_name FROM {RELEASE_TRACK_ARTIST_TABLE} WHERE release_id = ANY(%s)",  # noqa: S608
             (all_release_ids,),
         ).fetchall()
         release_track_artists: dict[int, list[str]] = {}
@@ -335,25 +343,25 @@ class DiscogsClient:
 
             # Styles (from release_style table)
             style_rows = conn.execute(
-                f"SELECT DISTINCT style FROM release_style WHERE release_id IN ({placeholder})",  # noqa: S608
+                f"SELECT DISTINCT style FROM {RELEASE_STYLE_TABLE} WHERE release_id IN ({placeholder})",  # noqa: S608
                 ids_tuple,
             ).fetchall()
 
             # Extra artists (personnel credits)
             extra_rows = conn.execute(
-                f"SELECT DISTINCT artist_name, role FROM release_artist WHERE release_id IN ({placeholder}) AND extra = 1",  # noqa: S608
+                f"SELECT DISTINCT artist_name, role FROM {RELEASE_ARTIST_TABLE} WHERE release_id IN ({placeholder}) AND extra = 1",  # noqa: S608
                 ids_tuple,
             ).fetchall()
 
             # Labels
             label_rows = conn.execute(
-                f"SELECT DISTINCT label_id, label_name FROM release_label WHERE release_id IN ({placeholder})",  # noqa: S608
+                f"SELECT DISTINCT label_id, label_name FROM {RELEASE_LABEL_TABLE} WHERE release_id IN ({placeholder})",  # noqa: S608
                 ids_tuple,
             ).fetchall()
 
             # Track artists (for compilation detection)
             track_artist_rows = conn.execute(
-                f"SELECT release_id, artist_name FROM release_track_artist WHERE release_id IN ({placeholder})",  # noqa: S608
+                f"SELECT release_id, artist_name FROM {RELEASE_TRACK_ARTIST_TABLE} WHERE release_id IN ({placeholder})",  # noqa: S608
                 ids_tuple,
             ).fetchall()
 
@@ -380,12 +388,12 @@ class DiscogsClient:
         try:
             # Try primary artist credits
             rows = conn.execute(
-                """
+                f"""
                 SELECT DISTINCT ra.artist_id, ra.artist_name
-                FROM release_artist ra
+                FROM {RELEASE_ARTIST_TABLE} ra
                 WHERE ra.extra = 0 AND lower(ra.artist_name) = lower(%s)
                 LIMIT 1
-                """,
+                """,  # noqa: S608
                 (name,),
             ).fetchall()
             if rows:
@@ -396,12 +404,12 @@ class DiscogsClient:
 
             # Fall back to per-track credits
             rows = conn.execute(
-                """
+                f"""
                 SELECT DISTINCT rta.artist_name
-                FROM release_track_artist rta
+                FROM {RELEASE_TRACK_ARTIST_TABLE} rta
                 WHERE lower(rta.artist_name) = lower(%s)
                 LIMIT 1
-                """,
+                """,  # noqa: S608
                 (name,),
             ).fetchall()
             if rows:
@@ -454,7 +462,7 @@ class DiscogsClient:
         try:
             # Release header
             row = conn.execute(
-                "SELECT id, title, release_year FROM release WHERE id = %s",
+                f"SELECT id, title, release_year FROM {RELEASE_TABLE} WHERE id = %s",  # noqa: S608
                 (release_id,),
             ).fetchone()
             if row is None:
@@ -465,22 +473,22 @@ class DiscogsClient:
 
             # Child tables
             artist_rows = conn.execute(
-                "SELECT artist_id, artist_name, extra, role FROM release_artist WHERE release_id = %s",
+                f"SELECT artist_id, artist_name, extra, role FROM {RELEASE_ARTIST_TABLE} WHERE release_id = %s",  # noqa: S608
                 (release_id,),
             ).fetchall()
 
             label_rows = conn.execute(
-                "SELECT label_id, label_name, catno FROM release_label WHERE release_id = %s",
+                f"SELECT label_id, label_name, catno FROM {RELEASE_LABEL_TABLE} WHERE release_id = %s",  # noqa: S608
                 (release_id,),
             ).fetchall()
 
             track_rows = conn.execute(
-                "SELECT position, title, sequence FROM release_track WHERE release_id = %s ORDER BY sequence",
+                f"SELECT position, title, sequence FROM {RELEASE_TRACK_TABLE} WHERE release_id = %s ORDER BY sequence",  # noqa: S608
                 (release_id,),
             ).fetchall()
 
             track_artist_rows = conn.execute(
-                "SELECT release_id, artist_name FROM release_track_artist WHERE release_id = %s",
+                f"SELECT release_id, artist_name FROM {RELEASE_TRACK_ARTIST_TABLE} WHERE release_id = %s",  # noqa: S608
                 (release_id,),
             ).fetchall()
 

--- a/semantic_index/graph_metrics.py
+++ b/semantic_index/graph_metrics.py
@@ -19,8 +19,9 @@ from dataclasses import dataclass
 
 import networkx as nx
 from networkx.algorithms.community import louvain_communities
+from wxyc_etl.text import is_compilation_artist  # type: ignore[import-untyped]
 
-from semantic_index.utils import ensure_columns, is_various_artists
+from semantic_index.utils import ensure_columns
 
 logger = logging.getLogger(__name__)
 
@@ -77,7 +78,7 @@ def _build_transition_graph(
     rows = conn.execute("SELECT id, canonical_name, genre, total_plays FROM artist").fetchall()
     artists = {}
     for r in rows:
-        if not is_various_artists(r[1]):
+        if not is_compilation_artist(r[1]):
             artists[r[0]] = {"name": r[1], "genre": r[2], "total_plays": r[3]}
 
     valid_ids = set(artists.keys())

--- a/semantic_index/reconciliation.py
+++ b/semantic_index/reconciliation.py
@@ -30,6 +30,11 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+from wxyc_etl.schema import (  # type: ignore[import-untyped]
+    RELEASE_ARTIST_TABLE,
+    RELEASE_STYLE_TABLE,
+)
+
 from semantic_index.discogs_client import DiscogsClient
 from semantic_index.entity_store import EntityStore
 from semantic_index.models import ReconciliationReport
@@ -396,10 +401,10 @@ class ArtistReconciler:
         # Fetch styles by discogs_artist_id
         matched_ids = list({did for did, _ in matches.values()})
         style_rows = conn.execute(
-            "SELECT DISTINCT ra.artist_id, rs.style "
-            "FROM release_style rs "
-            "JOIN release_artist ra ON rs.release_id = ra.release_id "
-            "WHERE ra.extra = 0 AND ra.artist_id = ANY(%s)",
+            f"SELECT DISTINCT ra.artist_id, rs.style "  # noqa: S608
+            f"FROM {RELEASE_STYLE_TABLE} rs "
+            f"JOIN {RELEASE_ARTIST_TABLE} ra ON rs.release_id = ra.release_id "
+            f"WHERE ra.extra = 0 AND ra.artist_id = ANY(%s)",
             (matched_ids,),
         ).fetchall()
 
@@ -440,9 +445,9 @@ class ArtistReconciler:
         rows = self._query_with_fallback(
             conn,
             "SELECT artist_name, discogs_artist_id FROM artist_discogs_id WHERE artist_name = ANY(%s)",
-            "SELECT DISTINCT lower(ra.artist_name), ra.artist_id "
-            "FROM release_artist ra "
-            "WHERE ra.extra = 0 AND lower(ra.artist_name) = ANY(%s)",
+            f"SELECT DISTINCT lower(ra.artist_name), ra.artist_id "  # noqa: S608
+            f"FROM {RELEASE_ARTIST_TABLE} ra "
+            f"WHERE ra.extra = 0 AND lower(ra.artist_name) = ANY(%s)",
             (lower_names,),
         )
 
@@ -460,10 +465,10 @@ class ArtistReconciler:
         style_rows = self._query_with_fallback(
             conn,
             "SELECT artist_name, style FROM artist_style_summary WHERE artist_name = ANY(%s)",
-            "SELECT DISTINCT lower(ra.artist_name), rs.style "
-            "FROM release_style rs "
-            "JOIN release_artist ra ON rs.release_id = ra.release_id "
-            "WHERE ra.extra = 0 AND lower(ra.artist_name) = ANY(%s)",
+            f"SELECT DISTINCT lower(ra.artist_name), rs.style "  # noqa: S608
+            f"FROM {RELEASE_STYLE_TABLE} rs "
+            f"JOIN {RELEASE_ARTIST_TABLE} ra ON rs.release_id = ra.release_id "
+            f"WHERE ra.extra = 0 AND lower(ra.artist_name) = ANY(%s)",
             (matched_lower,),
         )
 
@@ -535,10 +540,10 @@ class ArtistReconciler:
         # 3. Fetch styles by artist_id for matched artists
         matched_ids = list(set(matches.values()))
         style_rows = conn.execute(
-            "SELECT DISTINCT ra.artist_id, rs.style "
-            "FROM release_style rs "
-            "JOIN release_artist ra ON rs.release_id = ra.release_id "
-            "WHERE ra.extra = 0 AND ra.artist_id = ANY(%s)",
+            f"SELECT DISTINCT ra.artist_id, rs.style "  # noqa: S608
+            f"FROM {RELEASE_STYLE_TABLE} rs "
+            f"JOIN {RELEASE_ARTIST_TABLE} ra ON rs.release_id = ra.release_id "
+            f"WHERE ra.extra = 0 AND ra.artist_id = ANY(%s)",
             (matched_ids,),
         ).fetchall()
 

--- a/semantic_index/utils.py
+++ b/semantic_index/utils.py
@@ -7,17 +7,6 @@ import sqlite3
 
 logger = logging.getLogger(__name__)
 
-# ---- Various Artists filtering ----
-
-_VA_EXACT = {"v/a", "various", "various artists"}
-
-
-def is_various_artists(name: str) -> bool:
-    """Return True for Various Artists / V/A compilation entries."""
-    lower = name.lower().strip()
-    return lower in _VA_EXACT or lower.startswith("various artists")
-
-
 # ---- Schema migration ----
 
 

--- a/tests/unit/test_migration_parity.py
+++ b/tests/unit/test_migration_parity.py
@@ -1,0 +1,164 @@
+"""Characterization tests ensuring wxyc_etl functions are parity with local implementations.
+
+These tests verify that:
+1. wxyc_etl.text.is_compilation_artist covers all cases that utils.is_various_artists handles
+2. wxyc_etl.text.normalize_artist_name produces equivalent results to artist_resolver._normalize
+3. wxyc_etl.schema constants cover all hardcoded table names in discogs_client.py
+"""
+
+import pytest
+from wxyc_etl import schema, text
+
+# --- is_compilation_artist parity with utils.is_various_artists ---
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "V/A",
+        "Various",
+        "Various Artists",
+        "various artists",
+        "  Various Artists  ",
+    ],
+    ids=[
+        "V/A",
+        "Various",
+        "Various_Artists",
+        "various_artists_lowercase",
+        "various_artists_padded",
+    ],
+)
+def test_is_compilation_artist_covers_old_is_various_artists(name):
+    """wxyc_etl.is_compilation_artist returns True for every input
+    that the old is_various_artists returned True for."""
+    assert text.is_compilation_artist(name) is True
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "Soundtrack",
+        "Compilation",
+        "Original Motion Picture Soundtrack",
+        "v.a.",
+        "VARIOUS",
+    ],
+    ids=[
+        "Soundtrack",
+        "Compilation",
+        "Motion_Picture_Soundtrack",
+        "v.a.",
+        "VARIOUS_caps",
+    ],
+)
+def test_is_compilation_artist_additional_coverage(name):
+    """wxyc_etl.is_compilation_artist covers additional cases the old
+    narrow check missed."""
+    assert text.is_compilation_artist(name) is True
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "Autechre",
+        "Stereolab",
+        "Cat Power",
+        "Father John Misty",
+        "",
+    ],
+)
+def test_is_compilation_artist_false_for_real_artists(name):
+    """Real artist names should not be flagged as compilation artists."""
+    assert text.is_compilation_artist(name) is False
+
+
+# --- normalize_artist_name parity with artist_resolver._normalize ---
+
+
+@pytest.mark.parametrize(
+    "input_name,expected",
+    [
+        # Basic lowercasing and trimming
+        ("Autechre", "autechre"),
+        ("  Autechre  ", "autechre"),
+        ("AUTECHRE", "autechre"),
+        # Diacritics (NFKD decomposition)
+        ("Bjork", "bjork"),
+        ("Sigur Ros", "sigur ros"),
+        # wxyc_etl does NFKD + strip diacritics, which is a superset of what
+        # the old _normalize did (the old one only did lowercase + strip)
+        ("Cafe Tacvba", "cafe tacvba"),
+        # Empty
+        ("", ""),
+        # Whitespace edge cases
+        ("  Mixed Case  ", "mixed case"),
+    ],
+)
+def test_normalize_artist_name_parity(input_name, expected):
+    """wxyc_etl.normalize_artist_name produces equivalent results for common cases."""
+    assert text.normalize_artist_name(input_name) == expected
+
+
+def test_normalize_handles_none():
+    """normalize_artist_name accepts None and returns empty string."""
+    assert text.normalize_artist_name(None) == ""
+
+
+# --- split_artist_name parity with artist_resolver._normalized_forms ---
+
+
+def test_split_artist_name_slash():
+    """Slash-separated names split correctly."""
+    result = text.split_artist_name("J Dilla / Jay Dee")
+    assert result == ["J Dilla", "Jay Dee"]
+
+
+def test_split_artist_name_no_split():
+    """Single names return None."""
+    assert text.split_artist_name("Autechre") is None
+
+
+def test_split_artist_name_ampersand_no_context():
+    """Ampersand does not split without context."""
+    assert text.split_artist_name("Duke Ellington & John Coltrane") is None
+
+
+# --- schema constants cover all hardcoded table names ---
+
+
+class TestSchemaConstants:
+    """Verify wxyc_etl.schema has constants for all discogs-cache tables used
+    by semantic-index."""
+
+    def test_release_table(self):
+        assert schema.RELEASE_TABLE == "release"
+
+    def test_release_artist_table(self):
+        assert schema.RELEASE_ARTIST_TABLE == "release_artist"
+
+    def test_release_label_table(self):
+        assert schema.RELEASE_LABEL_TABLE == "release_label"
+
+    def test_release_style_table(self):
+        assert schema.RELEASE_STYLE_TABLE == "release_style"
+
+    def test_release_track_table(self):
+        assert schema.RELEASE_TRACK_TABLE == "release_track"
+
+    def test_release_track_artist_table(self):
+        assert schema.RELEASE_TRACK_ARTIST_TABLE == "release_track_artist"
+
+    def test_discogs_tables_includes_all(self):
+        """All tables used by discogs_client.py should be in the discogs_tables() list."""
+        tables = schema.discogs_tables()
+        used_tables = [
+            "release",
+            "release_artist",
+            "release_label",
+            "release_style",
+            "release_track",
+            "release_track_artist",
+        ]
+        for table in used_tables:
+            assert table in tables, f"{table} not in discogs_tables()"


### PR DESCRIPTION
## Summary

- Replace `is_various_artists()` with `wxyc_etl.text.is_compilation_artist()` in `graph_metrics.py` and delete the local implementation from `utils.py`. The wxyc_etl version covers additional cases (Soundtrack, Compilation, v.a.) beyond the narrow V/A check.
- Replace the base normalization in `artist_resolver._normalize()` with `wxyc_etl.text.normalize_artist_name()` (NFKD decomposition + diacritics stripping), then layer on semantic-index-specific transforms (bracket removal, "the " strip, `&` -> `and`). Replace slash/aka splitting in `_normalized_forms()` with `wxyc_etl.text.split_artist_name()`.
- Replace all hardcoded discogs-cache table names in `discogs_client.py` and `reconciliation.py` with `wxyc_etl.schema` constants (`RELEASE_TABLE`, `RELEASE_ARTIST_TABLE`, `RELEASE_LABEL_TABLE`, `RELEASE_STYLE_TABLE`, `RELEASE_TRACK_TABLE`, `RELEASE_TRACK_ARTIST_TABLE`).
- Add `wxyc-etl>=0.1.0` to `pyproject.toml` dependencies and configure mypy/ruff for the new package.
- Add 34 characterization tests in `test_migration_parity.py` verifying parity between old and new implementations.

Summary tables (`artist_style_summary`, `artist_personnel_summary`, `artist_label_summary`, `artist_compilation_summary`) are materialized views created by discogs-cache and are not part of the wxyc-etl schema constants -- they remain as string literals.

Source transport adoption (`PgSource`, `SparqlSource`, `HttpSource` from wxyc-catalog) is deferred -- wxyc-catalog is scaffolded but the transport classes are not yet implemented.

Closes WXYC/semantic-index#114

## Test plan

- [x] All 688 unit tests pass (654 existing + 34 new parity tests)
- [x] ruff check passes
- [x] ruff format passes
- [x] mypy passes
- [x] Pre-commit hooks pass