### PR TITLE
Add compilation track artist resolution for VA entries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ SQLite ──→ api (FastAPI + aiosqlite) ──→ JSON responses
 |--------|---------------|
 | `semantic_index/sql_parser.py` | Parse MySQL INSERT statements from SQL dump files. Uses `wxyc_etl.parser` Rust extension for ~1000x faster parsing, with `sql_parser_rs` and pure-Python fallbacks. Set `WXYC_ETL_NO_RUST=1` to force pure-Python. |
 | `semantic_index/models.py` | Pydantic data models for all pipeline entities. |
-| `semantic_index/artist_resolver.py` | Multi-tier artist name resolution: FK chain, name match, normalized (via `wxyc_etl.text.normalize_artist_name` + local bracket/the/& transforms), fuzzy (Jaro-Winkler), Discogs, raw fallback. Uses `wxyc_etl.text.split_artist_name` for alias splitting. |
+| `semantic_index/artist_resolver.py` | Multi-tier artist name resolution: compilation track artist (CTA) lookup for VA entries, FK chain, name match, normalized (via `wxyc_etl.text.normalize_artist_name` + local bracket/the/& transforms), fuzzy (Jaro-Winkler), Discogs, raw fallback. Uses `wxyc_etl.text.split_artist_name` for alias splitting, `wxyc_etl.text.is_compilation_artist` for VA detection. |
 | `semantic_index/adjacency.py` | Extract consecutive artist pairs within radio shows. |
 | `semantic_index/pmi.py` | Compute Pointwise Mutual Information for artist co-occurrences. |
 | `semantic_index/node_attributes.py` | Extract and compute per-artist temporal, DJ, and request statistics. |
@@ -62,6 +62,7 @@ SQLite ──→ api (FastAPI + aiosqlite) ──→ JSON responses
 | LIBRARY_CODE_CROSS_REFERENCE | 1=CROSS_REFERENCING_ARTIST_ID (→ LIBRARY_CODE.ID), 2=CROSS_REFERENCED_LIBRARY_CODE_ID, 3=COMMENT |
 | RELEASE_CROSS_REFERENCE | 1=CROSS_REFERENCING_ARTIST_ID (→ LIBRARY_CODE.ID), 2=CROSS_REFERENCED_RELEASE_ID, 3=COMMENT |
 | GENRE | 0=ID, 1=NAME |
+| COMPILATION_TRACK_ARTIST | 0=ID, 1=LIBRARY_RELEASE_ID, 2=ARTIST_NAME, 3=TRACK_TITLE (loaded from separate dump via `--compilation-track-artist-dump`) |
 
 ### SQLite Schema
 
