### PR TITLE
Add in-process nightly sync scheduler

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -350,20 +350,22 @@ Configuration via environment variables:
 - `PORT` — port (default: `8000`, set automatically by Railway)
 - `ANTHROPIC_API_KEY` — Anthropic API key for narrative generation (optional; narrative endpoint returns 501 when not set)
 - `SPOTIFY_CLIENT_ID` / `SPOTIFY_CLIENT_SECRET` — Spotify API credentials for preview URL lookups (optional; Spotify tier in the preview fallback chain is skipped when not set)
+- `SYNC_ENABLED` — enable the in-process nightly sync scheduler (default: `false`)
+- `SYNC_HOUR_UTC` — hour (UTC) to run the daily sync (default: `9`)
+- `DATABASE_URL_BACKEND` — Backend-Service PostgreSQL DSN for nightly sync (required when `SYNC_ENABLED=true`)
 
-### Railway cron service (nightly sync)
+### Nightly sync scheduler (in-process)
 
-A separate Railway cron service in the same project runs the nightly sync on a schedule. It shares the `/data` volume with the API service so the atomic swap updates the database the API reads from.
+The API service includes a built-in sync scheduler that runs `nightly_sync()` as a background daemon thread. Enable it by setting env vars on the Railway API service:
 
-**Setup (Railway dashboard):**
-1. Create a new service in the project, type "Cron Job"
-2. Source: same repo, same branch
-3. Override start command: `./scripts/cron_sync.sh`
-4. Schedule: `0 9 * * *` (daily at 9:00 UTC / 5:00 AM ET)
-5. Mount the same `/data` volume as the API service
-6. Set env vars: `DATABASE_URL_BACKEND` (Backend-Service PG DSN), `DB_PATH=/data/wxyc_artist_graph.db`
+- `SYNC_ENABLED=true` — enable the scheduler (default: false)
+- `SYNC_HOUR_UTC=9` — hour to run daily sync (default: 9 = 5:00 AM ET)
+- `DATABASE_URL_BACKEND=postgresql://...` — Backend-Service PG DSN (required when sync enabled)
+- `SYNC_MIN_COUNT=2` — minimum co-occurrence count for DJ transition edges
 
-The cron entrypoint (`scripts/cron_sync.sh`) calls `python -m semantic_index.nightly_sync` which queries PG, recomputes the graph, and atomically swaps the database. Runtime is ~5 minutes.
+The scheduler sleeps until the configured hour, runs the full pipeline (PG → resolve → PMI → export → facets → graph metrics), atomically swaps the database, then sleeps until the next day. The API continues serving requests during the rebuild. Runtime is ~5 minutes.
+
+The sync can also be run manually via CLI: `python scripts/nightly_sync.py --dsn postgresql://... --verbose`
 
 ## Data
 

--- a/semantic_index/api/__main__.py
+++ b/semantic_index/api/__main__.py
@@ -15,7 +15,14 @@ from semantic_index.api.config import Settings
 logging.basicConfig(level=logging.INFO)
 
 settings = Settings()
-app = create_app(settings.db_path, anthropic_api_key=settings.anthropic_api_key)
+app = create_app(
+    settings.db_path,
+    anthropic_api_key=settings.anthropic_api_key,
+    sync_enabled=settings.sync_enabled,
+    sync_hour_utc=settings.sync_hour_utc,
+    sync_dsn=settings.database_url_backend,
+    sync_min_count=settings.sync_min_count,
+)
 
 
 def find_available_port(host: str, start: int) -> int:

--- a/semantic_index/api/app.py
+++ b/semantic_index/api/app.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import sqlite3
 from pathlib import Path
 
@@ -15,18 +16,32 @@ from semantic_index.api.narrative import narrative_router
 from semantic_index.api.preview import preview_router
 from semantic_index.api.routes import router
 
+logger = logging.getLogger(__name__)
+
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 EXPLORER_DIR = PROJECT_ROOT / "explorer"
 EXPLORER_HTML = EXPLORER_DIR / "index.html"
 
 
