### PR TITLE
Add Discogs track artist fallback for VA compilation resolution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ SQLite ──→ api (FastAPI + aiosqlite) ──→ JSON responses
 |--------|---------------|
 | `semantic_index/sql_parser.py` | Parse MySQL INSERT statements from SQL dump files. Uses `wxyc_etl.parser` Rust extension for ~1000x faster parsing, with `sql_parser_rs` and pure-Python fallbacks. Set `WXYC_ETL_NO_RUST=1` to force pure-Python. |
 | `semantic_index/models.py` | Pydantic data models for all pipeline entities. |
-| `semantic_index/artist_resolver.py` | Multi-tier artist name resolution: compilation track artist (CTA) lookup for VA entries, FK chain, name match, normalized (via `wxyc_etl.text.normalize_artist_name` + local bracket/the/& transforms), fuzzy (Jaro-Winkler), Discogs, raw fallback. Uses `wxyc_etl.text.split_artist_name` for alias splitting, `wxyc_etl.text.is_compilation_artist` for VA detection. |
+| `semantic_index/artist_resolver.py` | Multi-tier artist name resolution: compilation track (CTA from SQL dump + Discogs from `compilation_track_artists.json`), FK chain, name match, normalized (via `wxyc_etl.text.normalize_artist_name` + local bracket/the/& transforms), fuzzy (Jaro-Winkler), Discogs search, raw fallback. Uses `wxyc_etl.text.split_artist_name` for alias splitting and `wxyc_etl.text.is_compilation_artist` for VA detection. |
 | `semantic_index/adjacency.py` | Extract consecutive artist pairs within radio shows. |
 | `semantic_index/pmi.py` | Compute Pointwise Mutual Information for artist co-occurrences. |
 | `semantic_index/node_attributes.py` | Extract and compute per-artist temporal, DJ, and request statistics. |
@@ -273,6 +273,7 @@ python run_pipeline.py dump.sql --db-path output/wxyc_artist_graph.db --discogs-
 - `--compute-discogs-edges` — Compute Discogs-derived edges (shared personnel, styles, labels, compilations). Off by default.
 - `--compute-wikidata-influences` — Query Wikidata P737 (influenced by) and create directed influence edges. Requires `--db-path` with reconciled Wikidata QIDs.
 - `--populate-label-hierarchy` — Populate label and label_hierarchy tables from Wikidata P749/P355. Requires `--db-path` and enrichment data.
+- `--discogs-track-json PATH` — Path to `compilation_track_artists.json` (from LML `match_compilations.py`). Provides a Discogs-derived fallback (Tier 0b) for VA entries not matched by the CTA table. JSON format: `[{comp_id, discogs_release_id, tracks: [{position, title, artists: [str]}]}]` where `comp_id` = WXYC `LIBRARY_RELEASE_ID`.
 
 ## Graph API
 

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -15,7 +15,11 @@ import time
 from pathlib import Path
 
 from semantic_index.adjacency import extract_adjacency_pairs
-from semantic_index.artist_resolver import ArtistResolver, build_cta_index
+from semantic_index.artist_resolver import (
+    ArtistResolver,
+    build_cta_index,
+    build_discogs_track_index,
+)
 from semantic_index.cross_reference import CrossReferenceExtractor
 from semantic_index.discogs_client import DiscogsClient
 from semantic_index.discogs_edges import (
@@ -180,6 +184,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=None,
         help="Path to a SQL dump file containing the COMPILATION_TRACK_ARTIST table. "
         "When provided, VA entries are resolved to per-track artists before the FK chain.",
+    )
+    parser.add_argument(
+        "--discogs-track-json",
+        default=None,
+        help="Path to compilation_track_artists.json (from LML match_compilations.py) "
+        "for resolving VA compilation entries via Discogs track credits.",
     )
     return parser.parse_args(argv)
 