@@ -268,6 +269,7 @@ python run_pipeline.py dump.sql --db-path output/wxyc_artist_graph.db --discogs-
 ```
 
 - `--db-path PATH` — Path to pipeline SQLite database. Creates it if needed. Identity resolution is read from LML's `entity.identity` PG table (requires `--discogs-cache-dsn`).
+- `--compilation-track-artist-dump PATH` — Path to a SQL dump containing the `COMPILATION_TRACK_ARTIST` table. When provided, VA/compilation entries are resolved to per-track artists (Tier 0) before the FK chain.
 - `--compute-discogs-edges` — Compute Discogs-derived edges (shared personnel, styles, labels, compilations). Off by default.
 - `--compute-wikidata-influences` — Query Wikidata P737 (influenced by) and create directed influence edges. Requires `--db-path` with reconciled Wikidata QIDs.
 - `--populate-label-hierarchy` — Populate label and label_hierarchy tables from Wikidata P749/P355. Requires `--db-path` and enrichment data.

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -15,7 +15,7 @@ import time
 from pathlib import Path
 
 from semantic_index.adjacency import extract_adjacency_pairs
-from semantic_index.artist_resolver import ArtistResolver
+from semantic_index.artist_resolver import ArtistResolver, build_cta_index
 from semantic_index.cross_reference import CrossReferenceExtractor
 from semantic_index.discogs_client import DiscogsClient
 from semantic_index.discogs_edges import (
@@ -174,6 +174,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         type=float,
         default=0.98,
         help="Minimum cosine similarity for acoustic similarity edges (default: 0.98)",
+    )
+    parser.add_argument(
+        "--compilation-track-artist-dump",
+        default=None,
+        help="Path to a SQL dump file containing the COMPILATION_TRACK_ARTIST table. "
+        "When provided, VA entries are resolved to per-track artists before the FK chain.",
     )
     return parser.parse_args(argv)
 
@@ -340,7 +346,18 @@ def run(args: argparse.Namespace) -> None:
         log.info("  %d shows with DJ mapping", len(show_to_dj))
 
         # 4. Build resolver
-        resolver = ArtistResolver(releases=releases, codes=codes)
+        cta_index = None
+        if args.compilation_track_artist_dump:
+            cta_dump_path = args.compilation_track_artist_dump
+            if not Path(cta_dump_path).exists():
+                log.warning("CTA dump file not found: %s — skipping", cta_dump_path)
+            else:
+                log.info("Parsing COMPILATION_TRACK_ARTIST table from %s...", cta_dump_path)
+                cta_rows = load_table_rows(cta_dump_path, "COMPILATION_TRACK_ARTIST")
+                cta_index = build_cta_index(cta_rows)
+                log.info("  %d track-artist entries indexed", len(cta_index))
+
+        resolver = ArtistResolver(releases=releases, codes=codes, compilation_track_index=cta_index)
 
         # 5. Stream flowsheet entries and resolve
         log.info("Parsing FLOWSHEET_ENTRY_PROD and resolving artists...")

--- a/semantic_index/artist_resolver.py
+++ b/semantic_index/artist_resolver.py
@@ -1,6 +1,7 @@
 """Artist name resolution via library catalog and Discogs.
 
 Resolution strategies (in order of precedence):
+0. Compilation track: for VA entries, look up per-track artist in COMPILATION_TRACK_ARTIST index
 1. FK chain: LIBRARY_RELEASE_ID → LIBRARY_RELEASE → LIBRARY_CODE → PRESENTATION_NAME
 2. Name match: exact case-insensitive match against LIBRARY_CODE.PRESENTATION_NAME
 3. Normalized match: strip "The ", "&" → "and", bracket removal, slash/aka alias splitting
@@ -19,7 +20,11 @@ from typing import TYPE_CHECKING
 
 from rapidfuzz import process as rfprocess
 from rapidfuzz.distance import JaroWinkler
-from wxyc_etl.text import normalize_artist_name, split_artist_name  # type: ignore[import-untyped]
+from wxyc_etl.text import (  # type: ignore[import-untyped]
+    is_compilation_artist,
+    normalize_artist_name,
+    split_artist_name,
+)
 
 from semantic_index.models import FlowsheetEntry, LibraryCode, LibraryRelease, ResolvedEntry
 
@@ -101,6 +106,27 @@ def _normalized_forms(name: str) -> list[str]:
     return forms
 
 
+def build_cta_index(rows: list[tuple]) -> dict[tuple[int, str], str]:
+    """Build a lookup index from COMPILATION_TRACK_ARTIST rows.
+
+    Args:
+        rows: Tuples of (id, library_release_id, artist_name, track_title).
+
+    Returns:
+        Dict keyed on (library_release_id, normalized_track_title) → artist_name.
+        Track titles are stripped and lowercased. NULL titles are skipped.
+        Duplicate keys are overwritten (last write wins).
+    """
+    index: dict[tuple[int, str], str] = {}
+    for row in rows:
+        _, release_id, artist_name, track_title = row[:4]
+        if track_title is None:
+            continue
+        key = (release_id, track_title.strip().lower())
+        index[key] = artist_name
+    return index
+
+
 class ArtistResolver:
     """Resolves flowsheet artist names to canonical catalog names.
 
@@ -115,8 +141,10 @@ class ArtistResolver:
         releases: list[LibraryRelease],
         codes: list[LibraryCode],
         discogs_client: DiscogsClient | None = None,
+        compilation_track_index: dict[tuple[int, str], str] | None = None,
     ) -> None:
         self._discogs_client = discogs_client
+        self._compilation_track_index = compilation_track_index
         self._release_to_code: dict[int, int] = {r.id: r.library_code_id for r in releases}
         self._code_to_name: dict[int, str] = {c.id: c.presentation_name for c in codes}
         self._code_to_genre: dict[int, int] = {c.id: c.genre_id for c in codes}
@@ -149,12 +177,55 @@ class ArtistResolver:
         # Cache: lowered query → (canonical_name | None) per threshold
         self._fuzzy_cache: dict[tuple[str, float], str | None] = {}
 
+    def _canonicalize_name(self, name: str) -> str:
+        """Canonicalize an artist name through the catalog indexes.
+
+        Tries exact name match, then normalized match, then fuzzy match.
+        Returns the canonical name if found, otherwise the lowercased input.
+        """
+        key = name.strip().lower()
+
+        # Exact match
+        matched = self._name_index.get(key)
+        if matched is not None:
+            return matched
+
+        # Normalized match
+        norm = _normalize(name)
+        norm_match = self._name_index.get(norm) or self._normalized_index.get(norm)
+        if norm_match is not None:
+            return norm_match
+
+        # Fuzzy match
+        fuzzy_result = self._fuzzy_match(key)
+        if fuzzy_result is not None:
+            return fuzzy_result
+
+        return key
+
     def resolve(self, entry: FlowsheetEntry) -> ResolvedEntry:
         """Resolve an entry's artist name to a canonical catalog name.
 
-        Tries FK chain first, then exact name match, then normalized name match,
-        then fuzzy match, then falls back to raw.
+        Tries compilation track lookup first (for VA entries), then FK chain,
+        then exact name match, then normalized name match, then fuzzy match,
+        then falls back to raw.
         """
+        # Tier 0: Compilation track artist (CTA) lookup
+        if (
+            self._compilation_track_index is not None
+            and entry.library_release_id > 0
+            and is_compilation_artist(entry.artist_name)
+        ):
+            track_key = (entry.library_release_id, entry.song_title.strip().lower())
+            cta_artist = self._compilation_track_index.get(track_key)
+            if cta_artist is not None:
+                canonical = self._canonicalize_name(cta_artist)
+                return ResolvedEntry(
+                    entry=entry,
+                    canonical_name=canonical,
+                    resolution_method="compilation_track",
+                )
+
         # Strategy 1: FK chain (LIBRARY_RELEASE_ID → LIBRARY_CODE → PRESENTATION_NAME)
         if entry.library_release_id > 0:
             code_id = self._release_to_code.get(entry.library_release_id)

--- a/tests/unit/test_artist_resolver.py
+++ b/tests/unit/test_artist_resolver.py
@@ -9,6 +9,7 @@ from semantic_index.artist_resolver import (
     FUZZY_MIN_SCORE_RELAXED,
     FUZZY_RELAXED_MIN_PLAYS,
     ArtistResolver,
+    build_cta_index,
 )
 from semantic_index.models import DiscogsSearchResult, ResolvedEntry
 from tests.conftest import make_flowsheet_entry, make_library_code, make_library_release
@@ -501,3 +502,223 @@ class TestPlayCountWeightedFuzzy:
         assert FUZZY_MIN_SCORE == 0.90
         assert FUZZY_MIN_SCORE_RELAXED == 0.82
         assert FUZZY_RELAXED_MIN_PLAYS == 10
+
+
+class TestBuildCtaIndex:
+    """Tests for build_cta_index() — builds lookup from COMPILATION_TRACK_ARTIST rows."""
+
+    def test_basic_index_building(self):
+        """Rows are indexed by (library_release_id, normalized_track_title)."""
+        rows = [
+            (1, 100, "Nirvana", "Pay To Play"),
+            (2, 100, "Beck", "Bogusflow"),
+        ]
+        index = build_cta_index(rows)
+
+        assert index[(100, "pay to play")] == "Nirvana"
+        assert index[(100, "bogusflow")] == "Beck"
+
+    def test_case_insensitive_track_title(self):
+        """Track titles are normalized to lowercase for lookup."""
+        rows = [(1, 100, "Sonic Youth", "COMPILATION BLUES")]
+        index = build_cta_index(rows)
+
+        assert index[(100, "compilation blues")] == "Sonic Youth"
+
+    def test_null_track_titles_skipped(self):
+        """Rows with NULL track titles are excluded from the index."""
+        rows = [
+            (1, 100, "Nirvana", None),
+            (2, 100, "Beck", "Bogusflow"),
+        ]
+        index = build_cta_index(rows)
+
+        assert len(index) == 1
+        assert index[(100, "bogusflow")] == "Beck"
+
+    def test_multiple_tracks_on_same_release(self):
+        """Different tracks on the same release are all indexed."""
+        rows = [
+            (1, 100, "Nirvana", "Pay To Play"),
+            (2, 100, "Beck", "Bogusflow"),
+            (3, 100, "Hole", "Beautiful Son"),
+        ]
+        index = build_cta_index(rows)
+
+        assert len(index) == 3
+        assert index[(100, "pay to play")] == "Nirvana"
+        assert index[(100, "bogusflow")] == "Beck"
+        assert index[(100, "beautiful son")] == "Hole"
+
+    def test_duplicate_key_last_write_wins(self):
+        """When (release_id, track_title) appears twice, the last row wins."""
+        rows = [
+            (1, 100, "Nirvana", "Pay To Play"),
+            (2, 100, "Kurt Cobain", "Pay To Play"),
+        ]
+        index = build_cta_index(rows)
+
+        assert index[(100, "pay to play")] == "Kurt Cobain"
+
+    def test_empty_rows(self):
+        """Empty input produces an empty index."""
+        index = build_cta_index([])
+        assert index == {}
+
+    def test_whitespace_stripped_from_title(self):
+        """Leading/trailing whitespace is stripped from track titles."""
+        rows = [(1, 100, "Nirvana", "  Pay To Play  ")]
+        index = build_cta_index(rows)
+
+        assert index[(100, "pay to play")] == "Nirvana"
+
+
+class TestCompilationTrackResolution:
+    """Tests for Tier 0: compilation track artist resolution (CTA + Discogs)."""
+
+    def _make_resolver(self, releases=None, codes=None, compilation_track_index=None):
+        return ArtistResolver(
+            releases=releases or [],
+            codes=codes or [],
+            compilation_track_index=compilation_track_index,
+        )
+
+    def test_va_entry_resolves_via_cta(self):
+        """A Various Artists entry resolves to the CTA track artist."""
+        cta_index = {(100, "pay to play"): "Nirvana"}
+        release = make_library_release(id=100, library_code_id=200)
+        code = make_library_code(id=200, presentation_name="Various Artists")
+        resolver = self._make_resolver(
+            releases=[release], codes=[code], compilation_track_index=cta_index
+        )
+
+        entry = make_flowsheet_entry(
+            library_release_id=100, artist_name="Various Artists", song_title="Pay To Play"
+        )
+        resolved = resolver.resolve(entry)
+
+        assert resolved.canonical_name == "nirvana"
+        assert resolved.resolution_method == "compilation_track"
+
+    def test_case_insensitive_song_title(self):
+        """Song title matching is case-insensitive."""
+        cta_index = {(100, "pay to play"): "Nirvana"}
+        resolver = self._make_resolver(compilation_track_index=cta_index)
+
+        entry = make_flowsheet_entry(
+            library_release_id=100, artist_name="Various Artists", song_title="PAY TO PLAY"
+        )
+        resolved = resolver.resolve(entry)
+
+        assert resolved.canonical_name == "nirvana"
+        assert resolved.resolution_method == "compilation_track"
+
+    def test_non_va_entries_skip_cta(self):
+        """Non-compilation entries are not affected by CTA lookup."""
+        cta_index = {(100, "vi scose poise"): "Nirvana"}
+        code = make_library_code(id=200, presentation_name="Autechre")
+        release = make_library_release(id=100, library_code_id=200)
+        resolver = self._make_resolver(
+            releases=[release], codes=[code], compilation_track_index=cta_index
+        )
+
+        entry = make_flowsheet_entry(
+            library_release_id=100, artist_name="Autechre", song_title="VI Scose Poise"
+        )
+        resolved = resolver.resolve(entry)
+
+        assert resolved.canonical_name == "Autechre"
+        assert resolved.resolution_method == "catalog"
+
+    def test_falls_through_when_no_cta_match(self):
+        """When CTA has no match for the track, fall through to existing tiers."""
+        cta_index = {(100, "other song"): "Nirvana"}
+        resolver = self._make_resolver(compilation_track_index=cta_index)
+
+        entry = make_flowsheet_entry(
+            library_release_id=100, artist_name="Various Artists", song_title="Unknown Track"
+        )
+        resolved = resolver.resolve(entry)
+
+        # Falls through to raw since no catalog match
+        assert resolved.resolution_method == "raw"
+
+    def test_cta_name_canonicalized_via_catalog(self):
+        """CTA artist name is canonicalized through the catalog name index."""
+        cta_index = {(100, "pay to play"): "Nirvana"}
+        code = make_library_code(id=300, presentation_name="Nirvana")
+        resolver = self._make_resolver(codes=[code], compilation_track_index=cta_index)
+
+        entry = make_flowsheet_entry(
+            library_release_id=100, artist_name="Various Artists", song_title="Pay To Play"
+        )
+        resolved = resolver.resolve(entry)
+
+        assert resolved.canonical_name == "Nirvana"
+        assert resolved.resolution_method == "compilation_track"
+
+    def test_cta_name_canonicalized_via_normalized(self):
+        """CTA artist name canonicalized through normalized match ('The X' -> 'X')."""
+        cta_index = {(100, "mad dog 20/20"): "The Teenage Fanclub"}
+        code = make_library_code(id=300, presentation_name="Teenage Fanclub")
+        resolver = self._make_resolver(codes=[code], compilation_track_index=cta_index)
+
+        entry = make_flowsheet_entry(
+            library_release_id=100, artist_name="Various Artists", song_title="Mad Dog 20/20"
+        )
+        resolved = resolver.resolve(entry)
+
+        assert resolved.canonical_name == "Teenage Fanclub"
+        assert resolved.resolution_method == "compilation_track"
+
+    def test_raw_cta_name_when_no_catalog_match(self):
+        """When CTA name doesn't match any catalog entry, return it lowercased."""
+        cta_index = {(100, "pay to play"): "Nirvana"}
+        resolver = self._make_resolver(compilation_track_index=cta_index)
+
+        entry = make_flowsheet_entry(
+            library_release_id=100, artist_name="Various Artists", song_title="Pay To Play"
+        )
+        resolved = resolver.resolve(entry)
+
+        assert resolved.canonical_name == "nirvana"
+        assert resolved.resolution_method == "compilation_track"
+
+    def test_skipped_when_library_release_id_zero(self):
+        """CTA lookup is skipped when library_release_id is 0."""
+        cta_index = {(0, "pay to play"): "Nirvana"}
+        resolver = self._make_resolver(compilation_track_index=cta_index)
+
+        entry = make_flowsheet_entry(
+            library_release_id=0, artist_name="Various Artists", song_title="Pay To Play"
+        )
+        resolved = resolver.resolve(entry)
+
+        assert resolved.resolution_method == "raw"
+
+    def test_backward_compatible_without_cta(self):
+        """When no CTA index is provided, resolver works exactly as before."""
+        resolver = self._make_resolver()
+
+        entry = make_flowsheet_entry(
+            library_release_id=0, artist_name="Various Artists", song_title="Something"
+        )
+        resolved = resolver.resolve(entry)
+
+        assert resolved.canonical_name == "various artists"
+        assert resolved.resolution_method == "raw"
+
+    def test_soundtracks_artist_resolves_via_cta(self):
+        """Soundtrack entries (also compilation artists) resolve via CTA."""
+        cta_index = {(100, "in a sentimental mood"): "Duke Ellington & John Coltrane"}
+        resolver = self._make_resolver(compilation_track_index=cta_index)
+
+        entry = make_flowsheet_entry(
+            library_release_id=100,
+            artist_name="Soundtracks - J",
+            song_title="In A Sentimental Mood",
+        )
+        resolved = resolver.resolve(entry)
+
+        assert resolved.canonical_name == "duke ellington & john coltrane"
+        assert resolved.resolution_method == "compilation_track"

--- a/tests/unit/test_run_pipeline.py
+++ b/tests/unit/test_run_pipeline.py
@@ -54,6 +54,14 @@ class TestParseArgs:
         args = parse_args(["dump.sql", "--facet-only", "--cache-dir", "/tmp/cache"])
         assert args.facet_only is True
 
+    def test_compilation_track_artist_dump_default(self):
+        args = parse_args(["dump.sql"])
+        assert args.compilation_track_artist_dump is None
+
+    def test_compilation_track_artist_dump_flag(self):
+        args = parse_args(["dump.sql", "--compilation-track-artist-dump", "/tmp/cta_dump.sql"])
+        assert args.compilation_track_artist_dump == "/tmp/cta_dump.sql"
+
     def test_deleted_flags_removed(self):
         """Verify deleted flags no longer exist in the parser."""
         with pytest.raises(SystemExit):


### PR DESCRIPTION
## Summary

- Add Tier 0 resolution for VA/compilation entries using the `COMPILATION_TRACK_ARTIST` table from tubafrenzy
- New `--compilation-track-artist-dump PATH` CLI flag loads per-track artist data
- CTA artist names are canonicalized through existing name match, normalized, and fuzzy tiers
- Non-compilation entries are completely unaffected (backward compatible)

Closes #130

## Test plan

- [x] `TestBuildCtaIndex` — 7 tests for index building (case normalization, NULL handling, duplicates)
- [x] `TestCompilationTrackResolution` — 10 tests for VA resolution, canonicalization, fallthrough, backward compat
- [x] `TestParseArgs` — 2 tests for new CLI flag
- [x] Full unit suite: 482 passed, 0 failed
- [x] Pre-commit hooks: ruff check, ruff format, mypy — all pass