### PR TITLE
Fix case mismatch dropping Discogs edges for pipeline DB artists

### DIFF
--- a/semantic_index/sqlite_export.py
+++ b/semantic_index/sqlite_export.py
@@ -526,11 +526,15 @@ def _insert_enrichments_with_pipeline_db(
     so styles must go through ``persist_artist_styles()``.
     Personnel and labels are inserted into their own tables as usual.
     """
+    # Enrichment keys may be lowercased (from Discogs summary tables) while
+    # name_to_id uses the original-case canonical names.  Build a lowercase
+    # lookup so both cases resolve to the correct artist ID.
+    lower_to_id = {k.lower(): v for k, v in name_to_id.items()}
     personnel_rows = []
     label_rows = []
 
     for name, enrich in enrichments.items():
-        artist_id = name_to_id.get(name)
+        artist_id = name_to_id.get(name) or lower_to_id.get(name.lower())
         if artist_id is None:
             continue
 
@@ -560,11 +564,17 @@ def _resolve_edge_rows(
     rows: list[tuple],
     name_to_id: dict[str, int],
 ) -> list[tuple]:
-    """Map artist names in first two columns to IDs."""
+    """Map artist names in first two columns to IDs.
+
+    Discogs summary tables return lowercased artist names, while the pipeline DB
+    stores mixed-case canonical names.  Build a lowercase fallback so both cases
+    resolve correctly.
+    """
+    lower_to_id = {k.lower(): v for k, v in name_to_id.items()}
     resolved = []
     for row in rows:
-        a_id = name_to_id.get(row[0])
-        b_id = name_to_id.get(row[1])
+        a_id = name_to_id.get(row[0]) or lower_to_id.get(row[0].lower())
+        b_id = name_to_id.get(row[1]) or lower_to_id.get(row[1].lower())
         if a_id is not None and b_id is not None:
             resolved.append((a_id, b_id, *row[2:]))
     return resolved

--- a/tests/unit/test_sqlite_export.py
+++ b/tests/unit/test_sqlite_export.py
@@ -4,7 +4,16 @@ import sqlite3
 import tempfile
 from pathlib import Path
 
-from semantic_index.models import ArtistStats, CrossReferenceEdge, PmiEdge, WikidataInfluenceEdge
+from semantic_index.models import (
+    ArtistStats,
+    CompilationEdge,
+    CrossReferenceEdge,
+    LabelFamilyEdge,
+    PmiEdge,
+    SharedPersonnelEdge,
+    SharedStyleEdge,
+    WikidataInfluenceEdge,
+)
 from semantic_index.sqlite_export import export_sqlite
 
 
@@ -292,6 +301,105 @@ class TestWikidataInfluenceInsertion:
         )
         count = conn.execute("SELECT COUNT(*) FROM wikidata_influence").fetchone()[0]
         assert count == 0
+
+
+class TestDiscogsEdgeCaseInsensitive:
+    """Discogs summary tables return lowercase names but artist table may have mixed case."""
+
+    def test_shared_personnel_resolves_lowercase_names(self):
+        stats = {
+            "Yo La Tengo": ArtistStats(canonical_name="Yo La Tengo", total_plays=100),
+            "Stereolab": ArtistStats(canonical_name="Stereolab", total_plays=80),
+        }
+        # Edge names are lowercase (as returned by Discogs summary tables)
+        sp_edges = [
+            SharedPersonnelEdge(
+                artist_a="stereolab",
+                artist_b="yo la tengo",
+                shared_count=3,
+                shared_names=["John McEntire", "Jim O'Rourke", "Roger Moutenot"],
+            )
+        ]
+        conn, _ = _export_and_connect(
+            artist_stats=stats,
+            pmi_edges=[],
+            xref_edges=[],
+            shared_personnel_edges=sp_edges,
+        )
+        count = conn.execute("SELECT COUNT(*) FROM shared_personnel").fetchone()[0]
+        assert count == 1
+        row = conn.execute(
+            "SELECT a.canonical_name, b.canonical_name "
+            "FROM shared_personnel sp "
+            "JOIN artist a ON sp.artist_a_id = a.id "
+            "JOIN artist b ON sp.artist_b_id = b.id"
+        ).fetchone()
+        assert set(row) == {"Yo La Tengo", "Stereolab"}
+
+    def test_shared_style_resolves_lowercase_names(self):
+        stats = {
+            "Beach House": ArtistStats(canonical_name="Beach House", total_plays=50),
+            "Cocteau Twins": ArtistStats(canonical_name="Cocteau Twins", total_plays=40),
+        }
+        ss_edges = [
+            SharedStyleEdge(
+                artist_a="beach house",
+                artist_b="cocteau twins",
+                jaccard=0.6,
+                shared_tags=["Dream Pop", "Shoegaze"],
+            )
+        ]
+        conn, _ = _export_and_connect(
+            artist_stats=stats,
+            pmi_edges=[],
+            xref_edges=[],
+            shared_style_edges=ss_edges,
+        )
+        count = conn.execute("SELECT COUNT(*) FROM shared_style").fetchone()[0]
+        assert count == 1
+
+    def test_label_family_resolves_lowercase_names(self):
+        stats = {
+            "Cat Power": ArtistStats(canonical_name="Cat Power", total_plays=30),
+            "Jessica Pratt": ArtistStats(canonical_name="Jessica Pratt", total_plays=20),
+        }
+        lf_edges = [
+            LabelFamilyEdge(
+                artist_a="cat power",
+                artist_b="jessica pratt",
+                shared_labels=["Matador Records"],
+            )
+        ]
+        conn, _ = _export_and_connect(
+            artist_stats=stats,
+            pmi_edges=[],
+            xref_edges=[],
+            label_family_edges=lf_edges,
+        )
+        count = conn.execute("SELECT COUNT(*) FROM label_family").fetchone()[0]
+        assert count == 1
+
+    def test_compilation_resolves_lowercase_names(self):
+        stats = {
+            "Autechre": ArtistStats(canonical_name="Autechre", total_plays=50),
+            "Aphex Twin": ArtistStats(canonical_name="Aphex Twin", total_plays=45),
+        }
+        comp_edges = [
+            CompilationEdge(
+                artist_a="aphex twin",
+                artist_b="autechre",
+                compilation_count=2,
+                compilation_titles=["Artificial Intelligence", "We Are Reasonable People"],
+            )
+        ]
+        conn, _ = _export_and_connect(
+            artist_stats=stats,
+            pmi_edges=[],
+            xref_edges=[],
+            compilation_edges=comp_edges,
+        )
+        count = conn.execute("SELECT COUNT(*) FROM compilation").fetchone()[0]
+        assert count == 1
 
 
 class TestRoundtrip:


### PR DESCRIPTION
## Summary

- Add case-insensitive name lookup in `_resolve_edge_rows` and `_insert_enrichments_with_pipeline_db` so Discogs edges (shared personnel, shared style, label family, compilation) resolve correctly when edge names are lowercase but the artist table has mixed-case canonical names
- Matches the pattern already used in `_insert_enrichments` (the non-pipeline-DB path)
- Adds 4 regression tests covering all four Discogs edge types with lowercase-to-mixed-case resolution

Closes #145

## Test plan

- [x] All 534 unit tests pass
- [x] ruff, black, mypy all pass
- [ ] Re-run pipeline with `--compute-discogs-edges` and verify Shared Personnel / Shared Style / Label Family / Compilation edge types show results in the graph explorer for top-played artists (Yo La Tengo, Autechre, etc.)