@@ -357,7 +367,25 @@ def run(args: argparse.Namespace) -> None:
                 cta_index = build_cta_index(cta_rows)
                 log.info("  %d track-artist entries indexed", len(cta_index))
 
-        resolver = ArtistResolver(releases=releases, codes=codes, compilation_track_index=cta_index)
+        discogs_track_index = None
+        if args.discogs_track_json:
+            import json as _json
+
+            discogs_json_path = args.discogs_track_json
+            if not Path(discogs_json_path).exists():
+                log.warning("Discogs track JSON not found: %s — skipping", discogs_json_path)
+            else:
+                log.info("Loading Discogs track artists from %s...", discogs_json_path)
+                with open(discogs_json_path) as f:
+                    compilations = _json.load(f)
+                discogs_track_index = build_discogs_track_index(compilations)
+
+        resolver = ArtistResolver(
+            releases=releases,
+            codes=codes,
+            compilation_track_index=cta_index,
+            discogs_track_index=discogs_track_index,
+        )
 
         # 5. Stream flowsheet entries and resolve
         log.info("Parsing FLOWSHEET_ENTRY_PROD and resolving artists...")

--- a/semantic_index/artist_resolver.py
+++ b/semantic_index/artist_resolver.py
@@ -1,7 +1,10 @@
-"""Artist name resolution via library catalog and Discogs.
+"""Artist name resolution via library catalog, compilation track data, and Discogs.
 
 Resolution strategies (in order of precedence):
-0. Compilation track: for VA entries, look up per-track artist in COMPILATION_TRACK_ARTIST index
+0a. Compilation track (CTA): for VA entries, look up per-track artist in tubafrenzy
+    COMPILATION_TRACK_ARTIST index (from SQL dump via --compilation-track-artist-dump)
+0b. Compilation track (Discogs): fallback for VA entries not matched by CTA, using
+    pre-computed track credits from compilation_track_artists.json (via --discogs-track-json)
 1. FK chain: LIBRARY_RELEASE_ID → LIBRARY_RELEASE → LIBRARY_CODE → PRESENTATION_NAME
 2. Name match: exact case-insensitive match against LIBRARY_CODE.PRESENTATION_NAME
 3. Normalized match: strip "The ", "&" → "and", bracket removal, slash/aka alias splitting
@@ -127,6 +130,41 @@ def build_cta_index(rows: list[tuple]) -> dict[tuple[int, str], str]:
     return index
 
 
+def build_discogs_track_index(
+    compilations: list[dict],
+) -> dict[tuple[int, str], str]:
+    """Build a lookup index from pre-computed Discogs compilation track artists.
+
+    Args:
+        compilations: Parsed JSON list from compilation_track_artists.json.
+            Each dict has: comp_id (int, = WXYC library_release_id),
+            tracks (list of {position, title, artists: [str]}).
+
+    Returns:
+        Dict keyed on (library_release_id, normalized_track_title) -> artist_name.
+        Tracks with empty/missing artists or title are skipped. For multi-artist
+        tracks, uses artists[0] (the primary credited artist).
+    """
+    index: dict[tuple[int, str], str] = {}
+    for comp in compilations:
+        comp_id = comp["comp_id"]
+        for track in comp.get("tracks", []):
+            title = track.get("title")
+            if not title:
+                continue
+            artists = track.get("artists")
+            if not artists:
+                continue
+            key = (comp_id, title.strip().lower())
+            index[key] = artists[0]
+    logger.info(
+        "Discogs track index: %d entries from %d compilations",
+        len(index),
+        len(compilations),
+    )
+    return index
+
+
 class ArtistResolver:
     """Resolves flowsheet artist names to canonical catalog names.
 
@@ -134,6 +172,8 @@ class ArtistResolver:
         releases: LIBRARY_RELEASE rows (only id and library_code_id needed).
         codes: LIBRARY_CODE rows (only id, genre_id, and presentation_name needed).
         discogs_client: Optional DiscogsClient for Tier 3 resolution.
+        compilation_track_index: Optional CTA lookup index (from build_cta_index).
+        discogs_track_index: Optional Discogs track lookup index (from build_discogs_track_index).
     """
 
     def __init__(
@@ -142,9 +182,11 @@ class ArtistResolver:
         codes: list[LibraryCode],
         discogs_client: DiscogsClient | None = None,
         compilation_track_index: dict[tuple[int, str], str] | None = None,
+        discogs_track_index: dict[tuple[int, str], str] | None = None,
     ) -> None:
         self._discogs_client = discogs_client
         self._compilation_track_index = compilation_track_index
