### PR TITLE
Add edge_type filter to narrative endpoint

### DIFF
--- a/explorer/index.html
+++ b/explorer/index.html
@@ -751,8 +751,10 @@ async function loadNarrative(card, sourceId, targetId, gen) {
   const params = {};
   const monthVal = document.getElementById('monthFilter').value;
   const djVal = document.getElementById('djFilter').value;
+  const edgeVal = document.getElementById('edgeType').value;
   if (monthVal) params.month = monthVal;
   if (djVal) params.dj_id = djVal;
+  if (edgeVal) params.edge_type = edgeVal;
 
   try {
     const data = await api(`/graph/artists/${sourceId}/explain/${targetId}/narrative`, params);

--- a/semantic_index/api/narrative.py
+++ b/semantic_index/api/narrative.py
@@ -47,10 +47,15 @@ CREATE TABLE IF NOT EXISTS narrative_cache (
     target_id INTEGER NOT NULL,
     month INTEGER NOT NULL DEFAULT 0,
     dj_id INTEGER NOT NULL DEFAULT 0,
+    edge_type TEXT NOT NULL DEFAULT '',
     narrative TEXT NOT NULL,
     created_at TEXT NOT NULL,
-    PRIMARY KEY (source_id, target_id, month, dj_id)
+    PRIMARY KEY (source_id, target_id, month, dj_id, edge_type)
 );
+"""
+
+_MIGRATE_EDGE_TYPE_COL = """
+ALTER TABLE narrative_cache ADD COLUMN edge_type TEXT NOT NULL DEFAULT '';
 """
 
 
@@ -61,6 +66,10 @@ def _get_cache_db(db_path: str) -> sqlite3.Connection:
     conn.row_factory = sqlite3.Row
     conn.execute("PRAGMA journal_mode=WAL")
     conn.executescript(_CACHE_SCHEMA)
+    # Migrate: add edge_type column if missing (old schema)
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(narrative_cache)")}
+    if "edge_type" not in cols:
+        conn.executescript(_MIGRATE_EDGE_TYPE_COL)
     return conn
 
 
@@ -192,6 +201,7 @@ def get_narrative(
     target_id: int,
     month: int | None = Query(default=None, ge=1, le=12),
     dj_id: int | None = Query(default=None, ge=1),
+    edge_type: str | None = Query(default=None),
     request: Request = None,  # type: ignore[assignment]
     db: sqlite3.Connection = Depends(get_db),
 ) -> NarrativeResponse:
@@ -200,6 +210,11 @@ def get_narrative(
     Uses Claude Haiku to produce a concise sentence from the structured explain data.
     Results are cached in a sidecar SQLite database. When ``ANTHROPIC_API_KEY`` is not
     set, returns HTTP 501.
+
+    Args:
+        edge_type: Optional edge type filter (e.g. ``djTransition``,
+            ``sharedPersonnel``).  When provided, the narrative focuses on that
+            relationship dimension only.  Omit for a cross-dimensional summary.
     """
     # Validate both artists exist
     source = _get_artist_or_404(db, source_id)
@@ -209,14 +224,15 @@ def get_narrative(
     lo, hi = min(source_id, target_id), max(source_id, target_id)
     cache_month = month or 0
     cache_dj = dj_id or 0
+    cache_edge_type = edge_type or ""
 
     # Check cache
     cache_db = _get_cache_db(request.app.state.db_path)
     try:
         cached_row = cache_db.execute(
             "SELECT narrative FROM narrative_cache "
-            "WHERE source_id = ? AND target_id = ? AND month = ? AND dj_id = ?",
-            (lo, hi, cache_month, cache_dj),
+            "WHERE source_id = ? AND target_id = ? AND month = ? AND dj_id = ? AND edge_type = ?",
+            (lo, hi, cache_month, cache_dj, cache_edge_type),
         ).fetchone()
         if cached_row:
             return NarrativeResponse(
@@ -234,11 +250,17 @@ def get_narrative(
             detail="Narrative generation not available (ANTHROPIC_API_KEY not set)",
         )
 
+    # Determine which edge types to query
+    if edge_type and edge_type in EdgeType.__members__.values():
+        query_types = [EdgeType(edge_type)]
+    else:
+        query_types = list(EdgeType)
+
     # Build the structured data for the prompt
     relationships = []
-    for edge_type in EdgeType:
+    for et in query_types:
         try:
-            rels = _query_explain(db, source_id, target_id, edge_type)
+            rels = _query_explain(db, source_id, target_id, et)
         except sqlite3.OperationalError:
             continue  # table doesn't exist in this database
         for rel in rels:
@@ -283,9 +305,17 @@ def get_narrative(
     try:
         cache_db.execute(
             "INSERT OR REPLACE INTO narrative_cache "
-            "(source_id, target_id, month, dj_id, narrative, created_at) "
-            "VALUES (?, ?, ?, ?, ?, ?)",
-            (lo, hi, cache_month, cache_dj, narrative, datetime.now(UTC).isoformat()),
+            "(source_id, target_id, month, dj_id, edge_type, narrative, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                lo,
+                hi,
+                cache_month,
+                cache_dj,
+                cache_edge_type,
+                narrative,
+                datetime.now(UTC).isoformat(),
+            ),
         )
         cache_db.commit()
     finally:

--- a/tests/unit/test_narrative.py
+++ b/tests/unit/test_narrative.py
@@ -236,6 +236,80 @@ class TestNarrativeCaching:
         assert resp_faceted.json()["cached"] is False
 
 
+class TestEdgeTypeFiltering:
+    @pytest.mark.asyncio
+    async def test_edge_type_scopes_prompt_to_single_type(
+        self, client: AsyncClient, narrative_artist_ids: dict[str, int]
+    ) -> None:
+        """When edge_type is provided, only that relationship type appears in the prompt."""
+        ae_id = narrative_artist_ids["Autechre"]
+        sl_id = narrative_artist_ids["Stereolab"]
+        resp = await client.get(
+            f"/graph/artists/{ae_id}/explain/{sl_id}/narrative",
+            params={"edge_type": "sharedPersonnel"},
+        )
+        assert resp.status_code == 200
+
+        mock_client = client._transport.app.state.anthropic_client  # type: ignore[union-attr]
+        last_call = mock_client.messages.create.call_args
+        messages = last_call.kwargs.get("messages") or last_call[1].get("messages", [])
+        prompt_data = json.loads(messages[0]["content"])
+
+        rel_types = [r["type"] for r in prompt_data["relationships"]]
+        assert rel_types == ["sharedPersonnel"]
+
+    @pytest.mark.asyncio
+    async def test_edge_type_cache_separate_from_global(
+        self, client: AsyncClient, narrative_artist_ids: dict[str, int]
+    ) -> None:
+        """Narratives for different edge types are cached separately."""
+        ae_id = narrative_artist_ids["Autechre"]
+        sl_id = narrative_artist_ids["Stereolab"]
+        # Global narrative (no edge_type)
+        resp1 = await client.get(f"/graph/artists/{ae_id}/explain/{sl_id}/narrative")
+        assert resp1.json()["cached"] is False
+        # sharedPersonnel narrative — separate cache entry
+        resp2 = await client.get(
+            f"/graph/artists/{ae_id}/explain/{sl_id}/narrative",
+            params={"edge_type": "sharedPersonnel"},
+        )
+        assert resp2.json()["cached"] is False
+        # sharedStyle narrative — also separate
+        resp3 = await client.get(
+            f"/graph/artists/{ae_id}/explain/{sl_id}/narrative",
+            params={"edge_type": "sharedStyle"},
+        )
+        assert resp3.json()["cached"] is False
+        # Repeat sharedPersonnel — should hit cache
+        resp4 = await client.get(
+            f"/graph/artists/{ae_id}/explain/{sl_id}/narrative",
+            params={"edge_type": "sharedPersonnel"},
+        )
+        assert resp4.json()["cached"] is True
+
+    @pytest.mark.asyncio
+    async def test_unknown_edge_type_falls_back_to_all(
+        self, client: AsyncClient, narrative_artist_ids: dict[str, int]
+    ) -> None:
+        """An unrecognized edge_type queries all relationship types."""
+        ae_id = narrative_artist_ids["Autechre"]
+        sl_id = narrative_artist_ids["Stereolab"]
+        resp = await client.get(
+            f"/graph/artists/{ae_id}/explain/{sl_id}/narrative",
+            params={"edge_type": "notARealType"},
+        )
+        assert resp.status_code == 200
+
+        mock_client = client._transport.app.state.anthropic_client  # type: ignore[union-attr]
+        last_call = mock_client.messages.create.call_args
+        messages = last_call.kwargs.get("messages") or last_call[1].get("messages", [])
+        prompt_data = json.loads(messages[0]["content"])
+
+        rel_types = {r["type"] for r in prompt_data["relationships"]}
+        assert "djTransition" in rel_types
+        assert "sharedPersonnel" in rel_types
+
+
 class TestPairNormalization:
     @pytest.mark.asyncio
     async def test_reversed_pair_shares_cache(


### PR DESCRIPTION
## Summary

- Add `edge_type` query parameter to the narrative endpoint so narratives focus on the active relationship dimension (e.g., only shared personnel, only label family) instead of summarizing all edge types
- Include `edge_type` in the sidecar cache key so each filter gets a separately cached narrative
- Frontend passes the current edge type dropdown value to narrative requests
- Auto-migrate existing sidecar cache databases (ALTER TABLE adds the new column)

Closes #147

## Test plan

- [x] 537 unit tests pass (13 narrative tests, including 3 new edge_type tests)
- [x] ruff, black, mypy all pass
- [ ] Verify in the explorer that switching edge type filters produces different narratives for the same artist pair