### PR TITLE
Add nightly sync pipeline with PostgreSQL source

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -351,6 +351,20 @@ Configuration via environment variables:
 - `ANTHROPIC_API_KEY` — Anthropic API key for narrative generation (optional; narrative endpoint returns 501 when not set)
 - `SPOTIFY_CLIENT_ID` / `SPOTIFY_CLIENT_SECRET` — Spotify API credentials for preview URL lookups (optional; Spotify tier in the preview fallback chain is skipped when not set)
 
+### Railway cron service (nightly sync)
+
+A separate Railway cron service in the same project runs the nightly sync on a schedule. It shares the `/data` volume with the API service so the atomic swap updates the database the API reads from.
+
+**Setup (Railway dashboard):**
+1. Create a new service in the project, type "Cron Job"
+2. Source: same repo, same branch
+3. Override start command: `./scripts/cron_sync.sh`
+4. Schedule: `0 9 * * *` (daily at 9:00 UTC / 5:00 AM ET)
+5. Mount the same `/data` volume as the API service
+6. Set env vars: `DATABASE_URL_BACKEND` (Backend-Service PG DSN), `DB_PATH=/data/wxyc_artist_graph.db`
+
+The cron entrypoint (`scripts/cron_sync.sh`) calls `python -m semantic_index.nightly_sync` which queries PG, recomputes the graph, and atomically swaps the database. Runtime is ~5 minutes.
+
 ## Data
 
 The pipeline parses tubafrenzy MySQL dump files directly (no database required). Production dumps are not committed to git — pass the path as a CLI argument. The fixture dump at `tubafrenzy/scripts/dev/fixtures/wxycmusic-fixture.sql` has minimal data suitable for structural testing only. The `data/` directory contains a committed copy of the latest pipeline output for deployment.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,12 +7,12 @@ Builds a semantic artist graph from WXYC DJ transition data. DJs curate transiti
 A batch pipeline that parses a tubafrenzy MySQL dump, resolves artist names via catalog and Discogs, extracts adjacency pairs and cross-reference edges, computes PMI, enriches artists with Discogs metadata, computes Discogs-derived edges, and exports a GEXF graph and SQLite database.
 
 ```
-SQL dump → sql_parser → artist_resolver → adjacency → pmi ──────────────→ graph_export → GEXF
-                       → cross_reference ────────────────────────────────→ sqlite_export → SQLite
-                       → node_attributes ────────────────────────────────→
-         → discogs_client → discogs_enrichment → discogs_edges ─────────→
-         → wikidata_client → wikidata_influence ────────────────────────→
-         → musicbrainz_client → acousticbrainz (feature loader) ───────→ audio_profile + acoustic_similarity
+SQL dump → sql_parser ──→ artist_resolver → adjacency → pmi ────────────→ graph_export → GEXF
+Backend PG → pg_source ─┘ → cross_reference ────────────────────────────→ sqlite_export → SQLite
+                           → node_attributes ───────────────────────────→
+            → discogs_client → discogs_enrichment → discogs_edges ──────→
+            → wikidata_client → wikidata_influence ─────────────────────→
+            → musicbrainz_client → acousticbrainz (feature loader) ────→ audio_profile + acoustic_similarity
 
 SQLite ──→ api (FastAPI + aiosqlite) ──→ JSON responses
 ```
@@ -49,7 +49,10 @@ SQLite ──→ api (FastAPI + aiosqlite) ──→ JSON responses
 | `semantic_index/api/routes.py` | Graph API query endpoints: search, artist detail, neighbors by edge type (with optional month/DJ facet filters), explain relationships, entity artist groups, available facets, community metadata, discovery (underplayed sonic fits). |
 | `semantic_index/api/narrative.py` | LLM-generated edge narrative endpoint. Calls Claude Haiku to explain artist relationships in plain English. Caches results in a sidecar SQLite database. Facet-aware. |
 | `semantic_index/api/preview.py` | Audio preview URL endpoint with multi-source fallback (iTunes lookup, Spotify, Bandcamp, Deezer, iTunes search). Caches results in a sidecar SQLite database. Powers the in-card transition player in the graph explorer. |
-| `run_pipeline.py` | CLI entry point wiring the pipeline. |
+| `semantic_index/pg_source.py` | Query Backend-Service PostgreSQL (`wxyc_schema.*`) for pipeline input data. Returns the same types as `sql_parser.py` (FlowsheetEntry, LibraryCode, LibraryRelease). Used by the nightly sync instead of SQL dump parsing. |
+| `semantic_index/nightly_sync.py` | Nightly sync orchestrator: query PG → resolve → PMI → stats → export → facets → graph metrics → atomic DB swap. Preserves enrichment tables from the existing database. |
+| `run_pipeline.py` | CLI entry point wiring the full pipeline (SQL dump mode). |
+| `scripts/nightly_sync.py` | CLI wrapper for `semantic_index.nightly_sync.main()`. |
 
 ### Column Mappings (0-indexed from SQL INSERT order)
 
@@ -274,6 +277,32 @@ python run_pipeline.py dump.sql --db-path output/wxyc_artist_graph.db --discogs-
 - `--compute-wikidata-influences` — Query Wikidata P737 (influenced by) and create directed influence edges. Requires `--db-path` with reconciled Wikidata QIDs.
 - `--populate-label-hierarchy` — Populate label and label_hierarchy tables from Wikidata P749/P355. Requires `--db-path` and enrichment data.
 - `--discogs-track-json PATH` — Path to `compilation_track_artists.json` (from LML `match_compilations.py`). Provides a Discogs-derived fallback (Tier 0b) for VA entries not matched by the CTA table. JSON format: `[{comp_id, discogs_release_id, tracks: [{position, title, artists: [str]}]}]` where `comp_id` = WXYC `LIBRARY_RELEASE_ID`.
+
+### Nightly sync mode
+
+The nightly sync queries Backend-Service PostgreSQL directly instead of parsing a SQL dump. It recomputes the core graph (resolution, PMI, stats, facets, graph metrics) while preserving enrichment data (Discogs, Wikidata, AcousticBrainz) from the existing production database via an atomic copy-and-swap.
+
+```bash
+python scripts/nightly_sync.py --dsn postgresql://... --db-path data/wxyc_artist_graph.db
+```
+
+Or via environment variables (for Railway cron):
+
+```bash
+DATABASE_URL_BACKEND=postgresql://... DB_PATH=data/wxyc_artist_graph.db python scripts/nightly_sync.py
+```
+
+- `--dsn` / `DATABASE_URL_BACKEND` — PostgreSQL DSN for Backend-Service (required).
+- `--db-path` / `DB_PATH` — Production SQLite database path (default: `data/wxyc_artist_graph.db`).
+- `--min-count` / `MIN_COUNT` — Minimum co-occurrence count for DJ transition edges (default: 2).
+- `--dry-run` — Run the full pipeline but skip the atomic swap (writes to a temp file instead).
+- `--verbose` — Enable debug logging.
+
+**PG schema mappings (`wxyc_schema.*` → pipeline types):**
+- `artists` → `LibraryCode` (id, genre_id from `genre_artist_crossreference`, artist_name → presentation_name)
+- `library` → `LibraryRelease` (id, artist_id → library_code_id)
+- `flowsheet` → `FlowsheetEntry` (filtered to `entry_type = 'track'`, `add_time` → epoch, `request_flag` boolean → int)
+- `shows` → show-to-DJ mapping (keyed by `shows.id`, `primary_dj_id` as value)
 
 ## Graph API
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ COPY pyproject.toml .
 RUN pip install --no-cache-dir ".[api]"
 
 COPY semantic_index/ semantic_index/
+COPY scripts/ scripts/
 COPY explorer/ explorer/
 COPY data/ data/
 COPY start.sh .