+        self._discogs_track_index = discogs_track_index
         self._release_to_code: dict[int, int] = {r.id: r.library_code_id for r in releases}
         self._code_to_name: dict[int, str] = {c.id: c.presentation_name for c in codes}
         self._code_to_genre: dict[int, int] = {c.id: c.genre_id for c in codes}
@@ -210,7 +252,7 @@ class ArtistResolver:
         then exact name match, then normalized name match, then fuzzy match,
         then falls back to raw.
         """
-        # Tier 0: Compilation track artist (CTA) lookup
+        # Tier 0a: Compilation track artist (CTA) lookup
         if (
             self._compilation_track_index is not None
             and entry.library_release_id > 0
@@ -224,6 +266,22 @@ class ArtistResolver:
                     entry=entry,
                     canonical_name=canonical,
                     resolution_method="compilation_track",
+                )
+
+        # Tier 0b: Discogs track artist fallback
+        if (
+            self._discogs_track_index is not None
+            and entry.library_release_id > 0
+            and is_compilation_artist(entry.artist_name)
+        ):
+            track_key = (entry.library_release_id, entry.song_title.strip().lower())
+            discogs_artist = self._discogs_track_index.get(track_key)
+            if discogs_artist is not None:
+                canonical = self._canonicalize_name(discogs_artist)
+                return ResolvedEntry(
+                    entry=entry,
+                    canonical_name=canonical,
+                    resolution_method="compilation_track_discogs",
                 )
 
         # Strategy 1: FK chain (LIBRARY_RELEASE_ID → LIBRARY_CODE → PRESENTATION_NAME)

--- a/tests/unit/test_artist_resolver.py
+++ b/tests/unit/test_artist_resolver.py
@@ -10,6 +10,7 @@ from semantic_index.artist_resolver import (
     FUZZY_RELAXED_MIN_PLAYS,
     ArtistResolver,
     build_cta_index,
+    build_discogs_track_index,
 )
 from semantic_index.models import DiscogsSearchResult, ResolvedEntry
 from tests.conftest import make_flowsheet_entry, make_library_code, make_library_release
@@ -576,11 +577,14 @@ class TestBuildCtaIndex:
 class TestCompilationTrackResolution:
     """Tests for Tier 0: compilation track artist resolution (CTA + Discogs)."""
 
-    def _make_resolver(self, releases=None, codes=None, compilation_track_index=None):
+    def _make_resolver(
+        self, releases=None, codes=None, compilation_track_index=None, discogs_track_index=None
+    ):
         return ArtistResolver(
             releases=releases or [],
             codes=codes or [],
             compilation_track_index=compilation_track_index,
+            discogs_track_index=discogs_track_index,
         )
 
     def test_va_entry_resolves_via_cta(self):
@@ -722,3 +726,181 @@ class TestCompilationTrackResolution:
 
         assert resolved.canonical_name == "duke ellington & john coltrane"
         assert resolved.resolution_method == "compilation_track"
+
+    # --- Tier 0b: Discogs track artist fallback ---
+
+    def test_va_falls_through_cta_to_discogs(self):
+        """VA entry with no CTA match falls through to Discogs tier."""
+        cta_index = {}  # empty CTA
+        discogs_index = {(100, "the lost planet"): "Planisphere"}
+        resolver = self._make_resolver(
+            compilation_track_index=cta_index, discogs_track_index=discogs_index
+        )
+
+        entry = make_flowsheet_entry(
+            library_release_id=100,
+            artist_name="Various Artists",
+            song_title="The Lost Planet",
+        )
+        resolved = resolver.resolve(entry)
+
+        assert resolved.canonical_name == "planisphere"
+        assert resolved.resolution_method == "compilation_track_discogs"
+
+    def test_discogs_tier_skipped_when_no_index(self):
+        """When no Discogs track index is provided, Discogs tier is a no-op."""
+        resolver = self._make_resolver(compilation_track_index={})
+
+        entry = make_flowsheet_entry(
+            library_release_id=100,
+            artist_name="Various Artists",
+            song_title="Track",
+        )
+        resolved = resolver.resolve(entry)
+
+        assert resolved.resolution_method == "raw"
+
+    def test_discogs_name_canonicalized(self):
+        """Discogs artist name is canonicalized through the catalog."""
+        code = make_library_code(id=300, presentation_name="Planisphere")
+        discogs_index = {(100, "the lost planet"): "planisphere"}
+        resolver = self._make_resolver(codes=[code], discogs_track_index=discogs_index)
+
+        entry = make_flowsheet_entry(
+            library_release_id=100,
+            artist_name="Various Artists",
+            song_title="The Lost Planet",
+        )
+        resolved = resolver.resolve(entry)
+
+        assert resolved.canonical_name == "Planisphere"
+        assert resolved.resolution_method == "compilation_track_discogs"
+
+    def test_cta_takes_precedence_over_discogs(self):
+        """When both CTA and Discogs have a match, CTA wins."""
+        cta_index = {(100, "track"): "CTA Artist"}
+        discogs_index = {(100, "track"): "Discogs Artist"}
+        resolver = self._make_resolver(
+            compilation_track_index=cta_index, discogs_track_index=discogs_index
+        )
+
+        entry = make_flowsheet_entry(
+            library_release_id=100,
+            artist_name="Various Artists",
+            song_title="Track",
+        )
+        resolved = resolver.resolve(entry)
+
+        assert resolved.canonical_name == "cta artist"
+        assert resolved.resolution_method == "compilation_track"
+
+
+class TestBuildDiscogsTrackIndex:
+    """Tests for build_discogs_track_index() — builds index from compilation_track_artists.json."""
+
+    def test_basic_index_building(self):
+        compilations = [
+            {
+                "comp_id": 935,
+                "discogs_release_id": 204068,
+                "tracks": [
+                    {"position": "1-01", "title": "The Lost Planet", "artists": ["Planisphere"]},
+                ],
+            }
+        ]
+        index = build_discogs_track_index(compilations)
+        assert index == {(935, "the lost planet"): "Planisphere"}
+
+    def test_multi_artist_uses_first(self):
+        """When a track has multiple credited artists, use artists[0]."""
+        compilations = [
+            {
+                "comp_id": 935,
+                "tracks": [
+                    {
+                        "position": "1-03",
+                        "title": "Standing",
+                        "artists": ["Silvio Ecomo", "Jamie Anderson"],
+                    },
+                ],
+            }
+        ]
+        index = build_discogs_track_index(compilations)
+        assert index[(935, "standing")] == "Silvio Ecomo"
+
+    def test_empty_artists_skipped(self):
+        compilations = [
+            {
+                "comp_id": 935,
+                "tracks": [{"position": "1", "title": "Track", "artists": []}],
+            }
+        ]
+        index = build_discogs_track_index(compilations)
+        assert len(index) == 0
+
+    def test_missing_artists_key_skipped(self):
+        compilations = [
+            {
+                "comp_id": 935,
+                "tracks": [{"position": "1", "title": "Track"}],
+            }
+        ]
+        index = build_discogs_track_index(compilations)
+        assert len(index) == 0
+
+    def test_none_artists_skipped(self):
+        compilations = [
+            {
+                "comp_id": 935,
+                "tracks": [{"position": "1", "title": "Track", "artists": None}],
+            }
+        ]
+        index = build_discogs_track_index(compilations)
+        assert len(index) == 0
+
+    def test_missing_title_skipped(self):
+        compilations = [
+            {
+                "comp_id": 935,
+                "tracks": [{"position": "1", "artists": ["Planisphere"]}],
+            }
+        ]
+        index = build_discogs_track_index(compilations)
+        assert len(index) == 0
+
+    def test_empty_title_skipped(self):
+        compilations = [
+            {
+                "comp_id": 935,
+                "tracks": [{"position": "1", "title": "", "artists": ["Planisphere"]}],
+            }
+        ]
+        index = build_discogs_track_index(compilations)
+        assert len(index) == 0
+
+    def test_case_insensitive_track_title(self):
+        compilations = [
+            {
+                "comp_id": 935,
+                "tracks": [
+                    {"position": "1", "title": "THE LOST PLANET", "artists": ["Planisphere"]},
+                ],
+            }
+        ]
+        index = build_discogs_track_index(compilations)
+        assert (935, "the lost planet") in index
+
+    def test_keyed_on_comp_id_not_discogs_release_id(self):
+        """Index keys use comp_id (= library_release_id), not discogs_release_id."""
+        compilations = [
+            {
+                "comp_id": 935,
+                "discogs_release_id": 204068,
+                "tracks": [
+                    {"position": "1", "title": "Track", "artists": ["Artist"]},
+                ],
+            }
+        ]
+        index = build_discogs_track_index(compilations)
+        assert (935, "track") in index
+        assert (204068, "track") not in index

--- a/tests/unit/test_run_pipeline.py
+++ b/tests/unit/test_run_pipeline.py
@@ -62,6 +62,14 @@ class TestParseArgs:
         args = parse_args(["dump.sql", "--compilation-track-artist-dump", "/tmp/cta_dump.sql"])
         assert args.compilation_track_artist_dump == "/tmp/cta_dump.sql"
 
+    def test_discogs_track_json_default(self):
+        args = parse_args(["dump.sql"])
+        assert args.discogs_track_json is None
+
+    def test_discogs_track_json_flag(self):
+        args = parse_args(["dump.sql", "--discogs-track-json", "/path/to/tracks.json"])
+        assert args.discogs_track_json == "/path/to/tracks.json"
+
     def test_deleted_flags_removed(self):
         """Verify deleted flags no longer exist in the parser."""
         with pytest.raises(SystemExit):


### PR DESCRIPTION
Closes #133

## Summary

- Adds **Tier 0b** (Discogs track artist fallback) to `ArtistResolver.resolve()`, complementing the existing CTA tier (0a) for resolving "Various Artists" entries to real performing artists
- New `build_discogs_track_index()` function loads pre-computed Discogs track credits from `compilation_track_artists.json` (3,990 compilations / 66,989 tracks matched by LML `match_compilations.py`)
- New `--discogs-track-json PATH` CLI arg in `run_pipeline.py` for the JSON file path
- For multi-artist tracks, uses `artists[0]` (primary credited artist); resolved names are canonicalized through the same name match / normalized / fuzzy pipeline as CTA

## Test plan

- [x] `TestBuildDiscogsTrackIndex` — 9 tests: basic building, multi-artist dedup, edge cases (empty/missing/None artists, empty/missing title), case insensitivity, comp_id keying
- [x] `TestCompilationTrackResolution` — 4 new Discogs tier tests: fallthrough from CTA, skipped when no index, canonicalization, CTA precedence over Discogs
- [x] `TestParseArgs` — 2 new CLI arg tests: default (None), flag with path
- [x] Full unit suite: 497 passed, 0 failures