### PR TITLE
Add workflow_call trigger to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_call:
 
 jobs:
   lint:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,111 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  ci:
+    uses: ./.github/workflows/ci.yml
+
+  build:
+    needs: ci
+    runs-on: ubuntu-latest
+    outputs:
+      image_tag: ${{ steps.tag.outputs.tag }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Determine image tag
+        id: tag
+        run: echo "tag=sha-$(echo ${{ github.sha }} | head -c 7)" >> $GITHUB_OUTPUT
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Amazon ECR
+        env:
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin ${{ secrets.AWS_ECR_URI }}
+
+      - name: Ensure ECR repository exists
+        env:
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: |
+          aws ecr describe-repositories --repository-names semantic-index --region $AWS_REGION 2>/dev/null || \
+            aws ecr create-repository --repository-name semantic-index --region $AWS_REGION
+
+      - name: Build Docker image
+        run: docker build --platform linux/amd64 -t semantic-index:ci .
+
+      - name: Tag and push to ECR
+        env:
+          IMAGE_URI: ${{ secrets.AWS_ECR_URI }}/semantic-index
+        run: |
+          TAG=${{ steps.tag.outputs.tag }}
+
+          docker tag semantic-index:ci $IMAGE_URI:$TAG
+          docker push $IMAGE_URI:$TAG
+
+          docker tag semantic-index:ci $IMAGE_URI:latest
+          docker push $IMAGE_URI:latest
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Deploy to EC2
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
+            set -e
+            export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
+            export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+            TAG=${{ needs.build.outputs.image_tag }}
+            AWS_ECR_URI=${{ secrets.AWS_ECR_URI }}
+            AWS_REGION=${{ secrets.AWS_REGION }}
+            IMAGE_URI="$AWS_ECR_URI/semantic-index:$TAG"
+
+            echo "Logging into AWS ECR..."
+            aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin $AWS_ECR_URI
+
+            echo "Pulling Docker image..."
+            docker pull $IMAGE_URI
+
+            echo "Stopping existing container..."
+            docker stop semantic-index || true
+            docker rm semantic-index || true
+
+            echo "Starting new container..."
+            docker run -d \
+              --name semantic-index \
+              -p 8083:8083 \
+              -v /home/ec2-user/semantic-index-data:/data \
+              --restart unless-stopped \
+              --env-file .env.semantic-index \
+              $IMAGE_URI
+
+            echo "Waiting for health check..."
+            sleep 10
+            if curl -sf http://localhost:8083/health > /dev/null; then
+              echo "Service is healthy."
+            else
+              echo "Health check failed!" >&2
+              docker logs semantic-index --tail 50
+              exit 1
+            fi
+
+            echo "Cleaning up old images..."
+            docker images --format '{{.Repository}} {{.Tag}} {{.ID}}' | \
+              grep 'semantic-index' | grep -v "$TAG" | grep -v 'latest' | \
+              awk '{print $3}' | xargs -r docker rmi 2>/dev/null || true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -338,25 +338,42 @@ app = create_app("data/wxyc_artist_graph.db")
 
 ### Deployment
 
-Deployed on Railway via Dockerfile. The `data/wxyc_artist_graph.db` file is the committed, deployment-ready copy of the pipeline output. After re-running the pipeline, copy the new database from `output/` to `data/` and commit:
+Deployed on EC2 (us-east-1) as a Docker container alongside Backend-Service. The container runs on port 8083, with nginx reverse proxy and Let's Encrypt TLS for `explore.wxyc.org`.
+
+**GitHub Actions** (`.github/workflows/deploy.yml`) auto-deploys on push to main: builds a Docker image, pushes to ECR, SSHs to EC2 to pull and restart the container. Manual deploys via `workflow_dispatch`.
+
+**EC2 container setup:**
 
 ```bash
-cp output/wxyc_artist_graph.db data/wxyc_artist_graph.db
+docker run -d \
+  --name semantic-index \
+  -p 8083:8083 \
+  -v /home/ec2-user/semantic-index-data:/data \
+  --restart unless-stopped \
+  --env-file .env.semantic-index \
+  $ECR_URI/semantic-index:$TAG
 ```
 
-Configuration via environment variables:
-- `DB_PATH` — path to SQLite database (default: `data/wxyc_artist_graph.db`)
+The SQLite database and sidecar caches live in the bind-mounted `/data` directory and persist across deploys.
+
+**Configuration** via environment variables (`.env.semantic-index` on EC2):
+- `DB_PATH` — path to SQLite database (default: `/data/wxyc_artist_graph.db`)
 - `HOST` — bind address (default: `0.0.0.0`)
-- `PORT` — port (default: `8000`, set automatically by Railway)
+- `PORT` — port (default: `8083`)
 - `ANTHROPIC_API_KEY` — Anthropic API key for narrative generation (optional; narrative endpoint returns 501 when not set)
 - `SPOTIFY_CLIENT_ID` / `SPOTIFY_CLIENT_SECRET` — Spotify API credentials for preview URL lookups (optional; Spotify tier in the preview fallback chain is skipped when not set)
 - `SYNC_ENABLED` — enable the in-process nightly sync scheduler (default: `false`)
-- `SYNC_HOUR_UTC` — hour (UTC) to run the daily sync (default: `9`)
-- `DATABASE_URL_BACKEND` — Backend-Service PostgreSQL DSN for nightly sync (required when `SYNC_ENABLED=true`)
+- `SYNC_HOUR_UTC` — hour (UTC) to run the daily sync (default: `9`, i.e. 5:00 AM ET)
+- `DATABASE_URL_BACKEND` — Backend-Service PostgreSQL DSN for nightly sync (required when `SYNC_ENABLED=true`; uses the RDS private endpoint since EC2 and RDS share a VPC)
+- `SYNC_MIN_COUNT` — minimum co-occurrence count for DJ transition edges (default: `2`)
+
+**GitHub Actions secrets** (shared with Backend-Service, same GitHub org):
+- `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, `AWS_ECR_URI`
+- `EC2_HOST`, `EC2_USER`, `EC2_SSH_KEY`
 
 ### Nightly sync scheduler (in-process)
 
-The API service includes a built-in sync scheduler that runs `nightly_sync()` as a background daemon thread. Enable it by setting env vars on the Railway API service:
+The API service includes a built-in sync scheduler that runs `nightly_sync()` as a background daemon thread. Enable it by setting env vars in `.env.semantic-index`:
 
 - `SYNC_ENABLED=true` — enable the scheduler (default: false)
 - `SYNC_HOUR_UTC=9` — hour to run daily sync (default: 9 = 5:00 AM ET)

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,4 +35,6 @@ COPY start.sh .
 
 ENV DB_PATH=/data/wxyc_artist_graph.db
 
+EXPOSE 8083
+
 CMD ["./start.sh"]

--- a/railway.toml
+++ b/railway.toml
@@ -1,9 +1,0 @@
-[build]
-builder = "DOCKERFILE"
-dockerfilePath = "Dockerfile"
-
-[deploy]
-healthcheckPath = "/health"
-healthcheckTimeout = 300
-restartPolicyType = "ON_FAILURE"
-restartPolicyMaxRetries = 10

--- a/start.sh
+++ b/start.sh
@@ -1,24 +1,2 @@
 #!/bin/sh
-# Copy database to volume if not already present or if the bundled copy is newer.
-# The volume at /data persists across deploys; the bundled copy in /app/data
-# comes from the Docker build (may be an LFS pointer on Railway).
-
-DB_VOL="/data/wxyc_artist_graph.db"
-DB_BUNDLED="/app/data/wxyc_artist_graph.db"
-
-# Check if volume DB exists and is a real SQLite file (not empty or pointer)
-if [ -f "$DB_VOL" ] && [ "$(head -c 6 "$DB_VOL")" = "SQLite" ]; then
-    echo "Using existing database on volume: $DB_VOL"
-else
-    # Check if bundled copy is a real SQLite file (not an LFS pointer)
-    if [ -f "$DB_BUNDLED" ] && [ "$(head -c 6 "$DB_BUNDLED")" = "SQLite" ]; then
-        echo "Copying bundled database to volume..."
-        cp "$DB_BUNDLED" "$DB_VOL"
-        echo "Done."
-    else
-        echo "WARNING: No valid database found. The bundled file may be a Git LFS pointer."
-        echo "Upload the database to the volume at $DB_VOL manually."
-    fi
-fi
-
 exec python -m semantic_index.api


### PR DESCRIPTION
Enables the deploy workflow to call CI as a reusable workflow. Without `workflow_call` in the `on` triggers, `uses: ./.github/workflows/ci.yml` fails at dispatch time.