### PR TITLE
Improve mobile layout: graph above list, parallax scroll, sticky header

### DIFF
--- a/explorer/index.html
+++ b/explorer/index.html
@@ -92,6 +92,7 @@
 
   svg { cursor: grab; }
   svg:active { cursor: grabbing; }
+  #graph-container { position: relative; }
 
   /* Sidebar */
   #sidebar {
@@ -222,7 +223,7 @@
     body { overflow: auto; }
 
     #controls {
-      position: sticky; top: 0; right: 0;
+      position: relative; right: auto;
       flex-wrap: wrap; padding: 8px 12px; gap: 8px;
     }
     #controls input[type="text"] { width: 140px; font-size: 12px; }
@@ -231,13 +232,19 @@
     .controls-collapsible.open { display: contents; }
     #status { display: none; }
 
+    #graph-container { height: 50vh; overflow: hidden; }
+
     #sidebar {
       position: static; width: 100%; height: auto;
       border-left: none; border-top: 1px solid #333;
     }
+    .sidebar-header {
+      position: sticky; top: 0; z-index: 10;
+      background: rgba(15,15,15,0.97);
+    }
     .sidebar-list { overflow-y: visible; }
 
-    svg#graph { width: 100% !important; height: 50vh !important; display: block; }
+    svg#graph { width: 100% !important; height: 100% !important; display: block; }
   }
   .external-links a:hover { border-color: #6a9fb5; }
 
@@ -348,6 +355,10 @@
   <div class="meta"></div>
 </div>
 
+<div id="graph-container">
+  <svg id="graph"></svg>
+</div>
+
 <div id="sidebar">
   <div class="sidebar-header">
     <span class="artist-name">Select an artist</span>
@@ -376,8 +387,6 @@
     <p style="margin-top:24px;font-size:11px;color:#666;"><a href="https://wxyc.org">WXYC 89.3 FM</a> &middot; Chapel Hill, NC &middot; Student-run freeform radio since 1977</p>
   </div>
 </div>
-
-<svg id="graph"></svg>
 
 <script type="module">
 import { parseURL, buildURL, DEFAULTS } from './url-state.js';
@@ -1544,6 +1553,18 @@ async function loadFacets() {
     opt.textContent = dj.display_name;
     djSelect.appendChild(opt);
   }
+}
+
+// Mobile parallax effect on the graph
+if (isMobile) {
+  const graphContainer = document.getElementById('graph-container');
+  const graphSvg = document.getElementById('graph');
+  window.addEventListener('scroll', () => {
+    const rect = graphContainer.getBoundingClientRect();
+    if (rect.bottom > 0) {
+      graphSvg.style.transform = `translateY(${window.scrollY * 0.4}px)`;
+    }
+  }, { passive: true });
 }
 
 // Initialize from URL or random artist

--- a/semantic_index/api/__main__.py
+++ b/semantic_index/api/__main__.py
@@ -5,6 +5,7 @@ Usage:
 """
 
 import logging
+import socket
 
 import uvicorn
 
@@ -16,5 +17,20 @@ logging.basicConfig(level=logging.INFO)
 settings = Settings()
 app = create_app(settings.db_path, anthropic_api_key=settings.anthropic_api_key)
 
+
+def find_available_port(host: str, start: int) -> int:
+    """Return start if available, otherwise find the next free port."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        if s.connect_ex((host if host != "0.0.0.0" else "127.0.0.1", start)) != 0:
+            return start
+    # Port in use — let the OS pick one
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind((host, 0))
+        return int(s.getsockname()[1])
+
+
 if __name__ == "__main__":
-    uvicorn.run(app, host=settings.host, port=settings.port)
+    port = find_available_port(settings.host, settings.port)
+    if port != settings.port:
+        logging.getLogger(__name__).info("Port %d in use, using %d instead", settings.port, port)
+    uvicorn.run(app, host=settings.host, port=port)


### PR DESCRIPTION
## Summary

- Move graph above the neighbor list on mobile so it's visible without scrolling past all cards
- Controls bar scrolls away naturally instead of staying sticky, maximizing screen real estate
- Parallax effect on the graph (60% scroll speed) as the list moves up over it
- Artist name/genre/playcount header sticks at the top while scrolling through neighbors
- Dev server auto-selects an available port when 8000 is in use

Closes #139

## Test plan

- [ ] Open on mobile (or responsive mode at ≤768px): graph should appear above the neighbor list
- [ ] Scroll down: controls bar should scroll away, graph should have parallax effect
- [ ] Continue scrolling into the neighbor list: artist header should stick at top
- [ ] Verify desktop layout is unchanged (fixed sidebar, fixed controls)
- [ ] Run `python -m semantic_index.api` when port 8000 is in use: should pick another port and log it