--- a/docs/backend-service-backfill.md
+++ b/docs/backend-service-backfill.md
@@ -1,0 +1,65 @@
+# Backend-Service PG Data Gaps for Nightly Sync
+
+The nightly sync pipeline (`semantic_index/nightly_sync.py`) queries Backend-Service PostgreSQL (`wxyc_schema.*`) instead of parsing a SQL dump. Three columns/tables are empty despite the data existing in the original tubafrenzy MySQL source. These gaps degrade the quality of the artist graph.
+
+## 1. `flowsheet.album_id` — FK to library releases
+
+**Impact:** Without this FK, the resolver can't use Tier 1 (FK chain) resolution: `flowsheet.album_id → library.id → library.artist_id → artists.id → canonical name`. All 1.95M entries fall through to name-based matching (Tiers 2-4), which produces more fragmented artist identities. The production graph drops from 81K to 69K DJ transition edges because name variants that the FK chain would have canonicalized instead become separate "raw" entries.
+
+**Current state:** `flowsheet.album_id` is NULL for all 1,954,255 track entries. The `library` table has 64,123 releases with valid `artist_id` FKs. The tubafrenzy source has this relationship as `FLOWSHEET_ENTRY_PROD.LIBRARY_RELEASE_ID` (column index 6).
+
+**What needs to happen:** For each flowsheet entry, match it to the correct `library.id` row. The tubafrenzy bulk load created both tables but didn't establish the FK. The most reliable approach is to match on the original tubafrenzy IDs — the `flowsheet.legacy_entry_id` column maps to the original `FLOWSHEET_ENTRY_PROD.ID`, and the `library` table would need a similar legacy ID mapping (currently `library.legacy_release_id` exists but is NULL for all rows).
+
+If legacy IDs aren't available for a direct mapping, a heuristic join on `(flowsheet.artist_name, flowsheet.album_title) → (artists.artist_name via library.artist_id, library.album_title)` could work, but may have ambiguity for common album names.
+
+**Permanent fix:** Beyond the one-time backfill, the Backend-Service application code should set `album_id` when DJs log tracks on the flowsheet. If a DJ selects a release from the library catalog, that FK should be written to the flowsheet row.
+
+## 2. `shows.primary_dj_id` — DJ assignment per show
+
+**Impact:** Without DJ data, the nightly sync produces a graph with no DJ facets. Users can't filter transitions by DJ or see DJ play counts. The facet tables (`dj`, `artist_dj_count`, `dj_total`) are empty.
+
+**Current state:** `shows.primary_dj_id` is NULL for all 71,629 shows. The `show_djs` junction table (for multi-DJ shows) is also empty. There is no `djs` table in the schema. The tubafrenzy source has `FLOWSHEET_RADIO_SHOW_PROD.DJ_ID` (column 3) and `DJ_NAME` (column 2) per show.
+
+**What needs to happen:** The Backend-Service needs a `djs` table (or equivalent) and the show-to-DJ relationship populated. The tubafrenzy data has integer DJ IDs and string DJ names. The `shows.primary_dj_id` column is varchar, suggesting it may reference a user/auth ID rather than a legacy integer ID — the mapping strategy depends on how the Backend-Service models DJs (as `djs` table rows vs. auth users).
+
+**Permanent fix:** When a DJ starts a show via the flowsheet UI, their user/DJ ID should be written to `shows.primary_dj_id` (and `show_djs` for multi-DJ shows). The Backend-Service auth system (better-auth) already knows who's logged in.
+
+## 3. `artist_crossreference` and `artist_library_crossreference` — catalog cross-references
+
+**Impact:** The production graph has 135 cross-reference edges (e.g., "see also: Yo La Tengo" on a catalog entry for Ira Kaplan). These are curated by music directors and encode relationships that PMI can't discover. With the PG tables empty, the nightly sync output has 0 cross-reference edges.
+
+**Current state:** Both `wxyc_schema.artist_crossreference` (0 rows) and `wxyc_schema.artist_library_crossreference` (0 rows) are empty. The tubafrenzy source has `LIBRARY_CODE_CROSS_REFERENCE` and `RELEASE_CROSS_REFERENCE` tables with this data.
+
+**What needs to happen:** Import the cross-reference rows from the tubafrenzy dump into the PG tables. The mapping is:
+- `LIBRARY_CODE_CROSS_REFERENCE(CROSS_REFERENCING_ARTIST_ID, CROSS_REFERENCED_LIBRARY_CODE_ID, COMMENT)` → `artist_crossreference(source_artist_id, target_artist_id, comment)` — both FK to `artists.id`
+- `RELEASE_CROSS_REFERENCE(CROSS_REFERENCING_ARTIST_ID, CROSS_REFERENCED_RELEASE_ID, COMMENT)` → `artist_library_crossreference(artist_id, library_id, comment)` — artist FK to `artists.id`, library FK to `library.id`
+
+**Permanent fix:** The dj-site card catalog UI should support adding/editing cross-references, writing them to these PG tables. This is a feature that music directors use when cataloging new additions.
+
+## PG Schema Reference
+
+```sql
+-- wxyc_schema.flowsheet (relevant columns)
+album_id        INTEGER  -- FK to library.id, currently NULL for all rows
+legacy_entry_id INTEGER  -- maps to tubafrenzy FLOWSHEET_ENTRY_PROD.ID
+
+-- wxyc_schema.library (relevant columns)
+id              INTEGER  -- PK
+artist_id       INTEGER  -- FK to artists.id
+legacy_release_id INTEGER -- maps to tubafrenzy LIBRARY_RELEASE.ID, currently NULL
+
+-- wxyc_schema.shows (relevant columns)
+id              INTEGER  -- PK
+primary_dj_id   VARCHAR  -- FK to djs or auth user, currently NULL
+legacy_show_id  INTEGER  -- maps to tubafrenzy FLOWSHEET_RADIO_SHOW_PROD.ID
+
+-- wxyc_schema.artist_crossreference (0 rows)
+source_artist_id INTEGER -- FK to artists.id
+target_artist_id INTEGER -- FK to artists.id
+comment          VARCHAR
+
+-- wxyc_schema.artist_library_crossreference (0 rows)
+artist_id        INTEGER -- FK to artists.id
+library_id       INTEGER -- FK to library.id
+comment          VARCHAR
+```

--- a/scripts/cron_sync.sh
+++ b/scripts/cron_sync.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Entrypoint for the Railway cron service.
+# Runs the nightly sync pipeline against Backend-Service PG
+# and atomically swaps the production SQLite database.
+#
+# Required env vars:
+#   DATABASE_URL_BACKEND  — PostgreSQL DSN for Backend-Service
+#   DB_PATH               — Path to production SQLite (default: /data/wxyc_artist_graph.db)
+
+set -e
+
+DB_PATH="${DB_PATH:-/data/wxyc_artist_graph.db}"
+
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) Starting nightly sync..."
+echo "  DB_PATH=$DB_PATH"
+
+if [ -z "$DATABASE_URL_BACKEND" ]; then
+    echo "ERROR: DATABASE_URL_BACKEND not set"
+    exit 1
+fi
+
+exec python -m semantic_index.nightly_sync \
+    --db-path "$DB_PATH" \
+    --dsn "$DATABASE_URL_BACKEND" \
+    --verbose

--- a/scripts/nightly_sync.py
+++ b/scripts/nightly_sync.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+"""Nightly sync CLI wrapper.
+
+Usage:
+    python scripts/nightly_sync.py --dsn postgresql://... [--db-path data/graph.db]
+    python scripts/nightly_sync.py --dry-run --verbose
+
+See ``semantic_index.nightly_sync`` for implementation.
+"""
+
+from semantic_index.nightly_sync import main
+
+if __name__ == "__main__":
+    main()

