### PR TITLE
Add --entity-source=lml flag for LML identity import

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,7 @@ SQLite ──→ api (FastAPI + aiosqlite) ──→ JSON responses
 | `semantic_index/discogs_client.py` | Two-tier Discogs client: discogs-cache PostgreSQL with library-metadata-lookup API fallback. |
 | `semantic_index/wikidata_client.py` | Wikidata SPARQL client: batched lookups by Discogs ID (P1953), influence relationships (P737), label hierarchy (P749/P355), streaming service IDs (P1902 Spotify, P2850 Apple Music, P3283 Bandcamp), and name search via wbsearchentities API. |
 | `semantic_index/entity_store.py` | Persistent entity store for reconciled artist identities: schema creation/migration, CRUD, artist upsert, reconciliation log, artist styles, entity deduplication by shared Wikidata QID. Creates the artist table from scratch on a fresh database or migrates an existing one. |
+| `semantic_index/lml_identity.py` | Import pre-resolved identities from LML's `entity.identity` PG table into the local SQLite entity store. Used by `--entity-source=lml`. Bridge module for ETL pipeline unification. |
 | `semantic_index/reconciliation.py` | Bulk Discogs matching for unreconciled artists via discogs-cache release_artist table, with member/group fallback via artist_member table. |
 | `semantic_index/wikidata_influence.py` | Extract directed Wikidata P737 influence edges between reconciled artists. Resolves QIDs to canonical names via entity store. |
 | `semantic_index/label_hierarchy.py` | Populate label and label_hierarchy tables from Wikidata P749/P355 relationships via Discogs label ID (P1902) lookups. |