-def create_app(db_path: str, anthropic_api_key: str | None = None) -> FastAPI:
+def create_app(
+    db_path: str,
+    anthropic_api_key: str | None = None,
+    *,
+    sync_enabled: bool = False,
+    sync_hour_utc: int = 9,
+    sync_dsn: str | None = None,
+    sync_min_count: int = 2,
+) -> FastAPI:
     """Create a FastAPI application wired to the given SQLite database.
 
     Args:
         db_path: Path to the SQLite graph database produced by the pipeline.
         anthropic_api_key: Anthropic API key for narrative generation. When None,
             the narrative endpoint returns 501.
+        sync_enabled: Start the nightly sync scheduler on startup.
+        sync_hour_utc: Hour (UTC) to run the daily sync.
+        sync_dsn: PostgreSQL DSN for Backend-Service (required when sync_enabled).
+        sync_min_count: Minimum co-occurrence count for DJ transition edges.
     """
     app = FastAPI(title="WXYC Semantic Graph API", version="0.1.0")
     app.add_middleware(
@@ -63,5 +78,19 @@ def create_app(db_path: str, anthropic_api_key: str | None = None) -> FastAPI:
         return FileResponse(EXPLORER_HTML, media_type="text/html")
 
     app.mount("/", StaticFiles(directory=str(EXPLORER_DIR)), name="explorer")
+
+    # Start nightly sync scheduler if enabled
+    if sync_enabled:
+        if not sync_dsn:
+            logger.error("SYNC_ENABLED=true but DATABASE_URL_BACKEND not set — skipping scheduler")
+        else:
+            from semantic_index.api.sync_scheduler import start_scheduler
+
+            start_scheduler(
+                db_path=db_path,
+                dsn=sync_dsn,
+                min_count=sync_min_count,
+                hour_utc=sync_hour_utc,
+            )
 
     return app

--- a/semantic_index/api/config.py
+++ b/semantic_index/api/config.py
@@ -18,3 +18,9 @@ class Settings(BaseSettings):
     host: str = "0.0.0.0"
     port: int = 8000
     anthropic_api_key: str | None = None
+
+    # Nightly sync scheduler
+    sync_enabled: bool = False
+    sync_hour_utc: int = 9  # 9:00 UTC = 5:00 AM ET
+    database_url_backend: str | None = None
+    sync_min_count: int = 2

--- a/semantic_index/api/sync_scheduler.py
+++ b/semantic_index/api/sync_scheduler.py
@@ -1,0 +1,94 @@
+"""Background scheduler for nightly sync within the API process.
+
+Runs ``nightly_sync()`` once daily at a configurable hour (UTC).
+The sync writes to a temp copy of the database and atomically swaps
+it, so the API can continue serving requests during the rebuild.
+
+Controlled by environment variables:
+    SYNC_ENABLED=true           — enable the scheduler (default: false)
+    SYNC_HOUR_UTC=9             — hour to run (default: 9 = 5am ET)
+    DATABASE_URL_BACKEND=...    — Backend-Service PG DSN (required)
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import threading
+import time
+from datetime import UTC, datetime
+
+logger = logging.getLogger(__name__)
+
+
+def _seconds_until_next_run(hour_utc: int) -> float:
+    """Compute seconds from now until the next occurrence of *hour_utc*:00 UTC."""
+    now = datetime.now(UTC)
+    target = now.replace(hour=hour_utc, minute=0, second=0, microsecond=0)
+    if target <= now:
+        # Already past today's window — schedule for tomorrow
+        target = target.replace(day=target.day + 1)
+    delta = (target - now).total_seconds()
+    return delta
+
+
+def _run_sync(db_path: str, dsn: str, min_count: int) -> None:
+    """Execute a single sync run, catching all exceptions."""
+    try:
+        from semantic_index.nightly_sync import nightly_sync
+
+        args = argparse.Namespace(
+            db_path=db_path,
+            dsn=dsn,
+            min_count=min_count,
+            dry_run=False,
+            verbose=False,
+        )
+        nightly_sync(args)
+    except SystemExit:
+        logger.error("Sync aborted (SystemExit)")
+    except Exception:
+        logger.exception("Sync failed with unexpected error")
+
+
+def _scheduler_loop(db_path: str, dsn: str, min_count: int, hour_utc: int) -> None:
+    """Sleep-and-run loop for the background thread."""
+    while True:
+        wait = _seconds_until_next_run(hour_utc)
+        logger.info(
+            "Next sync in %.1f hours (at %02d:00 UTC)",
+            wait / 3600,
+            hour_utc,
+        )
+        time.sleep(wait)
+
+        logger.info("Starting scheduled sync...")
+        _run_sync(db_path, dsn, min_count)
+
+
+def start_scheduler(
+    db_path: str,
+    dsn: str,
+    min_count: int = 2,
+    hour_utc: int = 9,
+) -> threading.Thread:
+    """Start the sync scheduler as a daemon thread.
+
+    Args:
+        db_path: Path to the production SQLite database.
+        dsn: PostgreSQL DSN for Backend-Service.
+        min_count: Minimum co-occurrence count for DJ transition edges.
+        hour_utc: Hour (UTC) to run the daily sync.
+
+    Returns:
+        The daemon thread (already started).
+    """
+    thread = threading.Thread(
+        target=_scheduler_loop,
+        args=(db_path, dsn, min_count, hour_utc),
+        name="sync-scheduler",
+        daemon=True,
+    )
+    thread.start()
+    logger.info("Sync scheduler started (daily at %02d:00 UTC)", hour_utc)
+    return thread


### PR DESCRIPTION
## Summary

- Add a background daemon thread to the API service that runs the nightly sync on a daily schedule
- Replaces the separate Railway cron service approach (cron services can't mount volumes)
- Enable via `SYNC_ENABLED=true` and `DATABASE_URL_BACKEND` env vars on the existing Railway API service
- The scheduler sleeps until the configured hour, runs the full pipeline, atomically swaps the DB, and repeats

## Files changed

- `semantic_index/api/sync_scheduler.py` — new scheduler module (daemon thread, sleep-until-hour loop)
- `semantic_index/api/app.py` — `create_app()` accepts sync params, starts scheduler on startup
- `semantic_index/api/config.py` — new settings: `sync_enabled`, `sync_hour_utc`, `database_url_backend`, `sync_min_count`
- `semantic_index/api/__main__.py` — passes sync settings to `create_app()`
- `CLAUDE.md` — updated deployment docs

## Test plan

- [x] All 33 unit tests pass (pg_source + nightly_sync)
- [x] All 49 API tests pass (backward-compatible `create_app` signature)
- [x] ruff check, ruff format, mypy all pass
- [ ] Deploy to Railway with `SYNC_ENABLED=true`, verify scheduler starts and logs next sync time
- [ ] Verify sync runs at configured hour and DB is swapped atomically