--- a/semantic_index/nightly_sync.py
+++ b/semantic_index/nightly_sync.py
@@ -1,0 +1,383 @@
+"""Nightly sync: refresh the semantic index from Backend-Service PostgreSQL.
+
+Replaces the manual SQL dump pipeline with direct PG queries via
+``pg_source``. Recomputes the core graph (artist resolution, PMI,
+stats, cross-references, facets, graph metrics) while preserving
+enrichment data (Discogs, Wikidata, AcousticBrainz) from the
+existing production database.
+
+Atomic swap strategy:
+    1. Copy existing production DB to a temp file
+    2. Open as PipelineDB (enrichment tables intact)
+    3. Clear recomputed edge tables
+    4. Run pipeline: PG → resolve → PMI → export → facets → metrics
+    5. WAL checkpoint, atomic ``os.replace``
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import shutil
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_DB_PATH = "data/wxyc_artist_graph.db"
+DEFAULT_MIN_COUNT = 2
+
+# Tables that are fully recomputed each run and must be cleared
+# before re-inserting to avoid stale data.  Facet tables and
+# community table are self-clearing (handled by their own export
+# functions).
+_TABLES_TO_CLEAR = ("dj_transition", "cross_reference")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _validate_sqlite(path: Path) -> bool:
+    """Check whether *path* is a valid SQLite database (magic header bytes)."""
+    if not path.exists():
+        return False
+    try:
+        with open(path, "rb") as f:
+            header = f.read(16)
+        return header[:6] == b"SQLite"
+    except OSError:
+        return False
+
+
+def _prepare_working_db(production_path: Path) -> Path:
+    """Create a working copy of the production database.
+
+    If the production file exists and is valid SQLite, copies it to a
+    temp file in the same directory (ensures same filesystem for atomic
+    rename). On first run, creates an empty temp file.
+
+    Returns:
+        Path to the temp file.
+    """
+    temp_path = production_path.with_suffix(f".tmp.{os.getpid()}.db")
+
+    if _validate_sqlite(production_path):
+        size_mb = production_path.stat().st_size / (1024 * 1024)
+        logger.info("Copying production DB (%.1f MB) to working copy...", size_mb)
+        shutil.copy2(production_path, temp_path)
+    else:
+        logger.info("No existing production DB — first run, creating empty working copy")
+        temp_path.parent.mkdir(parents=True, exist_ok=True)
+        temp_path.touch()
+
+    return temp_path
+
+
+def _clear_recomputed_tables(db_path: str) -> None:
+    """Clear edge tables that will be fully recomputed.
+
+    Handles the case where tables don't exist yet (fresh database).
+    Does NOT touch enrichment tables.
+    """
+    conn = sqlite3.connect(db_path)
+    for table in _TABLES_TO_CLEAR:
+        try:
+            conn.execute(f"DELETE FROM {table}")  # noqa: S608
+        except sqlite3.OperationalError:
+            pass  # table doesn't exist yet
+    conn.commit()
+    conn.close()
+
+
+def _checkpoint_and_close(db_path: str) -> None:
+    """Truncate WAL journal so the file is self-contained before swap."""
+    conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+    conn.close()
+
+
+def _atomic_swap(temp_path: Path, production_path: Path, *, dry_run: bool = False) -> None:
+    """Atomically replace the production DB with the completed working copy.
+
+    Uses ``os.replace`` which is atomic on POSIX when source and
+    destination are on the same filesystem.
+    """
+    if dry_run:
+        logger.info("DRY RUN: would swap %s -> %s", temp_path, production_path)
+        temp_path.unlink(missing_ok=True)
+        return
+
+    production_path.parent.mkdir(parents=True, exist_ok=True)
+    os.replace(str(temp_path), str(production_path))
+    logger.info("Atomic swap complete: %s", production_path)
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+
+def _load_from_pg(dsn: str):
+    """Connect to Backend-Service PG and load all pipeline inputs.
+
+    Returns:
+        Tuple of (genres, codes, releases, entries, show_to_dj,
+        show_dj_names, artist_xrefs, release_xrefs).
+    """
+    import psycopg
+    from psycopg.rows import dict_row
+
+    from semantic_index.pg_source import (
+        load_catalog,
+        load_cross_references,
+        load_flowsheet_entries,
+        load_genres,
+        load_shows,
+    )
+
+    logger.info("Connecting to Backend-Service PG...")
+    conn = psycopg.connect(dsn, autocommit=True, row_factory=dict_row)
+    try:
+        genres = load_genres(conn)
+        logger.info("  %d genres", len(genres))
+
+        codes, releases = load_catalog(conn)
+        logger.info("  %d artists, %d releases", len(codes), len(releases))
+
+        entries = load_flowsheet_entries(conn)
+        logger.info("  %d flowsheet track entries", len(entries))
+
+        show_to_dj, show_dj_names = load_shows(conn)
+        logger.info("  %d shows with DJ mapping", len(show_to_dj))
+
+        artist_xrefs, release_xrefs = load_cross_references(conn)
+        logger.info("  %d artist xrefs, %d release xrefs", len(artist_xrefs), len(release_xrefs))
+    finally:
+        conn.close()
+
+    return genres, codes, releases, entries, show_to_dj, show_dj_names, artist_xrefs, release_xrefs
+
+
+def nightly_sync(args: argparse.Namespace) -> None:
+    """Main orchestration: PG → resolve → PMI → export → swap."""
+    from semantic_index.adjacency import extract_adjacency_pairs
+    from semantic_index.artist_resolver import ArtistResolver
+    from semantic_index.cross_reference import CrossReferenceExtractor
+    from semantic_index.facet_export import export_facet_tables
+    from semantic_index.graph_metrics import compute_and_persist
+    from semantic_index.node_attributes import compute_artist_stats
+    from semantic_index.pipeline_db import PipelineDB
+    from semantic_index.pmi import compute_pmi
+    from semantic_index.sqlite_export import export_sqlite
+
+    t0 = time.time()
+    production_path = Path(args.db_path)
+    min_count = args.min_count
+
+    # --- Step 1: Prepare working copy ---
+    temp_path = _prepare_working_db(production_path)
+    swap_ok = False
+
+    try:
+        # --- Step 2: Load from PG ---
+        (
+            genres,
+            codes,
+            releases,
+            entries,
+            show_to_dj,
+            show_dj_names,
+            artist_xrefs,
+            release_xrefs,
+        ) = _load_from_pg(args.dsn)
+
+        if not entries:
+            logger.error("No flowsheet entries loaded from PG — aborting")
+            sys.exit(1)
+
+        # --- Step 3: Resolve artists ---
+        logger.info("Resolving artists...")
+        resolver = ArtistResolver(releases=releases, codes=codes)
+
+        resolved_entries = []
+        catalog_resolved = 0
+        for entry in entries:
+            resolved = resolver.resolve(entry)
+            if resolved.resolution_method == "catalog":
+                catalog_resolved += 1
+            resolved_entries.append(resolved)
+
+        pct = (catalog_resolved / len(entries) * 100) if entries else 0
+        logger.info(
+            "  %d entries resolved (%d catalog = %.1f%%)",
+            len(resolved_entries),
+            catalog_resolved,
+            pct,
+        )
+
+        logger.info("Re-resolving raw entries with play-count-weighted fuzzy matching...")
+        resolved_entries = resolver.re_resolve_with_play_counts(resolved_entries)
+
+        # --- Step 4: Adjacency + PMI ---
+        logger.info("Extracting adjacency pairs...")
+        pairs = extract_adjacency_pairs(resolved_entries)
+        logger.info("  %d adjacency pairs", len(pairs))
+
+        logger.info("Computing PMI...")
+        pmi_edges = compute_pmi(pairs, resolved_entries)
+        logger.info("  %d PMI edges", len(pmi_edges))
+
+        # --- Step 5: Artist stats ---
+        code_to_genre = {c.id: c.genre_id for c in codes}
+        genre_for_release: dict[int, int] = {}
+        for r in releases:
+            gid = code_to_genre.get(r.library_code_id)
+            if gid is not None:
+                genre_for_release[r.id] = gid
+
+        logger.info("Computing artist stats...")
+        artist_stats = compute_artist_stats(
+            resolved_entries,
+            show_to_dj,
+            genres,
+            genre_for_release=genre_for_release,
+        )
+        logger.info("  %d unique artists", len(artist_stats))
+
+        # --- Step 6: Cross-references ---
+        code_names = {c.id: c.presentation_name for c in codes}
+        release_to_code = {r.id: r.library_code_id for r in releases}
+        xref_extractor = CrossReferenceExtractor(codes=code_names, release_to_code=release_to_code)
+
+        lc_xrefs = xref_extractor.extract_library_code_xrefs(artist_xrefs)
+        rel_xrefs = xref_extractor.extract_release_xrefs(release_xrefs)
+        xref_edges = lc_xrefs + rel_xrefs
+        logger.info("  %d cross-reference edges", len(xref_edges))
+
+        # --- Step 7: Pipeline DB + export ---
+        logger.info("Opening pipeline DB: %s", temp_path)
+        pipeline_db = PipelineDB(str(temp_path))
+        pipeline_db.initialize()
+
+        all_canonical = list(dict.fromkeys(e.canonical_name for e in resolved_entries))
+        logger.info("Bulk upserting %d artists...", len(all_canonical))
+        pipeline_db.bulk_upsert_artists(all_canonical)
+
+        logger.info("Clearing recomputed edge tables...")
+        _clear_recomputed_tables(str(temp_path))
+
+        logger.info("Exporting to SQLite...")
+        export_sqlite(
+            str(temp_path),
+            artist_stats=artist_stats,
+            pmi_edges=pmi_edges,
+            xref_edges=xref_edges,
+            min_count=min_count,
+            pipeline_db=pipeline_db,
+        )
+
+        # --- Step 8: Facet tables ---
+        logger.info("Exporting facet tables...")
+        name_to_id = pipeline_db.get_name_to_id_mapping()
+
+        export_facet_tables(
+            db_path=str(temp_path),
+            resolved_entries=resolved_entries,
+            name_to_id=name_to_id,
+            show_to_dj=show_to_dj,
+            show_dj_names=show_dj_names,
+            adjacency_pairs=pairs,
+        )
+
+        # --- Step 9: Graph metrics ---
+        pipeline_db.close()
+
+        logger.info("Computing graph metrics...")
+        metrics = compute_and_persist(str(temp_path))
+        logger.info(
+            "  %d communities, %d artists scored",
+            metrics.community_count,
+            metrics.artists_scored,
+        )
+
+        # --- Step 10: Checkpoint + swap ---
+        _checkpoint_and_close(str(temp_path))
+
+        size_mb = temp_path.stat().st_size / (1024 * 1024)
+        elapsed = time.time() - t0
+        logger.info("Pipeline complete in %.1fs (%.1f MB)", elapsed, size_mb)
+
+        _atomic_swap(temp_path, production_path, dry_run=args.dry_run)
+        swap_ok = True
+
+    finally:
+        # Clean up temp file on failure
+        if not swap_ok and temp_path.exists():
+            temp_path.unlink(missing_ok=True)
+            logger.warning("Cleaned up temp file after failure: %s", temp_path)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments and environment variables."""
+    parser = argparse.ArgumentParser(
+        description="Nightly sync: refresh semantic index from Backend-Service PG.",
+    )
+    parser.add_argument(
+        "--db-path",
+        default=os.environ.get("DB_PATH", DEFAULT_DB_PATH),
+        help="Production SQLite DB path (default: $DB_PATH or data/wxyc_artist_graph.db)",
+    )
+    parser.add_argument(
+        "--dsn",
+        default=os.environ.get("DATABASE_URL_BACKEND"),
+        help="PostgreSQL DSN for Backend-Service (default: $DATABASE_URL_BACKEND)",
+    )
+    parser.add_argument(
+        "--min-count",
+        type=int,
+        default=int(os.environ.get("MIN_COUNT", str(DEFAULT_MIN_COUNT))),
+        help="Minimum co-occurrence count for DJ transition edges (default: 2)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Run pipeline but skip atomic swap",
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Enable debug logging",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Entry point for the nightly sync script."""
+    args = parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s [nightly_sync] %(message)s",
+        datefmt="%Y-%m-%dT%H:%M:%S",
+    )
+
+    if not args.dsn:
+        logger.error("DATABASE_URL_BACKEND not set and --dsn not provided")
+        sys.exit(1)
+
+    nightly_sync(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/semantic_index/nightly_sync.py
+++ b/semantic_index/nightly_sync.py
@@ -205,23 +205,31 @@ def nightly_sync(args: argparse.Namespace) -> None:
         resolver = ArtistResolver(releases=releases, codes=codes)
 
         resolved_entries = []
-        catalog_resolved = 0
+        method_counts: dict[str, int] = {}
         for entry in entries:
             resolved = resolver.resolve(entry)
-            if resolved.resolution_method == "catalog":
-                catalog_resolved += 1
+            method_counts[resolved.resolution_method] = (
+                method_counts.get(resolved.resolution_method, 0) + 1
+            )
             resolved_entries.append(resolved)
 
-        pct = (catalog_resolved / len(entries) * 100) if entries else 0
-        logger.info(
-            "  %d entries resolved (%d catalog = %.1f%%)",
-            len(resolved_entries),
-            catalog_resolved,
-            pct,
-        )
+        n = len(entries)
+        for method, count in sorted(method_counts.items(), key=lambda x: -x[1]):
+            logger.info("  %-25s %8d  (%.1f%%)", method, count, count / n * 100)
 
         logger.info("Re-resolving raw entries with play-count-weighted fuzzy matching...")
         resolved_entries = resolver.re_resolve_with_play_counts(resolved_entries)
+
+        # Log post-re-resolve breakdown
+        post_counts: dict[str, int] = {}
+        for r in resolved_entries:
+            post_counts[r.resolution_method] = post_counts.get(r.resolution_method, 0) + 1
+        raw_pct = post_counts.get("raw", 0) / n * 100 if n else 0
+        logger.info(
+            "  After re-resolve: %d raw (%.1f%%)",
+            post_counts.get("raw", 0),
+            raw_pct,
+        )
 
         # --- Step 4: Adjacency + PMI ---
         logger.info("Extracting adjacency pairs...")

--- a/semantic_index/pg_source.py
+++ b/semantic_index/pg_source.py
@@ -1,0 +1,254 @@
+"""Query Backend-Service PostgreSQL for pipeline input data.
+
+Replaces SQL dump parsing (``sql_parser.py``) for the nightly sync pipeline.
+Each function queries ``wxyc_schema.*`` tables and returns the same pipeline
+types that ``run_pipeline.py`` constructs from raw SQL tuples.
+
+Schema mappings (PG → pipeline types):
+    - ``wxyc_schema.artists`` → ``LibraryCode``
+      (id, genre_id from genre_artist_crossreference, artist_name → presentation_name)
+    - ``wxyc_schema.library`` → ``LibraryRelease``
+      (id, artist_id → library_code_id)
+    - ``wxyc_schema.flowsheet`` → ``FlowsheetEntry``
+      (entry_type = 'track' filter replaces type_code < 7)
+    - ``wxyc_schema.shows`` → show-to-DJ mapping
+      (show.id as key, primary_dj_id as value)
+
+Requires a psycopg connection with ``dict_row`` row factory.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from semantic_index.models import FlowsheetEntry, LibraryCode, LibraryRelease
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# SQL queries
+# ---------------------------------------------------------------------------
+
+_GENRES_SQL = """\
+SELECT id, genre_name
+FROM wxyc_schema.genres
+ORDER BY id
+"""
+
+_ARTISTS_SQL = """\
+SELECT id, artist_name
+FROM wxyc_schema.artists
+ORDER BY id
+"""
+
+_GENRE_ARTIST_XREF_SQL = """\
+SELECT artist_id, genre_id
+FROM wxyc_schema.genre_artist_crossreference
+ORDER BY artist_id, artist_genre_code
+"""
+
+_LIBRARY_SQL = """\
+SELECT id, artist_id
+FROM wxyc_schema.library
+ORDER BY id
+"""
+
+_FLOWSHEET_SQL = """\
+SELECT id, artist_name, track_title, album_title, record_label,
+       show_id, play_order, album_id, request_flag,
+       EXTRACT(EPOCH FROM add_time)::bigint AS add_time_epoch,
+       legacy_entry_id
+FROM wxyc_schema.flowsheet
+WHERE entry_type = 'track'
+ORDER BY show_id, play_order
+"""
+
+_SHOWS_SQL = """\
+SELECT id, primary_dj_id, legacy_show_id
+FROM wxyc_schema.shows
+ORDER BY id
+"""
+
+_ARTIST_XREF_SQL = """\
+SELECT source_artist_id, target_artist_id, comment
+FROM wxyc_schema.artist_crossreference
+"""
+
+_RELEASE_XREF_SQL = """\
+SELECT artist_id, library_id, comment
+FROM wxyc_schema.artist_library_crossreference
+"""
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def load_genres(conn: Any) -> dict[int, str]:
+    """Load genre ID → name mapping from ``wxyc_schema.genres``.
+
+    Args:
+        conn: psycopg connection (dict_row factory).
+
+    Returns:
+        Dict mapping genre ID to genre name.
+    """
+    rows = conn.execute(_GENRES_SQL).fetchall()
+    return {row["id"]: row["genre_name"] for row in rows}
+
+
+def load_catalog(conn: Any) -> tuple[list[LibraryCode], list[LibraryRelease]]:
+    """Load library catalog (artists + releases) from PG.
+
+    Queries ``wxyc_schema.artists``, ``genre_artist_crossreference``, and
+    ``library`` to build the ``LibraryCode`` and ``LibraryRelease`` lists
+    that the resolver needs.
+
+    For artists with multiple genre entries, the first one (lowest
+    ``artist_genre_code``) is used. Artists without a genre entry get
+    ``genre_id=0``.
+
+    Args:
+        conn: psycopg connection (dict_row factory).
+
+    Returns:
+        Tuple of (codes, releases).
+    """
+    # Build artist_id → genre_id mapping (first genre wins)
+    genre_xref_rows = conn.execute(_GENRE_ARTIST_XREF_SQL).fetchall()
+    artist_genre: dict[int, int] = {}
+    for row in genre_xref_rows:
+        artist_id = row["artist_id"]
+        if artist_id not in artist_genre:
+            artist_genre[artist_id] = row["genre_id"]
+
+    # Build LibraryCode list from artists
+    artist_rows = conn.execute(_ARTISTS_SQL).fetchall()
+    codes = [
+        LibraryCode(
+            id=row["id"],
+            genre_id=artist_genre.get(row["id"], 0),
+            presentation_name=row["artist_name"],
+        )
+        for row in artist_rows
+    ]
+
+    # Build LibraryRelease list from library
+    library_rows = conn.execute(_LIBRARY_SQL).fetchall()
+    releases = [
+        LibraryRelease(id=row["id"], library_code_id=row["artist_id"]) for row in library_rows
+    ]
+
+    logger.info("Loaded catalog: %d artists, %d releases", len(codes), len(releases))
+    return codes, releases
+
+
+def load_flowsheet_entries(conn: Any) -> list[FlowsheetEntry]:
+    """Load music flowsheet entries from PG.
+
+    Queries ``wxyc_schema.flowsheet`` filtered to ``entry_type = 'track'``
+    and maps PG columns to ``FlowsheetEntry`` fields:
+
+    - ``album_id`` → ``library_release_id`` (NULL → 0)
+    - ``request_flag`` boolean → int (0 or 1)
+    - ``add_time`` timestamptz → epoch seconds int (via EXTRACT(EPOCH ...))
+    - ``entry_type`` enum 'track' → ``entry_type_code = 1``
+
+    Args:
+        conn: psycopg connection (dict_row factory).
+
+    Returns:
+        List of FlowsheetEntry, ordered by (show_id, play_order).
+    """
+    rows = conn.execute(_FLOWSHEET_SQL).fetchall()
+    entries: list[FlowsheetEntry] = []
+
+    for row in rows:
+        album_id = row["album_id"]
+        add_time_epoch = row["add_time_epoch"]
+
+        entries.append(
+            FlowsheetEntry(
+                id=row["id"],
+                artist_name=row["artist_name"] or "",
+                song_title=row["track_title"] or "",
+                release_title=row["album_title"] or "",
+                label_name=row["record_label"] or "",
+                show_id=row["show_id"] if row["show_id"] is not None else 0,
+                sequence=row["play_order"],
+                library_release_id=album_id if isinstance(album_id, int) else 0,
+                entry_type_code=1,  # all rows are 'track' (filtered in SQL)
+                request_flag=1 if row["request_flag"] else 0,
+                start_time=int(add_time_epoch) if add_time_epoch is not None else None,
+            )
+        )
+
+    logger.info("Loaded %d flowsheet track entries", len(entries))
+    return entries
+
+
+def load_shows(conn: Any) -> tuple[dict[int, int | str], dict[int, str]]:
+    """Load show → DJ mapping from PG.
+
+    Queries ``wxyc_schema.shows`` for ``primary_dj_id``. Shows where
+    ``primary_dj_id`` is NULL are skipped.
+
+    Args:
+        conn: psycopg connection (dict_row factory).
+
+    Returns:
+        Tuple of (show_to_dj, show_dj_names).
+        ``show_to_dj`` maps show ID to DJ identifier (string or int).
+        ``show_dj_names`` maps show ID to display name (currently same as DJ ID).
+    """
+    rows = conn.execute(_SHOWS_SQL).fetchall()
+    show_to_dj: dict[int, int | str] = {}
+    show_dj_names: dict[int, str] = {}
+
+    for row in rows:
+        dj_id = row["primary_dj_id"]
+        if dj_id is not None:
+            show_id = row["id"]
+            show_to_dj[show_id] = dj_id
+            show_dj_names[show_id] = str(dj_id)
+
+    logger.info("Loaded %d shows, %d with DJ mapping", len(rows), len(show_to_dj))
+    return show_to_dj, show_dj_names
+
+
+def load_cross_references(
+    conn: Any,
+) -> tuple[list[tuple], list[tuple]]:
+    """Load cross-reference data from PG.
+
+    Returns tuples in the shape expected by ``CrossReferenceExtractor``:
+    ``(id, source_artist_id, target_artist_id, comment)`` for artist xrefs,
+    ``(id, artist_id, library_id, comment)`` for release xrefs.
+
+    The PG tables don't have a row ID, so a synthetic ``0`` is used.
+
+    Args:
+        conn: psycopg connection (dict_row factory).
+
+    Returns:
+        Tuple of (artist_xrefs, release_xrefs).
+    """
+    artist_rows = conn.execute(_ARTIST_XREF_SQL).fetchall()
+    artist_xrefs = [
+        (0, row["source_artist_id"], row["target_artist_id"], row.get("comment"))
+        for row in artist_rows
+    ]
+
+    release_rows = conn.execute(_RELEASE_XREF_SQL).fetchall()
+    release_xrefs = [
+        (0, row["artist_id"], row["library_id"], row.get("comment")) for row in release_rows
+    ]
+
+    logger.info(
+        "Loaded cross-references: %d artist, %d release",
+        len(artist_xrefs),
+        len(release_xrefs),
+    )
+    return artist_xrefs, release_xrefs

--- a/semantic_index/pg_source.py
+++ b/semantic_index/pg_source.py
@@ -65,7 +65,7 @@ ORDER BY show_id, play_order
 """
 
 _SHOWS_SQL = """\
-SELECT id, primary_dj_id, legacy_show_id
+SELECT id, primary_dj_id, legacy_dj_name, legacy_show_id
 FROM wxyc_schema.shows
 ORDER BY id
 """
@@ -192,8 +192,8 @@ def load_flowsheet_entries(conn: Any) -> list[FlowsheetEntry]:
 def load_shows(conn: Any) -> tuple[dict[int, int | str], dict[int, str]]:
     """Load show → DJ mapping from PG.
 
-    Queries ``wxyc_schema.shows`` for ``primary_dj_id``. Shows where
-    ``primary_dj_id`` is NULL are skipped.
+    Queries ``wxyc_schema.shows`` for ``primary_dj_id`` (auth user FK) with
+    ``legacy_dj_name`` as a fallback for shows imported from tubafrenzy.
 
     Args:
         conn: psycopg connection (dict_row factory).
@@ -201,7 +201,7 @@ def load_shows(conn: Any) -> tuple[dict[int, int | str], dict[int, str]]:
     Returns:
         Tuple of (show_to_dj, show_dj_names).
         ``show_to_dj`` maps show ID to DJ identifier (string or int).
-        ``show_dj_names`` maps show ID to display name (currently same as DJ ID).
+        ``show_dj_names`` maps show ID to display name.
     """
     rows = conn.execute(_SHOWS_SQL).fetchall()
     show_to_dj: dict[int, int | str] = {}
@@ -209,10 +209,15 @@ def load_shows(conn: Any) -> tuple[dict[int, int | str], dict[int, str]]:
 
     for row in rows:
         dj_id = row["primary_dj_id"]
+        legacy_name = row.get("legacy_dj_name")
         if dj_id is not None:
             show_id = row["id"]
             show_to_dj[show_id] = dj_id
             show_dj_names[show_id] = str(dj_id)
+        elif legacy_name:
+            show_id = row["id"]
+            show_to_dj[show_id] = legacy_name
+            show_dj_names[show_id] = legacy_name
 
     logger.info("Loaded %d shows, %d with DJ mapping", len(rows), len(show_to_dj))
     return show_to_dj, show_dj_names

--- a/tests/unit/test_nightly_sync.py
+++ b/tests/unit/test_nightly_sync.py
@@ -1,0 +1,265 @@
+"""Tests for nightly sync orchestrator helpers.
+
+Tests the utility functions (_prepare_working_db, _clear_recomputed_tables,
+_atomic_swap) and verifies enrichment data survives a pipeline re-run on
+a copied database.
+"""
+
+import sqlite3
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _create_test_db(path: Path, *, with_enrichment: bool = False) -> None:
+    """Create a minimal SQLite database with pipeline tables.
+
+    When *with_enrichment* is True, also creates enrichment tables and
+    inserts sample data that should survive a nightly sync.
+    """
+    conn = sqlite3.connect(str(path))
+    conn.executescript(
+        """
+        CREATE TABLE artist (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            canonical_name TEXT NOT NULL UNIQUE,
+            genre TEXT,
+            total_plays INTEGER NOT NULL DEFAULT 0,
+            dj_count INTEGER NOT NULL DEFAULT 0,
+            request_ratio REAL NOT NULL DEFAULT 0.0,
+            show_count INTEGER NOT NULL DEFAULT 0
+        );
+        CREATE TABLE dj_transition (
+            source_id INTEGER NOT NULL,
+            target_id INTEGER NOT NULL,
+            raw_count INTEGER NOT NULL,
+            pmi REAL NOT NULL,
+            PRIMARY KEY (source_id, target_id)
+        );
+        CREATE TABLE cross_reference (
+            artist_a_id INTEGER NOT NULL,
+            artist_b_id INTEGER NOT NULL,
+            comment TEXT,
+            source TEXT NOT NULL,
+            PRIMARY KEY (artist_a_id, artist_b_id, source)
+        );
+        """
+    )
+
+    # Seed some edge data that should be cleared
+    conn.execute("INSERT INTO artist (canonical_name, total_plays) VALUES ('Autechre', 500)")
+    conn.execute("INSERT INTO artist (canonical_name, total_plays) VALUES ('Stereolab', 400)")
+    conn.execute("INSERT INTO dj_transition VALUES (1, 2, 10, 3.5)")
+    conn.execute("INSERT INTO cross_reference VALUES (1, 2, 'see also', 'library_code')")
+
+    if with_enrichment:
+        conn.executescript(
+            """
+            CREATE TABLE entity (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                wikidata_qid TEXT,
+                name TEXT NOT NULL,
+                entity_type TEXT NOT NULL DEFAULT 'artist',
+                created_at TEXT NOT NULL DEFAULT '2025-01-01',
+                updated_at TEXT NOT NULL DEFAULT '2025-01-01'
+            );
+            CREATE TABLE wikidata_influence (
+                source_id INTEGER NOT NULL,
+                target_id INTEGER NOT NULL,
+                source_qid TEXT NOT NULL,
+                target_qid TEXT NOT NULL,
+                PRIMARY KEY (source_id, target_id)
+            );
+            CREATE TABLE audio_profile (
+                artist_id INTEGER PRIMARY KEY,
+                avg_danceability REAL,
+                recording_count INTEGER NOT NULL DEFAULT 0,
+                created_at TEXT NOT NULL DEFAULT '2025-01-01'
+            );
+            """
+        )
+        conn.execute("INSERT INTO entity (wikidata_qid, name) VALUES ('Q210513', 'Autechre')")
+        conn.execute("INSERT INTO wikidata_influence VALUES (1, 2, 'Q210513', 'Q484464')")
+        conn.execute("INSERT INTO audio_profile VALUES (1, 0.35, 42, '2025-01-01')")
+
+    conn.commit()
+    conn.close()
+
+
+# ===========================================================================
+# _validate_sqlite
+# ===========================================================================
+
+
+class TestValidateSqlite:
+    def test_valid_sqlite_file(self, tmp_path):
+        from semantic_index.nightly_sync import _validate_sqlite
+
+        db = tmp_path / "test.db"
+        conn = sqlite3.connect(str(db))
+        conn.execute("CREATE TABLE t (id INTEGER)")
+        conn.close()
+
+        assert _validate_sqlite(db) is True
+
+    def test_non_sqlite_file(self, tmp_path):
+        from semantic_index.nightly_sync import _validate_sqlite
+
+        f = tmp_path / "not_a_db.db"
+        f.write_text("this is not sqlite")
+
+        assert _validate_sqlite(f) is False
+
+    def test_nonexistent_file(self, tmp_path):
+        from semantic_index.nightly_sync import _validate_sqlite
+
+        assert _validate_sqlite(tmp_path / "missing.db") is False
+
+
+# ===========================================================================
+# _prepare_working_db
+# ===========================================================================
+
+
+class TestPrepareWorkingDb:
+    def test_copies_existing_db(self, tmp_path):
+        from semantic_index.nightly_sync import _prepare_working_db
+
+        prod = tmp_path / "prod.db"
+        _create_test_db(prod)
+
+        temp = _prepare_working_db(prod)
+
+        assert temp.exists()
+        assert temp != prod
+        # Verify content was copied
+        conn = sqlite3.connect(str(temp))
+        count = conn.execute("SELECT COUNT(*) FROM artist").fetchone()[0]
+        conn.close()
+        assert count == 2
+
+    def test_first_run_creates_empty_temp(self, tmp_path):
+        from semantic_index.nightly_sync import _prepare_working_db
+
+        prod = tmp_path / "nonexistent.db"
+        temp = _prepare_working_db(prod)
+
+        assert temp.exists()
+        assert temp.stat().st_size == 0
+
+    def test_temp_in_same_directory_as_production(self, tmp_path):
+        from semantic_index.nightly_sync import _prepare_working_db
+
+        prod = tmp_path / "data" / "graph.db"
+        prod.parent.mkdir()
+        _create_test_db(prod)
+
+        temp = _prepare_working_db(prod)
+
+        assert temp.parent == prod.parent
+
+
+# ===========================================================================
+# _clear_recomputed_tables
+# ===========================================================================
+
+
+class TestClearRecomputedTables:
+    def test_clears_edge_tables(self, tmp_path):
+        from semantic_index.nightly_sync import _clear_recomputed_tables
+
+        db = tmp_path / "test.db"
+        _create_test_db(db, with_enrichment=True)
+
+        _clear_recomputed_tables(str(db))
+
+        conn = sqlite3.connect(str(db))
+        assert conn.execute("SELECT COUNT(*) FROM dj_transition").fetchone()[0] == 0
+        assert conn.execute("SELECT COUNT(*) FROM cross_reference").fetchone()[0] == 0
+        conn.close()
+
+    def test_preserves_enrichment_tables(self, tmp_path):
+        from semantic_index.nightly_sync import _clear_recomputed_tables
+
+        db = tmp_path / "test.db"
+        _create_test_db(db, with_enrichment=True)
+
+        _clear_recomputed_tables(str(db))
+
+        conn = sqlite3.connect(str(db))
+        assert conn.execute("SELECT COUNT(*) FROM entity").fetchone()[0] == 1
+        assert conn.execute("SELECT COUNT(*) FROM wikidata_influence").fetchone()[0] == 1
+        assert conn.execute("SELECT COUNT(*) FROM audio_profile").fetchone()[0] == 1
+        conn.close()
+
+    def test_handles_missing_tables_gracefully(self, tmp_path):
+        """Works on a fresh DB that doesn't have edge tables yet."""
+        from semantic_index.nightly_sync import _clear_recomputed_tables
+
+        db = tmp_path / "empty.db"
+        conn = sqlite3.connect(str(db))
+        conn.execute("CREATE TABLE artist (id INTEGER PRIMARY KEY)")
+        conn.close()
+
+        # Should not raise
+        _clear_recomputed_tables(str(db))
+
+
+# ===========================================================================
+# _atomic_swap
+# ===========================================================================
+
+
+class TestAtomicSwap:
+    def test_replaces_production_with_temp(self, tmp_path):
+        from semantic_index.nightly_sync import _atomic_swap
+
+        prod = tmp_path / "prod.db"
+        prod.write_bytes(b"old content")
+
+        temp = tmp_path / "temp.db"
+        temp.write_bytes(b"new content")
+
+        _atomic_swap(temp, prod, dry_run=False)
+
+        assert prod.read_bytes() == b"new content"
+        assert not temp.exists()
+
+    def test_dry_run_removes_temp_keeps_production(self, tmp_path):
+        from semantic_index.nightly_sync import _atomic_swap
+
+        prod = tmp_path / "prod.db"
+        prod.write_bytes(b"old content")
+
+        temp = tmp_path / "temp.db"
+        temp.write_bytes(b"new content")
+
+        _atomic_swap(temp, prod, dry_run=True)
+
+        assert prod.read_bytes() == b"old content"
+        assert not temp.exists()
+
+    def test_first_run_no_existing_production(self, tmp_path):
+        from semantic_index.nightly_sync import _atomic_swap
+
+        prod = tmp_path / "prod.db"
+        temp = tmp_path / "temp.db"
+        temp.write_bytes(b"new content")
+
+        _atomic_swap(temp, prod, dry_run=False)
+
+        assert prod.read_bytes() == b"new content"
+
+    def test_creates_parent_directory(self, tmp_path):
+        from semantic_index.nightly_sync import _atomic_swap
+
+        prod = tmp_path / "data" / "graph.db"
+        temp = tmp_path / "data" / "temp.db"
+        temp.parent.mkdir()
+        temp.write_bytes(b"new content")
+
+        _atomic_swap(temp, prod, dry_run=False)
+
+        assert prod.exists()

--- a/tests/unit/test_pg_source.py
+++ b/tests/unit/test_pg_source.py
@@ -379,8 +379,18 @@ class TestLoadShows:
         conn = _mock_conn_with_queries(
             {
                 "shows": [
-                    {"id": 3210, "primary_dj_id": "dj_42", "legacy_show_id": 121},
-                    {"id": 3211, "primary_dj_id": None, "legacy_show_id": 124},
+                    {
+                        "id": 3210,
+                        "primary_dj_id": "dj_42",
+                        "legacy_dj_name": None,
+                        "legacy_show_id": 121,
+                    },
+                    {
+                        "id": 3211,
+                        "primary_dj_id": None,
+                        "legacy_dj_name": None,
+                        "legacy_show_id": 124,
+                    },
                 ],
                 "djs": [],
             }
@@ -390,6 +400,36 @@ class TestLoadShows:
 
         assert show_to_dj[3210] == "dj_42"
         assert 3211 not in show_to_dj
+
+    def test_legacy_dj_name_fallback(self):
+        """When primary_dj_id is NULL, fall back to legacy_dj_name."""
+        from semantic_index.pg_source import load_shows
+
+        conn = _mock_conn_with_queries(
+            {
+                "shows": [
+                    {
+                        "id": 100,
+                        "primary_dj_id": None,
+                        "legacy_dj_name": "Ellie Blake",
+                        "legacy_show_id": 1,
+                    },
+                    {
+                        "id": 200,
+                        "primary_dj_id": "auth_uuid",
+                        "legacy_dj_name": "Old Name",
+                        "legacy_show_id": 2,
+                    },
+                ],
+                "djs": [],
+            }
+        )
+
+        show_to_dj, show_dj_names = load_shows(conn)
+
+        assert show_to_dj[100] == "Ellie Blake"
+        assert show_dj_names[100] == "Ellie Blake"
+        assert show_to_dj[200] == "auth_uuid"
 
     def test_empty_shows_returns_empty_dicts(self):
         from semantic_index.pg_source import load_shows
@@ -401,14 +441,14 @@ class TestLoadShows:
         assert show_to_dj == {}
         assert show_dj_names == {}
 
-    def test_all_null_dj_ids_returns_empty(self):
+    def test_all_null_dj_ids_and_names_returns_empty(self):
         from semantic_index.pg_source import load_shows
 
         conn = _mock_conn_with_queries(
             {
                 "shows": [
-                    {"id": 100, "primary_dj_id": None, "legacy_show_id": 1},
-                    {"id": 200, "primary_dj_id": None, "legacy_show_id": 2},
+                    {"id": 100, "primary_dj_id": None, "legacy_dj_name": None, "legacy_show_id": 1},
+                    {"id": 200, "primary_dj_id": None, "legacy_dj_name": None, "legacy_show_id": 2},
                 ],
                 "djs": [],
             }

--- a/tests/unit/test_pg_source.py
+++ b/tests/unit/test_pg_source.py
@@ -1,0 +1,479 @@
+"""Tests for pg_source — PostgreSQL query functions for the nightly sync pipeline.
+
+Mocks psycopg cursors to verify column mapping from the Backend-Service
+PG schema (wxyc_schema.*) to pipeline types (FlowsheetEntry, LibraryCode,
+LibraryRelease, etc.).
+"""
+
+from unittest.mock import MagicMock
+
+from semantic_index.models import LibraryRelease
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_conn_with_rows(rows: list[dict]) -> MagicMock:
+    """Create a mock psycopg connection whose execute().fetchall() returns *rows*.
+
+    Each row is a dict (simulating psycopg's dict_row factory).
+    """
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_cursor.fetchall.return_value = rows
+    mock_conn.execute.return_value = mock_cursor
+    return mock_conn
+
+
+def _mock_conn_with_queries(query_results: dict[str, list[dict]]) -> MagicMock:
+    """Create a mock connection that returns different results based on query substring.
+
+    *query_results* maps a substring of the SQL query to the rows it should return.
+    """
+    mock_conn = MagicMock()
+
+    def _execute(query, params=None):
+        cursor = MagicMock()
+        for key, rows in query_results.items():
+            if key in query:
+                cursor.fetchall.return_value = rows
+                return cursor
+        cursor.fetchall.return_value = []
+        return cursor
+
+    mock_conn.execute.side_effect = _execute
+    return mock_conn
+
+
+# ===========================================================================
+# load_genres
+# ===========================================================================
+
+
+class TestLoadGenres:
+    """load_genres() queries wxyc_schema.genres and returns {id: name}."""
+
+    def test_returns_genre_id_to_name_mapping(self):
+        from semantic_index.pg_source import load_genres
+
+        rows = [
+            {"id": 6, "genre_name": "Hiphop"},
+            {"id": 15, "genre_name": "Electronic"},
+            {"id": 1, "genre_name": "Rock"},
+        ]
+        conn = _mock_conn_with_rows(rows)
+
+        result = load_genres(conn)
+
+        assert result == {6: "Hiphop", 15: "Electronic", 1: "Rock"}
+
+    def test_empty_table_returns_empty_dict(self):
+        from semantic_index.pg_source import load_genres
+
+        conn = _mock_conn_with_rows([])
+        assert load_genres(conn) == {}
+
+
+# ===========================================================================
+# load_catalog
+# ===========================================================================
+
+
+class TestLoadCatalog:
+    """load_catalog() queries artists, genre_artist_crossreference, and library."""
+
+    _DEFAULT_ARTISTS = [
+        {"id": 1, "artist_name": "A Guy Called Gerald"},
+        {"id": 2, "artist_name": "A Tribe Called Quest"},
+    ]
+    _DEFAULT_LIBRARY = [
+        {"id": 10, "artist_id": 1},
+        {"id": 11, "artist_id": 2},
+    ]
+
+    def _make_catalog_conn(
+        self,
+        artists: list[dict] | None = None,
+        genre_xrefs: list[dict] | None = None,
+        library: list[dict] | None = None,
+    ) -> MagicMock:
+        """Build a mock connection with canned results for catalog queries."""
+        return _mock_conn_with_queries(
+            {
+                "genre_artist_crossreference": genre_xrefs if genre_xrefs is not None else [],
+                "artists": artists if artists is not None else self._DEFAULT_ARTISTS,
+                "library": library if library is not None else self._DEFAULT_LIBRARY,
+            }
+        )
+
+    def test_returns_library_codes_from_artists(self):
+        from semantic_index.pg_source import load_catalog
+
+        conn = self._make_catalog_conn(
+            artists=[
+                {"id": 19516, "artist_name": "Autechre"},
+                {"id": 100, "artist_name": "Stereolab"},
+            ],
+            genre_xrefs=[
+                {"artist_id": 19516, "genre_id": 15},
+                {"artist_id": 100, "genre_id": 1},
+            ],
+            library=[],
+        )
+
+        codes, releases = load_catalog(conn)
+
+        assert len(codes) == 2
+        autechre = next(c for c in codes if c.id == 19516)
+        assert autechre.presentation_name == "Autechre"
+        assert autechre.genre_id == 15
+
+        stereolab = next(c for c in codes if c.id == 100)
+        assert stereolab.presentation_name == "Stereolab"
+        assert stereolab.genre_id == 1
+
+    def test_artist_without_genre_gets_zero(self):
+        """Artists not in genre_artist_crossreference get genre_id=0."""
+        from semantic_index.pg_source import load_catalog
+
+        conn = self._make_catalog_conn(
+            artists=[{"id": 42, "artist_name": "Unknown Artist"}],
+            genre_xrefs=[],
+            library=[],
+        )
+
+        codes, _ = load_catalog(conn)
+
+        assert len(codes) == 1
+        assert codes[0].genre_id == 0
+
+    def test_artist_with_multiple_genres_uses_first(self):
+        """When an artist has multiple genre entries, use the first one returned."""
+        from semantic_index.pg_source import load_catalog
+
+        conn = self._make_catalog_conn(
+            artists=[{"id": 5, "artist_name": "Genre Hopper"}],
+            genre_xrefs=[
+                {"artist_id": 5, "genre_id": 3},
+                {"artist_id": 5, "genre_id": 7},
+            ],
+            library=[],
+        )
+
+        codes, _ = load_catalog(conn)
+
+        assert len(codes) == 1
+        assert codes[0].genre_id == 3
+
+    def test_returns_library_releases(self):
+        from semantic_index.pg_source import load_catalog
+
+        conn = self._make_catalog_conn(
+            artists=[{"id": 1, "artist_name": "A Guy Called Gerald"}],
+            genre_xrefs=[{"artist_id": 1, "genre_id": 6}],
+            library=[
+                {"id": 10, "artist_id": 1},
+                {"id": 11, "artist_id": 1},
+            ],
+        )
+
+        _, releases = load_catalog(conn)
+
+        assert len(releases) == 2
+        assert releases[0] == LibraryRelease(id=10, library_code_id=1)
+        assert releases[1] == LibraryRelease(id=11, library_code_id=1)
+
+    def test_empty_tables_return_empty_lists(self):
+        from semantic_index.pg_source import load_catalog
+
+        conn = self._make_catalog_conn(artists=[], genre_xrefs=[], library=[])
+
+        codes, releases = load_catalog(conn)
+
+        assert codes == []
+        assert releases == []
+
+
+# ===========================================================================
+# load_flowsheet_entries
+# ===========================================================================
+
+
+class TestLoadFlowsheetEntries:
+    """load_flowsheet_entries() queries wxyc_schema.flowsheet WHERE entry_type='track'."""
+
+    def test_maps_pg_columns_to_flowsheet_entry(self):
+        from semantic_index.pg_source import load_flowsheet_entries
+
+        rows = [
+            {
+                "id": 155,
+                "artist_name": "Jett Rink",
+                "track_title": "Born Hungry",
+                "album_title": "Bandwidth",
+                "record_label": "WXYC",
+                "show_id": 3210,
+                "play_order": 2,
+                "album_id": None,
+                "request_flag": False,
+                "add_time_epoch": 1099537681,
+                "legacy_entry_id": 2,
+            },
+        ]
+        conn = _mock_conn_with_rows(rows)
+
+        entries = load_flowsheet_entries(conn)
+
+        assert len(entries) == 1
+        e = entries[0]
+        assert e.id == 155
+        assert e.artist_name == "Jett Rink"
+        assert e.song_title == "Born Hungry"
+        assert e.release_title == "Bandwidth"
+        assert e.label_name == "WXYC"
+        assert e.show_id == 3210
+        assert e.sequence == 2
+        assert e.library_release_id == 0  # album_id is NULL
+        assert e.request_flag == 0  # boolean False → int 0
+        assert e.entry_type_code == 1  # track entries get code 1
+        assert e.start_time == 1099537681  # epoch seconds
+
+    def test_request_flag_true_becomes_one(self):
+        from semantic_index.pg_source import load_flowsheet_entries
+
+        rows = [
+            {
+                "id": 200,
+                "artist_name": "Cat Power",
+                "track_title": "Cross Bones Style",
+                "album_title": "Moon Pix",
+                "record_label": "Matador Records",
+                "show_id": 5000,
+                "play_order": 10,
+                "album_id": 42,
+                "request_flag": True,
+                "add_time_epoch": 1276632000,
+                "legacy_entry_id": None,
+            },
+        ]
+        conn = _mock_conn_with_rows(rows)
+
+        entries = load_flowsheet_entries(conn)
+
+        assert entries[0].request_flag == 1
+        assert entries[0].library_release_id == 42
+
+    def test_null_fields_become_empty_strings(self):
+        """NULL artist_name, track_title, album_title, record_label → empty strings."""
+        from semantic_index.pg_source import load_flowsheet_entries
+
+        rows = [
+            {
+                "id": 300,
+                "artist_name": None,
+                "track_title": None,
+                "album_title": None,
+                "record_label": None,
+                "show_id": 1000,
+                "play_order": 1,
+                "album_id": None,
+                "request_flag": False,
+                "add_time_epoch": None,
+                "legacy_entry_id": None,
+            },
+        ]
+        conn = _mock_conn_with_rows(rows)
+
+        entries = load_flowsheet_entries(conn)
+
+        e = entries[0]
+        assert e.artist_name == ""
+        assert e.song_title == ""
+        assert e.release_title == ""
+        assert e.label_name == ""
+        assert e.start_time is None
+
+    def test_null_show_id_becomes_zero(self):
+        from semantic_index.pg_source import load_flowsheet_entries
+
+        rows = [
+            {
+                "id": 400,
+                "artist_name": "Sessa",
+                "track_title": "Pequena Vertigem",
+                "album_title": "Pequena Vertigem de Amor",
+                "record_label": "Mexican Summer",
+                "show_id": None,
+                "play_order": 5,
+                "album_id": None,
+                "request_flag": False,
+                "add_time_epoch": 1672531200,
+                "legacy_entry_id": None,
+            },
+        ]
+        conn = _mock_conn_with_rows(rows)
+
+        entries = load_flowsheet_entries(conn)
+
+        assert entries[0].show_id == 0
+
+    def test_multiple_entries_preserve_order(self):
+        from semantic_index.pg_source import load_flowsheet_entries
+
+        rows = [
+            {
+                "id": 1,
+                "artist_name": "Autechre",
+                "track_title": "VI Scose Poise",
+                "album_title": "Confield",
+                "record_label": "Warp",
+                "show_id": 100,
+                "play_order": 1,
+                "album_id": None,
+                "request_flag": False,
+                "add_time_epoch": 1577836800,
+                "legacy_entry_id": None,
+            },
+            {
+                "id": 2,
+                "artist_name": "Stereolab",
+                "track_title": "Metronomic Underground",
+                "album_title": "Emperor Tomato Ketchup",
+                "record_label": "Duophonic",
+                "show_id": 100,
+                "play_order": 2,
+                "album_id": None,
+                "request_flag": False,
+                "add_time_epoch": 1577837100,
+                "legacy_entry_id": None,
+            },
+        ]
+        conn = _mock_conn_with_rows(rows)
+
+        entries = load_flowsheet_entries(conn)
+
+        assert len(entries) == 2
+        assert entries[0].artist_name == "Autechre"
+        assert entries[1].artist_name == "Stereolab"
+
+    def test_empty_table_returns_empty_list(self):
+        from semantic_index.pg_source import load_flowsheet_entries
+
+        conn = _mock_conn_with_rows([])
+
+        assert load_flowsheet_entries(conn) == []
+
+
+# ===========================================================================
+# load_shows
+# ===========================================================================
+
+
+class TestLoadShows:
+    """load_shows() queries shows + show_djs and returns (show_to_dj, show_dj_names)."""
+
+    def test_maps_show_id_to_primary_dj_id(self):
+        from semantic_index.pg_source import load_shows
+
+        conn = _mock_conn_with_queries(
+            {
+                "shows": [
+                    {"id": 3210, "primary_dj_id": "dj_42", "legacy_show_id": 121},
+                    {"id": 3211, "primary_dj_id": None, "legacy_show_id": 124},
+                ],
+                "djs": [],
+            }
+        )
+
+        show_to_dj, show_dj_names = load_shows(conn)
+
+        assert show_to_dj[3210] == "dj_42"
+        assert 3211 not in show_to_dj
+
+    def test_empty_shows_returns_empty_dicts(self):
+        from semantic_index.pg_source import load_shows
+
+        conn = _mock_conn_with_queries({"shows": [], "djs": []})
+
+        show_to_dj, show_dj_names = load_shows(conn)
+
+        assert show_to_dj == {}
+        assert show_dj_names == {}
+
+    def test_all_null_dj_ids_returns_empty(self):
+        from semantic_index.pg_source import load_shows
+
+        conn = _mock_conn_with_queries(
+            {
+                "shows": [
+                    {"id": 100, "primary_dj_id": None, "legacy_show_id": 1},
+                    {"id": 200, "primary_dj_id": None, "legacy_show_id": 2},
+                ],
+                "djs": [],
+            }
+        )
+
+        show_to_dj, show_dj_names = load_shows(conn)
+
+        assert show_to_dj == {}
+
+
+# ===========================================================================
+# load_cross_references
+# ===========================================================================
+
+
+class TestLoadCrossReferences:
+    """load_cross_references() queries artist_crossreference and artist_library_crossreference."""
+
+    def test_returns_artist_crossref_tuples(self):
+        from semantic_index.pg_source import load_cross_references
+
+        conn = _mock_conn_with_queries(
+            {
+                "artist_crossreference": [
+                    {"source_artist_id": 1, "target_artist_id": 2, "comment": "see also"},
+                ],
+                "artist_library_crossreference": [],
+            }
+        )
+
+        artist_xrefs, release_xrefs = load_cross_references(conn)
+
+        assert len(artist_xrefs) == 1
+        # Returns tuples matching the shape expected by CrossReferenceExtractor
+        # (id, source_artist_id, target_artist_id, comment)
+        assert artist_xrefs[0] == (0, 1, 2, "see also")
+
+    def test_returns_release_crossref_tuples(self):
+        from semantic_index.pg_source import load_cross_references
+
+        conn = _mock_conn_with_queries(
+            {
+                "artist_crossreference": [],
+                "artist_library_crossreference": [
+                    {"artist_id": 10, "library_id": 20, "comment": "compilation"},
+                ],
+            }
+        )
+
+        artist_xrefs, release_xrefs = load_cross_references(conn)
+
+        assert len(release_xrefs) == 1
+        assert release_xrefs[0] == (0, 10, 20, "compilation")
+
+    def test_empty_tables_return_empty_lists(self):
+        from semantic_index.pg_source import load_cross_references
+
+        conn = _mock_conn_with_queries(
+            {
+                "artist_crossreference": [],
+                "artist_library_crossreference": [],
+            }
+        )
+
+        artist_xrefs, release_xrefs = load_cross_references(conn)
+
+        assert artist_xrefs == []
+        assert release_xrefs == []


### PR DESCRIPTION
## Summary

- Add `pg_source.py` to query Backend-Service PostgreSQL (`wxyc_schema.*`) and return the same pipeline types as the SQL dump parser
- Add `nightly_sync.py` orchestrator that runs PG → resolve → PMI → stats → facets → graph metrics with atomic copy-and-swap
- Enrichment data (Discogs, Wikidata, AcousticBrainz) preserved from the existing DB — only the core graph is recomputed
- 32 unit tests covering PG column mapping and all orchestrator helpers

Closes #137

## Test plan

- [x] 19 unit tests for `pg_source.py` (mock psycopg cursors, column mapping verification)
- [x] 13 unit tests for nightly sync helpers (validate SQLite, copy DB, clear edge tables, atomic swap, enrichment preservation)
- [x] Smoke tested all PG queries against live `wxyc-db` RDS
- [x] ruff check, ruff format, mypy all pass
- [x] Dry run against production DB: `python scripts/nightly_sync.py --dry-run --verbose`
- [x] Full run with DB inspection: verify artist/transition/facet counts match expectations