@@ -256,7 +257,8 @@ python run_pipeline.py dump.sql --entity-store-path output/wxyc_artist_graph.db 
 ```
 
 - `--entity-store-path PATH` — Path to entity store SQLite database. Creates it if needed.
-- `--skip-reconciliation` — Skip Discogs reconciliation step.
+- `--entity-source {local,lml}` — Identity source for reconciliation. `local` (default) runs local reconciliation via entity_store.py + reconciliation.py. `lml` reads pre-resolved identities from LML's `entity.identity` PG table (requires `--discogs-cache-dsn`). Both paths coexist during the transition to centralized identity resolution. When `lml` is set, local reconciliation steps (reconcile_batch, reconcile_members, reconcile_wikidata) are skipped.
+- `--skip-reconciliation` — Skip Discogs reconciliation step (only applies to `--entity-source=local`).
 - `--compute-discogs-edges` — Compute Discogs-derived edges (shared personnel, styles, labels, compilations). Off by default.
 - `--compute-wikidata-influences` — Query Wikidata P737 (influenced by) and create directed influence edges. Requires `--entity-store-path` with reconciled Wikidata QIDs.
 - `--populate-label-hierarchy` — Populate label and label_hierarchy tables from Wikidata P749/P355. Requires `--entity-store-path` and enrichment data.

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -177,6 +177,15 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "from the existing database, and calls export_facet_tables. Skips all other steps.",
     )
     parser.add_argument(
+        "--entity-source",
+        choices=["local", "lml"],
+        default="local",
+        help="Identity source for reconciliation. 'local' (default) runs local "
+        "reconciliation via entity_store.py + reconciliation.py. 'lml' reads "
+        "pre-resolved identities from LML's entity.identity PG table "
+        "(requires --discogs-cache-dsn). Both paths coexist during transition.",
+    )
+    parser.add_argument(
         "--acousticbrainz-dir",
         default=os.environ.get("ACOUSTICBRAINZ_DIR"),
         help="Path to extracted AcousticBrainz data dump. "
@@ -450,47 +459,68 @@ def run(args: argparse.Namespace) -> None:
         log.info("Bulk upserting %d artists into entity store...", len(all_canonical))
         entity_store.bulk_upsert_artists(all_canonical)
 
-        # 5d. Reconcile via Discogs (unless skipped or no cache DSN)
-        reconcile_client = DiscogsClient(
-            cache_dsn=args.discogs_cache_dsn,
-            api_base_url=None,
-        )
-        reconciler = ArtistReconciler(entity_store, reconcile_client)
+        # 5d. Reconcile: either from LML entity store (PG) or locally
+        if getattr(args, "entity_source", "local") == "lml":
+            # Read pre-resolved identities from LML's entity.identity PG table
+            if not args.discogs_cache_dsn:
+                log.error("--entity-source=lml requires --discogs-cache-dsn")
+                sys.exit(1)
+            log.info("Importing identities from LML entity store (entity.identity)...")
+            from semantic_index.lml_identity import PgSource, import_lml_identities
 
-        if not args.skip_reconciliation and args.discogs_cache_dsn:
-            log.info("Running Discogs reconciliation...")
-            report = reconciler.reconcile_batch()
-            log.info(
-                "Reconciliation: %d attempted, %d succeeded, %d no_match, %d errored",
-                report.attempted,
-                report.succeeded,
-                report.no_match,
-                report.errored,
+            pg_source = PgSource(args.discogs_cache_dsn)
+            try:
+                lml_report = import_lml_identities(entity_store, pg_source)
+                log.info(
+                    "LML identity import: %d matched, %d unmatched, %d entities created",
+                    lml_report.matched,
+                    lml_report.unmatched,
+                    lml_report.entities_created,
+                )
+            finally:
+                pg_source.close()
+        else:
+            # Local reconciliation (existing behavior)
+            reconcile_client = DiscogsClient(
+                cache_dsn=args.discogs_cache_dsn,
+                api_base_url=None,
             )
-            # Re-try no_match artists against member/group table
-            member_report = reconciler.reconcile_members()
-            log.info(
-                "Member reconciliation: %d attempted, %d succeeded, %d no_match, %d errored",
-                member_report.attempted,
-                member_report.succeeded,
-                member_report.no_match,
-                member_report.errored,
-            )
-        elif not args.skip_reconciliation:
-            log.warning("Skipping reconciliation: no discogs-cache DSN available")
+            reconciler = ArtistReconciler(entity_store, reconcile_client)
 
-        # 5e. Wikidata name search for remaining no_match artists (opt-in)
-        if args.wikidata_reconciliation:
-            log.info("Running Wikidata name search for no_match artists...")
-            wikidata_client = WikidataClient(cache_dsn=args.wikidata_cache_dsn)
-            wikidata_report = reconciler.reconcile_wikidata(wikidata_client)
-            log.info(
-                "Wikidata reconciliation: %d attempted, %d succeeded, %d no_match, %d errored",
-                wikidata_report.attempted,
-                wikidata_report.succeeded,
-                wikidata_report.no_match,
-                wikidata_report.errored,
-            )
+            if not args.skip_reconciliation and args.discogs_cache_dsn:
+                log.info("Running Discogs reconciliation...")
+                report = reconciler.reconcile_batch()
+                log.info(
+                    "Reconciliation: %d attempted, %d succeeded, %d no_match, %d errored",
+                    report.attempted,
+                    report.succeeded,
+                    report.no_match,
+                    report.errored,
+                )
+                # Re-try no_match artists against member/group table
+                member_report = reconciler.reconcile_members()
+                log.info(
+                    "Member reconciliation: %d attempted, %d succeeded, %d no_match, %d errored",
+                    member_report.attempted,
+                    member_report.succeeded,
+                    member_report.no_match,
+                    member_report.errored,
+                )
+            elif not args.skip_reconciliation:
+                log.warning("Skipping reconciliation: no discogs-cache DSN available")
+
+            # 5e. Wikidata name search for remaining no_match artists (opt-in)
+            if args.wikidata_reconciliation:
+                log.info("Running Wikidata name search for no_match artists...")
+                wikidata_client = WikidataClient(cache_dsn=args.wikidata_cache_dsn)
+                wikidata_report = reconciler.reconcile_wikidata(wikidata_client)
+                log.info(
+                    "Wikidata reconciliation: %d attempted, %d succeeded, %d no_match, %d errored",
+                    wikidata_report.attempted,
+                    wikidata_report.succeeded,
+                    wikidata_report.no_match,
+                    wikidata_report.errored,
+                )
 
         # 5e2. Assign Wikidata QIDs from wikidata-cache via Discogs ID bridge
         if args.wikidata_cache_dsn:

--- a/semantic_index/lml_identity.py
+++ b/semantic_index/lml_identity.py
@@ -1,0 +1,189 @@
+"""Import pre-resolved artist identities from LML's entity.identity table.
+
+When ``--entity-source=lml`` is set, the pipeline reads identity mappings
+from the discogs-cache PostgreSQL database (``entity.identity`` table)
+instead of running local reconciliation. This module provides the bridge
+function that reads those identities and writes them into the local
+SQLite entity store.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from dataclasses import dataclass
+from typing import Any, Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+_FETCH_ALL_IDENTITIES_SQL = """\
+SELECT library_name, discogs_artist_id, wikidata_qid,
+       musicbrainz_artist_id, spotify_artist_id,
+       apple_music_artist_id, bandcamp_id, reconciliation_status
+FROM entity.identity
+WHERE reconciliation_status != 'unreconciled'
+"""
+
+
+@runtime_checkable
+class PgFetchProtocol(Protocol):
+    """Protocol for a PostgreSQL connection that can fetch rows as dicts."""
+
+    def fetchall(self, query: str) -> list[dict[str, Any]]: ...
+    def close(self) -> None: ...
+
+
+class PgSource:
+    """Synchronous PostgreSQL source using psycopg.
+
+    Matches the interface used by ``discogs_client.py`` in semantic-index.
+    Returns rows as dicts.
+
+    Args:
+        dsn: PostgreSQL connection string.
+    """
+
+    def __init__(self, dsn: str) -> None:
+        self._dsn = dsn
+        self._conn: Any | None = None
+
+    def _get_conn(self) -> Any:
+        if self._conn is None:
+            import psycopg
+            from psycopg.rows import dict_row
+
+            self._conn = psycopg.connect(self._dsn, autocommit=True, row_factory=dict_row)
+        return self._conn
+
+    def fetchall(self, query: str) -> list[dict[str, Any]]:
+        """Execute a query and return all rows as dicts."""
+        conn = self._get_conn()
+        result: list[dict[str, Any]] = conn.execute(query).fetchall()
+        return result
+
+    def close(self) -> None:
+        """Close the connection."""
+        if self._conn is not None:
+            self._conn.close()
+            self._conn = None
+
+
+@dataclass
+class ImportReport:
+    """Summary of an LML identity import run."""
+
+    matched: int = 0
+    unmatched: int = 0
+    entities_created: int = 0
+
+
+def import_lml_identities(
+    entity_store: Any,
+    pg_source: PgFetchProtocol,
+) -> ImportReport:
+    """Read identities from LML's entity.identity PG table and apply to local entity store.
+
+    For each identity row, updates the local SQLite artist row with external IDs
+    (discogs_artist_id, musicbrainz_artist_id, reconciliation_status) and creates
+    an entity row with QID and streaming IDs when a wikidata_qid is present.
+
+    Args:
+        entity_store: The local SQLite EntityStore instance.
+        pg_source: A PG source connected to the discogs-cache database.
+
+    Returns:
+        ImportReport with match/unmatch counts.
+
+    Raises:
+        Exception: If the PG connection fails.
+    """
+    rows = pg_source.fetchall(_FETCH_ALL_IDENTITIES_SQL)
+
+    # Index by library_name for fast lookup
+    identity_by_name: dict[str, dict[str, Any]] = {row["library_name"]: row for row in rows}
+
+    # Get all local artist names
+    conn = entity_store._conn
+    conn.row_factory = sqlite3.Row
+    local_artists = conn.execute("SELECT id, canonical_name FROM artist").fetchall()
+    conn.row_factory = None
+
+    report = ImportReport()
+    now_expr = "strftime('%Y-%m-%dT%H:%M:%SZ', 'now')"
+
+    for artist_row in local_artists:
+        artist_id = artist_row[0]
+        canonical_name = artist_row[1]
+        identity = identity_by_name.get(canonical_name)
+
+        if identity is None:
+            report.unmatched += 1
+            continue
+
+        report.matched += 1
+
+        # Update artist row with external IDs
+        entity_store.upsert_artist(
+            canonical_name,
+            discogs_artist_id=identity["discogs_artist_id"],
+            musicbrainz_artist_id=identity["musicbrainz_artist_id"],
+        )
+
+        # Update reconciliation status
+        conn.execute(
+            f"UPDATE artist SET reconciliation_status = ?, updated_at = {now_expr} WHERE id = ?",
+            (identity["reconciliation_status"], artist_id),
+        )
+
+        # Create/update entity with QID and streaming IDs
+        qid = identity.get("wikidata_qid")
+        spotify = identity.get("spotify_artist_id")
+        apple_music = identity.get("apple_music_artist_id")
+        bandcamp = identity.get("bandcamp_id")
+
+        if qid or spotify or apple_music or bandcamp:
+            # Check if artist already has an entity
+            conn.row_factory = sqlite3.Row
+            existing = conn.execute(
+                "SELECT entity_id FROM artist WHERE id = ?", (artist_id,)
+            ).fetchone()
+            conn.row_factory = None
+            existing_entity_id = existing[0] if existing and existing[0] else None
+
+            if existing_entity_id:
+                # Update existing entity
+                conn.execute(
+                    f"UPDATE entity SET "
+                    f"wikidata_qid = COALESCE(?, wikidata_qid), "
+                    f"spotify_artist_id = COALESCE(?, spotify_artist_id), "
+                    f"apple_music_artist_id = COALESCE(?, apple_music_artist_id), "
+                    f"bandcamp_id = COALESCE(?, bandcamp_id), "
+                    f"updated_at = {now_expr} "
+                    f"WHERE id = ?",
+                    (qid, spotify, apple_music, bandcamp, existing_entity_id),
+                )
+            else:
+                # Create new entity and link to artist
+                cur = conn.execute(
+                    f"INSERT INTO entity (name, entity_type, wikidata_qid, "
+                    f"spotify_artist_id, apple_music_artist_id, bandcamp_id, "
+                    f"created_at, updated_at) "
+                    f"VALUES (?, 'artist', ?, ?, ?, ?, {now_expr}, {now_expr})",
+                    (canonical_name, qid, spotify, apple_music, bandcamp),
+                )
+                new_entity_id = cur.lastrowid
+                conn.execute(
+                    "UPDATE artist SET entity_id = ? WHERE id = ?",
+                    (new_entity_id, artist_id),
+                )
+                report.entities_created += 1
+
+    conn.commit()
+
+    logger.info(
+        "LML identity import: %d matched, %d unmatched, %d entities created",
+        report.matched,
+        report.unmatched,
+        report.entities_created,
+    )
+    return report

--- a/tests/unit/test_lml_entity_source.py
+++ b/tests/unit/test_lml_entity_source.py
@@ -1,0 +1,206 @@
+"""Tests for --entity-source=lml flag and LML identity reading."""
+
+import sqlite3
+from unittest.mock import MagicMock
+
+import pytest
+
+from run_pipeline import parse_args
+from semantic_index.entity_store import EntityStore
+from semantic_index.lml_identity import import_lml_identities
+
+
+class TestParseEntitySourceFlag:
+    def test_entity_source_default_is_local(self):
+        args = parse_args(["dump.sql"])
+        assert args.entity_source == "local"
+
+    def test_entity_source_local_explicit(self):
+        args = parse_args(["dump.sql", "--entity-source", "local"])
+        assert args.entity_source == "local"
+
+    def test_entity_source_lml(self):
+        args = parse_args(["dump.sql", "--entity-source", "lml"])
+        assert args.entity_source == "lml"
+
+    def test_entity_source_invalid_rejected(self):
+        with pytest.raises(SystemExit):
+            parse_args(["dump.sql", "--entity-source", "invalid"])
+
+    def test_entity_source_lml_with_entity_store_path(self):
+        args = parse_args(
+            ["dump.sql", "--entity-source", "lml", "--entity-store-path", "/tmp/store.db"]
+        )
+        assert args.entity_source == "lml"
+        assert args.entity_store_path == "/tmp/store.db"
+
+
+class TestImportLmlIdentities:
+    """Tests for import_lml_identities() which reads from entity.identity PG table."""
+
+    def _make_entity_store(self, tmp_path) -> EntityStore:
+        """Create a temporary EntityStore with an artist table."""
+        db_path = str(tmp_path / "test.db")
+        store = EntityStore(db_path)
+        store.initialize()
+        return store
+
+    def _make_pg_source(self, rows: list[dict]) -> MagicMock:
+        """Create a mock PG source that returns the given rows from fetchall()."""
+        mock_pg = MagicMock()
+        mock_pg.fetchall = MagicMock(return_value=rows)
+        return mock_pg
+
+    def test_populates_discogs_artist_id(self, tmp_path):
+        """Artists matched in entity.identity get their discogs_artist_id populated."""
+        store = self._make_entity_store(tmp_path)
+        store.bulk_upsert_artists(["Stereolab", "Autechre"])
+
+        mock_pg = self._make_pg_source(
+            [
+                {
+                    "library_name": "Stereolab",
+                    "discogs_artist_id": 2154,
+                    "wikidata_qid": "Q484464",
+                    "musicbrainz_artist_id": "d4133898-91ea-48ea-8820-1b85825901fe",
+                    "spotify_artist_id": "1p6GVMFhLhSrRE7qgy8aAS",
+                    "apple_music_artist_id": "5765873",
+                    "bandcamp_id": None,
+                    "reconciliation_status": "reconciled",
+                },
+                {
+                    "library_name": "Autechre",
+                    "discogs_artist_id": 12,
+                    "wikidata_qid": "Q210513",
+                    "musicbrainz_artist_id": "410c9baf-5469-44f6-9852-826524b80c61",
+                    "spotify_artist_id": "6WH1V41LwGDGmlPUhSZLHO",
+                    "apple_music_artist_id": None,
+                    "bandcamp_id": None,
+                    "reconciliation_status": "reconciled",
+                },
+            ]
+        )
+
+        report = import_lml_identities(store, mock_pg)
+
+        artist = store.get_artist_by_name("Stereolab")
+        assert artist is not None
+        assert artist["discogs_artist_id"] == 2154
+        assert artist["reconciliation_status"] == "reconciled"
+
+        artist2 = store.get_artist_by_name("Autechre")
+        assert artist2 is not None
+        assert artist2["discogs_artist_id"] == 12
+
+        assert report.matched == 2
+        assert report.unmatched == 0
+
+    def test_unmatched_artists_counted(self, tmp_path):
+        """Artists in the local store but not in entity.identity are counted as unmatched."""
+        store = self._make_entity_store(tmp_path)
+        store.bulk_upsert_artists(["Stereolab", "Unknown Artist"])
+
+        mock_pg = self._make_pg_source(
+            [
+                {
+                    "library_name": "Stereolab",
+                    "discogs_artist_id": 2154,
+                    "wikidata_qid": None,
+                    "musicbrainz_artist_id": None,
+                    "spotify_artist_id": None,
+                    "apple_music_artist_id": None,
+                    "bandcamp_id": None,
+                    "reconciliation_status": "reconciled",
+                },
+            ]
+        )
+
+        report = import_lml_identities(store, mock_pg)
+        assert report.matched == 1
+        assert report.unmatched == 1
+
+    def test_empty_entity_identity_table(self, tmp_path):
+        """When entity.identity returns no rows, all local artists are unmatched."""
+        store = self._make_entity_store(tmp_path)
+        store.bulk_upsert_artists(["Stereolab", "Autechre"])
+
+        mock_pg = self._make_pg_source([])
+
+        report = import_lml_identities(store, mock_pg)
+        assert report.matched == 0
+        assert report.unmatched == 2
+
+    def test_creates_entity_with_qid(self, tmp_path):
+        """When a QID is present, an entity row is created and linked to the artist."""
+        store = self._make_entity_store(tmp_path)
+        store.bulk_upsert_artists(["Stereolab"])
+
+        mock_pg = self._make_pg_source(
+            [
+                {
+                    "library_name": "Stereolab",
+                    "discogs_artist_id": 2154,
+                    "wikidata_qid": "Q484464",
+                    "musicbrainz_artist_id": None,
+                    "spotify_artist_id": "1p6GVMFhLhSrRE7qgy8aAS",
+                    "apple_music_artist_id": "5765873",
+                    "bandcamp_id": None,
+                    "reconciliation_status": "reconciled",
+                },
+            ]
+        )
+
+        import_lml_identities(store, mock_pg)
+
+        artist = store.get_artist_by_name("Stereolab")
+        assert artist is not None
+        assert artist["entity_id"] is not None
+
+        # Check the entity row has the QID and streaming IDs
+        conn = store._conn
+        conn.row_factory = sqlite3.Row
+        entity = conn.execute(
+            "SELECT * FROM entity WHERE id = ?", (artist["entity_id"],)
+        ).fetchone()
+        conn.row_factory = None
+        assert entity is not None
+        assert entity["wikidata_qid"] == "Q484464"
+        assert entity["spotify_artist_id"] == "1p6GVMFhLhSrRE7qgy8aAS"
+        assert entity["apple_music_artist_id"] == "5765873"
+
+    def test_musicbrainz_id_populated(self, tmp_path):
+        """MusicBrainz artist ID from entity.identity is written to the artist row."""
+        store = self._make_entity_store(tmp_path)
+        store.bulk_upsert_artists(["Autechre"])
+
+        mock_pg = self._make_pg_source(
+            [
+                {
+                    "library_name": "Autechre",
+                    "discogs_artist_id": 12,
+                    "wikidata_qid": None,
+                    "musicbrainz_artist_id": "410c9baf-5469-44f6-9852-826524b80c61",
+                    "spotify_artist_id": None,
+                    "apple_music_artist_id": None,
+                    "bandcamp_id": None,
+                    "reconciliation_status": "reconciled",
+                },
+            ]
+        )
+
+        import_lml_identities(store, mock_pg)
+
+        artist = store.get_artist_by_name("Autechre")
+        assert artist is not None
+        assert artist["musicbrainz_artist_id"] == "410c9baf-5469-44f6-9852-826524b80c61"
+
+    def test_pg_connection_failure_raises(self, tmp_path):
+        """When PG connection fails, import_lml_identities raises an exception."""
+        store = self._make_entity_store(tmp_path)
+        store.bulk_upsert_artists(["Stereolab"])
+
+        mock_pg = MagicMock()
+        mock_pg.fetchall = MagicMock(side_effect=Exception("Connection refused"))
+
+        with pytest.raises(Exception, match="Connection refused"):
+            import_lml_identities(store, mock_pg)


### PR DESCRIPTION
## Summary

- Add `--entity-source=lml` flag to `run_pipeline.py` that reads pre-resolved identities from LML's `entity.identity` PG table instead of running local reconciliation
- Add `semantic_index/lml_identity.py` module with `PgSource` (sync psycopg), `ImportReport` dataclass, and `import_lml_identities()` function that matches PG identities to local artist rows by canonical name
- When `--entity-source=lml` is set, the pipeline populates discogs_artist_id, musicbrainz_artist_id, reconciliation_status, and creates entity rows with QID/streaming IDs -- skipping local reconcile_batch, reconcile_members, and reconcile_wikidata steps
- Default `--entity-source=local` preserves existing behavior exactly
- 11 unit tests covering flag parsing (5) and import function (6: matched/unmatched counts, entity creation with QID, MusicBrainz ID, empty table, PG failure)

Closes WXYC/library-metadata-lookup#98

## Test plan

- [x] All 11 new tests pass
- [x] All 14 existing run_pipeline tests pass
- [x] mypy, ruff check, ruff format all pass
- [ ] End-to-end: run pipeline with `--entity-source=lml` against a real discogs-cache database and compare coverage with `--entity-source=local`