### PR TITLE
Import AcousticBrainz into PostgreSQL and expand feature vector to 59 dimensions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,8 @@ Backend PG → pg_source ─┘ → cross_reference ─────────�
                            → node_attributes ───────────────────────────→
             → discogs_client → discogs_enrichment → discogs_edges ──────→
             → wikidata_client → wikidata_influence ─────────────────────→
-            → musicbrainz_client → acousticbrainz (feature loader) ────→ audio_profile + acoustic_similarity
+            → musicbrainz_client → acousticbrainz_client (PG) ─────────→ audio_profile + acoustic_similarity
+            → musicbrainz_client → acousticbrainz (tar loader, deprecated) → audio_profile + acoustic_similarity
 
 SQLite ──→ api (FastAPI + aiosqlite) ──→ JSON responses
 ```
@@ -37,7 +38,8 @@ SQLite ──→ api (FastAPI + aiosqlite) ──→ JSON responses
 | `semantic_index/label_hierarchy.py` | Populate label and label_hierarchy tables from Wikidata P749/P355 relationships via Discogs label ID (P1902) lookups. |
 | `semantic_index/discogs_enrichment.py` | Aggregate Discogs metadata (styles, personnel, labels, compilations) per artist. |
 | `semantic_index/discogs_edges.py` | Compute Discogs-derived edges: shared personnel, shared style (Jaccard), label family, compilation co-appearance. |
-| `semantic_index/acousticbrainz.py` | Load AcousticBrainz high-level features from extracted data dump, aggregate per-artist audio profiles, compute cosine similarity edges. |
+| `semantic_index/acousticbrainz.py` | Load AcousticBrainz high-level features, aggregate per-artist audio profiles (59-dim feature vector across 18 classifiers), compute cosine similarity edges. Supports both PG and tar-based loading. |
+| `semantic_index/acousticbrainz_client.py` | PostgreSQL client for AcousticBrainz features. Queries `ab_recording` in musicbrainz-cache, joining with `mb_artist_recording` for per-artist feature retrieval. Preferred over tar-based loading. |
 | `semantic_index/musicbrainz_client.py` | MusicBrainz cache client: recording MBID resolution via `mb_artist_recording` materialized view. Identity resolution methods (lookup_by_name, batch_lookup) have been moved to LML. |
 | `semantic_index/graph_metrics.py` | Compute and persist Louvain communities, betweenness centrality, PageRank, and discovery scores to the SQLite database. Uses `wxyc_etl.text.is_compilation_artist` to filter compilation entries. Idempotent post-processing step runnable standalone or as a pipeline step. |
 | `semantic_index/graph_export.py` | Build NetworkX graph and export GEXF. |
@@ -53,6 +55,7 @@ SQLite ──→ api (FastAPI + aiosqlite) ──→ JSON responses
 | `semantic_index/nightly_sync.py` | Nightly sync orchestrator: query PG → resolve → PMI → stats → export → facets → graph metrics → atomic DB swap. Preserves enrichment tables from the existing database. |
 | `run_pipeline.py` | CLI entry point wiring the full pipeline (SQL dump mode). |
 | `scripts/nightly_sync.py` | CLI wrapper for `semantic_index.nightly_sync.main()`. |
+| `scripts/import_acousticbrainz.py` | ETL script: import AcousticBrainz high-level features from tar archives into PostgreSQL `ab_recording` table. Per-tar checkpointing, NAS-resilient, idempotent via `ON CONFLICT DO NOTHING`. |
 
 ### Column Mappings (0-indexed from SQL INSERT order)
 
@@ -119,7 +122,7 @@ CREATE TABLE audio_profile (
     primary_genre TEXT,
     primary_genre_probability REAL,
     voice_instrumental_ratio REAL,
-    feature_centroid TEXT,  -- JSON array of 36 floats
+    feature_centroid TEXT,  -- JSON array of 59 floats
     recording_count INTEGER NOT NULL DEFAULT 0,
     created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
 );
@@ -277,6 +280,22 @@ python run_pipeline.py dump.sql --db-path output/wxyc_artist_graph.db --discogs-
 - `--compute-wikidata-influences` — Query Wikidata P737 (influenced by) and create directed influence edges. Requires `--db-path` with reconciled Wikidata QIDs.
 - `--populate-label-hierarchy` — Populate label and label_hierarchy tables from Wikidata P749/P355. Requires `--db-path` and enrichment data.
 - `--discogs-track-json PATH` — Path to `compilation_track_artists.json` (from LML `match_compilations.py`). Provides a Discogs-derived fallback (Tier 0b) for VA entries not matched by the CTA table. JSON format: `[{comp_id, discogs_release_id, tracks: [{position, title, artists: [str]}]}]` where `comp_id` = WXYC `LIBRARY_RELEASE_ID`.
+- `--musicbrainz-cache-dsn` — When set (without `--acousticbrainz-dir`), uses the PostgreSQL `ab_recording` table for audio features. This is the preferred path — a single JOIN query replaces the two-step MusicBrainzClient + tar loader flow. Requires `import_acousticbrainz.py` to have populated `ab_recording`.
+- `--acousticbrainz-dir` — **(Deprecated)** Path to AcousticBrainz tar archives. Requires `--musicbrainz-cache-dsn`. When both `--acousticbrainz-dir` and `--musicbrainz-cache-dsn` are set, the PG path is used and the tar dir is ignored.
+
+### AcousticBrainz import
+
+One-time ETL to populate the `ab_recording` table in the musicbrainz PostgreSQL database from the AcousticBrainz data dump tar archives. The import is resumable — per-tar checkpointing skips completed tars, and `ON CONFLICT DO NOTHING` handles duplicate MBIDs.
+
+```bash
+python scripts/import_acousticbrainz.py \
+    --tar-dir "/Volumes/Peak Twins/acousticbrainz/" \
+    --dsn postgresql://localhost/musicbrainz \
+    --checkpoint output/ab_import_progress.db \
+    [--retry-failed]
+```
+
+The `ab_recording` table stores all 18 AcousticBrainz classifiers as structured columns plus JSONB for probability distributions and metadata tags. The feature vector uses all 18 classifiers for a 59-dimension representation.
 
 ### Nightly sync mode
 

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -799,9 +799,84 @@ def run(args: argparse.Namespace) -> None:
         log.info("SQLite written to %s", sqlite_path)
 
         # 13b. AcousticBrainz audio profiles (optional)
+        #
+        # Two paths:
+        # - PG path (preferred): --musicbrainz-cache-dsn with ab_recording table populated
+        # - Tar path (deprecated): --acousticbrainz-dir with --musicbrainz-cache-dsn
+        # When both are set, PG path is used and tar dir is ignored.
         audio_profile_count = 0
         acoustic_edge_count = 0
+        use_pg_path = args.musicbrainz_cache_dsn and not args.acousticbrainz_dir
+        use_tar_path = args.acousticbrainz_dir and args.musicbrainz_cache_dsn
         if args.acousticbrainz_dir and args.musicbrainz_cache_dsn:
+            log.warning(
+                "--acousticbrainz-dir is deprecated; use --musicbrainz-cache-dsn with "
+                "PostgreSQL AcousticBrainz data instead. Using PG path, ignoring tar dir."
+            )
+            use_pg_path = True
+            use_tar_path = False
+
+        if use_pg_path:
+            import sqlite3 as _ab_sqlite3
+
+            from semantic_index.acousticbrainz import (
+                build_audio_profiles_from_features,
+                compute_acoustic_similarity,
+                store_audio_profiles,
+            )
+            from semantic_index.acousticbrainz_client import AcousticBrainzClient as _ABClient
+
+            log.info("Building audio profiles from AcousticBrainz (PostgreSQL)...")
+            ab_client = _ABClient(cache_dsn=args.musicbrainz_cache_dsn)
+
+            # Get MB artist IDs from the graph database
+            _ab_conn = _ab_sqlite3.connect(str(sqlite_path))
+            mb_rows = _ab_conn.execute(
+                "SELECT id, musicbrainz_artist_id FROM artist "
+                "WHERE musicbrainz_artist_id IS NOT NULL"
+            ).fetchall()
+            _ab_conn.close()
+
+            if mb_rows:
+                graph_id_to_mb = {row[0]: int(row[1]) for row in mb_rows}
+                mb_to_graph_id = {v: k for k, v in graph_id_to_mb.items()}
+                mb_ids = list(graph_id_to_mb.values())
+                log.info("  %d artists with MusicBrainz IDs", len(mb_ids))
+
+                # Single JOIN query: ab_recording × mb_artist_recording
+                ab_features = ab_client.get_features_for_artists(mb_ids)
+                total_recordings = sum(len(v) for v in ab_features.values())
+                log.info(
+                    "  %d recordings with AB features across %d MB artists",
+                    total_recordings,
+                    len(ab_features),
+                )
+
+                # Remap MB artist IDs → graph artist IDs
+                artist_features: dict[int, list] = {}
+                for mb_id, recordings in ab_features.items():
+                    graph_id = mb_to_graph_id.get(mb_id)
+                    if graph_id is not None:
+                        artist_features[graph_id] = recordings
+
+                profiles = build_audio_profiles_from_features(
+                    artist_features, min_recordings=args.min_recordings
+                )
+                audio_profile_count = len(profiles)
+                log.info("  %d audio profiles built", audio_profile_count)
+
+                if profiles:
+                    _ab_conn = _ab_sqlite3.connect(str(sqlite_path))
+                    store_audio_profiles(_ab_conn, profiles)
+                    acoustic_edge_count = compute_acoustic_similarity(
+                        _ab_conn, profiles, threshold=args.acoustic_similarity_threshold
+                    )
+                    _ab_conn.close()
+                    log.info("  %d acoustic similarity edges", acoustic_edge_count)
+            else:
+                log.warning("  No artists with MusicBrainz IDs — skipping audio profiles")
+
+        elif use_tar_path:
             import sqlite3 as _ab_sqlite3
 
             from semantic_index.acousticbrainz import (
@@ -813,10 +888,13 @@ def run(args: argparse.Namespace) -> None:
             )
             from semantic_index.musicbrainz_client import MusicBrainzClient as _MBClient
 
-            log.info("Building audio profiles from AcousticBrainz...")
+            log.warning(
+                "--acousticbrainz-dir is deprecated; use --musicbrainz-cache-dsn with "
+                "PostgreSQL AcousticBrainz data instead."
+            )
+            log.info("Building audio profiles from AcousticBrainz (tar files)...")
             mb_client = _MBClient(cache_dsn=args.musicbrainz_cache_dsn)
 
-            # Get MB artist IDs from the graph database
             _ab_conn = _ab_sqlite3.connect(str(sqlite_path))
             mb_rows = _ab_conn.execute(
                 "SELECT id, musicbrainz_artist_id FROM artist "
@@ -825,27 +903,23 @@ def run(args: argparse.Namespace) -> None:
             _ab_conn.close()
 
             if mb_rows:
-                # Map graph artist IDs → MB artist IDs
                 graph_id_to_mb = {row[0]: int(row[1]) for row in mb_rows}
                 mb_to_graph_id = {v: k for k, v in graph_id_to_mb.items()}
                 mb_ids = list(graph_id_to_mb.values())
                 log.info("  %d artists with MusicBrainz IDs", len(mb_ids))
 
-                # Resolve MB artists → recording MBIDs
                 mb_recordings = mb_client.get_recording_mbids(mb_ids)
                 total_recordings = sum(len(v) for v in mb_recordings.values())
                 log.info(
                     "  %d recording MBIDs across %d artists", total_recordings, len(mb_recordings)
                 )
 
-                # Remap to graph artist IDs
                 artist_recordings: dict[int, list[str]] = {}
                 for mb_id, mbids in mb_recordings.items():
                     graph_id = mb_to_graph_id.get(mb_id)
                     if graph_id is not None:
                         artist_recordings[graph_id] = mbids
 
-                # Create loader: use tar-indexed mode if tar files present, else extracted dir
                 ab_path = Path(args.acousticbrainz_dir)
                 tar_files = list(ab_path.glob("*.tar"))
                 preloaded = None
@@ -859,13 +933,11 @@ def run(args: argparse.Namespace) -> None:
                     ab_loader = TarAcousticBrainzLoader(
                         args.acousticbrainz_dir, wanted_mbids=all_wanted
                     )
-                    # Bulk load all features in a single pass per tar (much faster over NAS)
                     log.info("  Bulk loading features from tar files...")
                     preloaded = ab_loader.bulk_load_all_features()
                 else:
                     ab_loader = AcousticBrainzLoader(args.acousticbrainz_dir)
 
-                # Build profiles
                 profiles = build_audio_profiles(
                     ab_loader,
                     artist_recordings,

--- a/scripts/import_acousticbrainz.py
+++ b/scripts/import_acousticbrainz.py
@@ -102,8 +102,9 @@ def parse_recording_json(mbid: str, data: dict, tar_name: str) -> dict:
         distributions[key] = classifier.get("all", {})
 
     # Audio properties
-    audio = data.get("metadata", {}).get("audio_properties", {})
-    tags = data.get("metadata", {}).get("tags", {})
+    metadata = data.get("metadata") or {}
+    audio = metadata.get("audio_properties") or {}
+    tags = metadata.get("tags") or {}
 
     return {
         "recording_mbid": mbid,

--- a/scripts/import_acousticbrainz.py
+++ b/scripts/import_acousticbrainz.py
@@ -1,0 +1,388 @@
+"""ETL script: Import AcousticBrainz high-level features from tar archives into PostgreSQL.
+
+Processes tar files one at a time (NAS-friendly), with per-tar checkpointing
+to support resume after interruption. Uses COPY for fast bulk inserts and
+ON CONFLICT DO NOTHING for idempotent re-runs.
+
+Usage:
+    python scripts/import_acousticbrainz.py \
+        --tar-dir "/Volumes/Peak Twins/acousticbrainz/" \
+        --dsn postgresql://localhost/musicbrainz \
+        --checkpoint output/ab_import_progress.db \
+        [--retry-failed]
+"""
+
+import argparse
+import json
+import logging
+import os
+import sqlite3
+import tarfile
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+
+import psycopg
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+    datefmt="%H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+# Column names matching the ab_recording table, in INSERT order
+_COLUMNS = [
+    "recording_mbid",
+    "danceability",
+    "gender_value",
+    "gender_probability",
+    "genre_dortmund_value",
+    "genre_dortmund_prob",
+    "genre_electronic_value",
+    "genre_electronic_prob",
+    "genre_rosamerica_value",
+    "genre_rosamerica_prob",
+    "genre_tzanetakis_value",
+    "genre_tzanetakis_prob",
+    "ismir04_rhythm_value",
+    "ismir04_rhythm_prob",
+    "mood_acoustic",
+    "mood_aggressive",
+    "mood_electronic",
+    "mood_happy",
+    "mood_party",
+    "mood_relaxed",
+    "mood_sad",
+    "moods_mirex_value",
+    "moods_mirex_prob",
+    "timbre_value",
+    "timbre_probability",
+    "tonal",
+    "voice_instrumental_value",
+    "voice_instrumental_prob",
+    "classifier_distributions",
+    "audio_length",
+    "audio_codec",
+    "audio_sample_rate",
+    "audio_bit_rate",
+    "replay_gain",
+    "metadata_tags",
+    "tar_file",
+]
+
+_BATCH_SIZE = 10_000
+
+
+def parse_recording_json(mbid: str, data: dict, tar_name: str) -> dict:
+    """Parse an AcousticBrainz JSON into a flat dict for DB insertion.
+
+    Args:
+        mbid: MusicBrainz recording UUID.
+        data: Parsed JSON data from the AcousticBrainz dump.
+        tar_name: Name of the source tar file (provenance tracking).
+
+    Returns:
+        Dict with keys matching _COLUMNS.
+    """
+    hl = data["highlevel"]
+
+    # Build classifier distributions JSONB
+    distributions = {}
+    for key in [
+        "genre_dortmund",
+        "genre_electronic",
+        "genre_rosamerica",
+        "genre_tzanetakis",
+        "ismir04_rhythm",
+        "moods_mirex",
+        "gender",
+    ]:
+        classifier = hl.get(key, {})
+        distributions[key] = classifier.get("all", {})
+
+    # Audio properties
+    audio = data.get("metadata", {}).get("audio_properties", {})
+    tags = data.get("metadata", {}).get("tags", {})
+
+    return {
+        "recording_mbid": mbid,
+        "danceability": hl["danceability"]["all"]["danceable"],
+        "gender_value": hl["gender"]["value"],
+        "gender_probability": hl["gender"]["probability"],
+        "genre_dortmund_value": hl["genre_dortmund"]["value"],
+        "genre_dortmund_prob": hl["genre_dortmund"]["probability"],
+        "genre_electronic_value": hl.get("genre_electronic", {}).get("value", ""),
+        "genre_electronic_prob": hl.get("genre_electronic", {}).get("probability", 0.0),
+        "genre_rosamerica_value": hl.get("genre_rosamerica", {}).get("value", ""),
+        "genre_rosamerica_prob": hl.get("genre_rosamerica", {}).get("probability", 0.0),
+        "genre_tzanetakis_value": hl.get("genre_tzanetakis", {}).get("value", ""),
+        "genre_tzanetakis_prob": hl.get("genre_tzanetakis", {}).get("probability", 0.0),
+        "ismir04_rhythm_value": hl.get("ismir04_rhythm", {}).get("value", ""),
+        "ismir04_rhythm_prob": hl.get("ismir04_rhythm", {}).get("probability", 0.0),
+        "mood_acoustic": hl["mood_acoustic"]["all"].get("acoustic", 0.0),
+        "mood_aggressive": hl["mood_aggressive"]["all"].get("aggressive", 0.0),
+        "mood_electronic": hl["mood_electronic"]["all"].get("electronic", 0.0),
+        "mood_happy": hl["mood_happy"]["all"].get("happy", 0.0),
+        "mood_party": hl["mood_party"]["all"].get("party", 0.0),
+        "mood_relaxed": hl["mood_relaxed"]["all"].get("relaxed", 0.0),
+        "mood_sad": hl["mood_sad"]["all"].get("sad", 0.0),
+        "moods_mirex_value": hl.get("moods_mirex", {}).get("value", ""),
+        "moods_mirex_prob": hl.get("moods_mirex", {}).get("probability", 0.0),
+        "timbre_value": hl["timbre"]["value"],
+        "timbre_probability": hl["timbre"]["probability"],
+        "tonal": hl["tonal_atonal"]["all"]["tonal"],
+        "voice_instrumental_value": hl["voice_instrumental"]["value"],
+        "voice_instrumental_prob": hl["voice_instrumental"]["probability"],
+        "classifier_distributions": json.dumps(distributions),
+        "audio_length": audio.get("length"),
+        "audio_codec": audio.get("codec"),
+        "audio_sample_rate": audio.get("analysis_sample_rate"),
+        "audio_bit_rate": audio.get("bit_rate"),
+        "replay_gain": audio.get("replay_gain"),
+        "metadata_tags": json.dumps(tags) if tags else None,
+        "tar_file": tar_name,
+    }
+
+
+def process_tar(tar_path: str) -> list[dict]:
+    """Read all AcousticBrainz JSON files from a tar archive.
+
+    Args:
+        tar_path: Path to the tar file.
+
+    Returns:
+        List of parsed recording dicts.
+    """
+    tar_name = Path(tar_path).name
+    rows = []
+    with tarfile.open(tar_path) as tf:
+        for member in tf:
+            if not member.isfile() or not member.name.endswith(".json"):
+                continue
+            filename = member.name.rsplit("/", 1)[-1]
+            mbid = filename.rsplit("-", 1)[0]
+            try:
+                f = tf.extractfile(member)
+                if f is None:
+                    continue
+                data = json.load(f)
+                row = parse_recording_json(mbid, data, tar_name)
+                rows.append(row)
+            except (json.JSONDecodeError, KeyError) as e:
+                logger.warning("  Skipping %s: %s", member.name, e)
+                continue
+    return rows
+
+
+def init_checkpoint(checkpoint_path: str) -> None:
+    """Initialize the checkpoint SQLite database."""
+    conn = sqlite3.connect(checkpoint_path)
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS progress ("
+        "tar_file TEXT PRIMARY KEY, status TEXT NOT NULL, "
+        "rows_imported INTEGER, completed_at TEXT, error_msg TEXT)"
+    )
+    conn.commit()
+    conn.close()
+
+
+def get_completed_tars(checkpoint_path: str) -> set[str]:
+    """Get the set of tar filenames that have been fully imported."""
+    conn = sqlite3.connect(checkpoint_path)
+    rows = conn.execute("SELECT tar_file FROM progress WHERE status = 'complete'").fetchall()
+    conn.close()
+    return {r[0] for r in rows}
+
+
+def get_failed_tars(checkpoint_path: str) -> set[str]:
+    """Get the set of tar filenames that failed during import."""
+    conn = sqlite3.connect(checkpoint_path)
+    rows = conn.execute("SELECT tar_file FROM progress WHERE status = 'failed'").fetchall()
+    conn.close()
+    return {r[0] for r in rows}
+
+
+def mark_tar_complete(checkpoint_path: str, tar_name: str, rows_imported: int) -> None:
+    """Mark a tar file as successfully imported."""
+    conn = sqlite3.connect(checkpoint_path)
+    conn.execute(
+        "INSERT OR REPLACE INTO progress (tar_file, status, rows_imported, completed_at) "
+        "VALUES (?, 'complete', ?, ?)",
+        (tar_name, rows_imported, datetime.now(UTC).isoformat()),
+    )
+    conn.commit()
+    conn.close()
+
+
+def mark_tar_failed(checkpoint_path: str, tar_name: str, error_msg: str) -> None:
+    """Mark a tar file as failed."""
+    conn = sqlite3.connect(checkpoint_path)
+    conn.execute(
+        "INSERT OR REPLACE INTO progress (tar_file, status, rows_imported, completed_at, error_msg) "
+        "VALUES (?, 'failed', 0, ?, ?)",
+        (tar_name, datetime.now(UTC).isoformat(), error_msg),
+    )
+    conn.commit()
+    conn.close()
+
+
+def insert_batch(conn: psycopg.Connection, rows: list[dict]) -> int:
+    """Insert a batch of rows using multi-row INSERT with ON CONFLICT DO NOTHING.
+
+    Args:
+        conn: PostgreSQL connection.
+        rows: List of recording dicts to insert.
+
+    Returns:
+        Number of rows actually inserted (excluding conflicts).
+    """
+    if not rows:
+        return 0
+
+    placeholders = ", ".join([f"({', '.join(['%s'] * len(_COLUMNS))})"] * len(rows))
+    col_names = ", ".join(_COLUMNS)
+    query = (
+        f"INSERT INTO ab_recording ({col_names}) VALUES "
+        f"{placeholders} "
+        f"ON CONFLICT (recording_mbid) DO NOTHING"
+    )
+
+    values = []
+    for row in rows:
+        for col in _COLUMNS:
+            values.append(row[col])
+
+    with conn.cursor() as cur:
+        cur.execute(query, values)
+        return cur.rowcount
+
+
+def import_tar(dsn: str, tar_path: str, checkpoint_path: str) -> int:
+    """Import a single tar file into PostgreSQL.
+
+    Reads all JSON files from the tar, then bulk inserts in batches.
+    Commits per batch so partial progress is retained on failure.
+
+    Args:
+        dsn: PostgreSQL connection string.
+        tar_path: Path to the tar archive.
+        checkpoint_path: Path to the checkpoint SQLite database.
+
+    Returns:
+        Number of rows inserted.
+    """
+    tar_name = Path(tar_path).name
+    logger.info("Processing %s...", tar_name)
+    t0 = time.time()
+
+    try:
+        rows = process_tar(tar_path)
+    except (tarfile.TarError, OSError) as e:
+        logger.error("Failed to read %s: %s", tar_name, e)
+        mark_tar_failed(checkpoint_path, tar_name, str(e))
+        return 0
+
+    logger.info("  %d recordings parsed from %s (%.1fs)", len(rows), tar_name, time.time() - t0)
+
+    if not rows:
+        mark_tar_complete(checkpoint_path, tar_name, 0)
+        return 0
+
+    conn = psycopg.connect(dsn)
+    total_inserted = 0
+    try:
+        for i in range(0, len(rows), _BATCH_SIZE):
+            batch = rows[i : i + _BATCH_SIZE]
+            inserted = insert_batch(conn, batch)
+            conn.commit()
+            total_inserted += inserted
+            logger.info(
+                "  Batch %d/%d: %d inserted (%d total)",
+                i // _BATCH_SIZE + 1,
+                (len(rows) + _BATCH_SIZE - 1) // _BATCH_SIZE,
+                inserted,
+                total_inserted,
+            )
+    except Exception as e:
+        logger.error("Failed during insert for %s: %s", tar_name, e)
+        conn.rollback()
+        mark_tar_failed(checkpoint_path, tar_name, str(e))
+        conn.close()
+        return total_inserted
+    finally:
+        if not conn.closed:
+            conn.close()
+
+    mark_tar_complete(checkpoint_path, tar_name, total_inserted)
+    elapsed = time.time() - t0
+    logger.info("  %s complete: %d rows in %.1fs", tar_name, total_inserted, elapsed)
+    return total_inserted
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Import AcousticBrainz high-level features from tar archives into PostgreSQL."
+    )
+    parser.add_argument(
+        "--tar-dir",
+        required=True,
+        help="Directory containing AcousticBrainz tar files.",
+    )
+    parser.add_argument(
+        "--dsn",
+        default=os.environ.get("DATABASE_URL_MUSICBRAINZ", "postgresql://localhost/musicbrainz"),
+        help="PostgreSQL DSN (default: DATABASE_URL_MUSICBRAINZ env var).",
+    )
+    parser.add_argument(
+        "--checkpoint",
+        default="output/ab_import_progress.db",
+        help="Path to checkpoint SQLite database (default: output/ab_import_progress.db).",
+    )
+    parser.add_argument(
+        "--retry-failed",
+        action="store_true",
+        help="Re-attempt previously failed tars.",
+    )
+    args = parser.parse_args()
+
+    init_checkpoint(args.checkpoint)
+
+    tar_dir = Path(args.tar_dir)
+    tar_files = sorted(tar_dir.glob("*.tar"))
+    logger.info("Found %d tar files in %s", len(tar_files), tar_dir)
+
+    completed = get_completed_tars(args.checkpoint)
+    failed = get_failed_tars(args.checkpoint) if args.retry_failed else set()
+    skipping = completed - failed  # retry_failed removes failed from skip set
+
+    to_process = [t for t in tar_files if t.name not in skipping]
+    logger.info(
+        "%d tars to process (%d completed, %d skipped)",
+        len(to_process),
+        len(completed),
+        len(skipping),
+    )
+
+    grand_total = 0
+    for i, tar_path in enumerate(to_process, 1):
+        logger.info("=== Tar %d/%d: %s ===", i, len(to_process), tar_path.name)
+        count = import_tar(args.dsn, str(tar_path), args.checkpoint)
+        grand_total += count
+
+    logger.info(
+        "Import complete: %d total rows inserted across %d tars", grand_total, len(to_process)
+    )
+
+    # Final verification
+    try:
+        conn = psycopg.connect(args.dsn)
+        total = conn.execute("SELECT COUNT(*) FROM ab_recording").fetchone()[0]
+        conn.close()
+        logger.info("Total rows in ab_recording: %d", total)
+    except Exception:
+        logger.warning("Could not verify final count", exc_info=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/import_acousticbrainz.py
+++ b/scripts/import_acousticbrainz.py
@@ -71,7 +71,7 @@ _COLUMNS = [
     "tar_file",
 ]
 
-_BATCH_SIZE = 10_000
+_BATCH_SIZE = 1_000
 
 
 def parse_recording_json(mbid: str, data: dict, tar_name: str) -> dict:

--- a/scripts/import_acousticbrainz.py
+++ b/scripts/import_acousticbrainz.py
@@ -72,6 +72,8 @@ _COLUMNS = [
 ]
 
 _BATCH_SIZE = 1_000
+_NAS_POLL_INTERVAL = 10  # seconds between NAS reconnection checks
+_NAS_MAX_RETRIES = 3  # max retries per tar before marking failed
 
 
 def parse_recording_json(mbid: str, data: dict, tar_name: str) -> dict:
@@ -144,6 +146,14 @@ def parse_recording_json(mbid: str, data: dict, tar_name: str) -> dict:
         "metadata_tags": json.dumps(tags) if tags else None,
         "tar_file": tar_name,
     }
+
+
+def _wait_for_nas(tar_dir: str) -> None:
+    """Block until the NAS volume is reachable again."""
+    while not Path(tar_dir).exists():
+        logger.warning("NAS unreachable (%s), waiting %ds...", tar_dir, _NAS_POLL_INTERVAL)
+        time.sleep(_NAS_POLL_INTERVAL)
+    logger.info("NAS reconnected (%s)", tar_dir)
 
 
 def process_tar(tar_path: str) -> list[dict]:
@@ -264,6 +274,8 @@ def import_tar(dsn: str, tar_path: str, checkpoint_path: str) -> int:
 
     Reads all JSON files from the tar, then bulk inserts in batches.
     Commits per batch so partial progress is retained on failure.
+    Retries up to _NAS_MAX_RETRIES times on NAS read errors, waiting
+    for the volume to come back between attempts.
 
     Args:
         dsn: PostgreSQL connection string.
@@ -274,15 +286,22 @@ def import_tar(dsn: str, tar_path: str, checkpoint_path: str) -> int:
         Number of rows inserted.
     """
     tar_name = Path(tar_path).name
-    logger.info("Processing %s...", tar_name)
-    t0 = time.time()
+    tar_dir = str(Path(tar_path).parent)
 
-    try:
-        rows = process_tar(tar_path)
-    except (tarfile.TarError, OSError) as e:
-        logger.error("Failed to read %s: %s", tar_name, e)
-        mark_tar_failed(checkpoint_path, tar_name, str(e))
-        return 0
+    for attempt in range(_NAS_MAX_RETRIES):
+        logger.info("Processing %s... (attempt %d/%d)", tar_name, attempt + 1, _NAS_MAX_RETRIES)
+        t0 = time.time()
+
+        try:
+            rows = process_tar(tar_path)
+            break
+        except (tarfile.TarError, OSError) as e:
+            logger.error("Failed to read %s: %s", tar_name, e)
+            if attempt + 1 < _NAS_MAX_RETRIES:
+                _wait_for_nas(tar_dir)
+            else:
+                mark_tar_failed(checkpoint_path, tar_name, str(e))
+                return 0
 
     logger.info("  %d recordings parsed from %s (%.1fs)", len(rows), tar_name, time.time() - t0)
 

--- a/semantic_index/acousticbrainz.py
+++ b/semantic_index/acousticbrainz.py
@@ -70,6 +70,13 @@ RHYTHM_LABELS = [
     "Waltz",
 ]
 
+# Labels from AcousticBrainz classifier outputs (verified against data dump)
+GENRE_ELECTRONIC_LABELS = ["ambient", "dnb", "house", "techno", "trance"]
+GENRE_ROSAMERICA_LABELS = ["cla", "dan", "hip", "jaz", "pop", "rhy", "roc", "spe"]
+GENRE_TZANETAKIS_LABELS = ["blu", "cla", "cou", "dis", "hip", "jaz", "met", "pop", "reg", "roc"]
+
+FEATURE_VECTOR_DIM = 59
+
 
 @dataclass
 class RecordingFeatures:
@@ -106,11 +113,14 @@ class RecordingFeatures:
     tonal: float
     voice_instrumental: str
     voice_instrumental_probability: float
+    genre_electronic_vector: list[float]  # 5-element electronic subgenre distribution
+    genre_rosamerica_vector: list[float]  # 8-element rosamerica genre distribution
+    genre_tzanetakis_vector: list[float]  # 10-element tzanetakis genre distribution
 
     def feature_vector(self) -> list[float]:
         """Build a fixed-length numeric feature vector for similarity computation.
 
-        Layout (36 dimensions):
+        Layout (59 dimensions):
             [0:9]   genre_dortmund probability distribution (9 genres)
             [9:16]  mood probabilities (7 binary mood classifiers)
             [16:21] moods_mirex compound mood distribution (5 clusters)
@@ -120,9 +130,12 @@ class RecordingFeatures:
             [33]    tonal probability
             [34]    voice probability (1=voice, 0=instrumental)
             [35]    gender (female probability)
+            [36:41] genre_electronic probability distribution (5 subgenres)
+            [41:49] genre_rosamerica probability distribution (8 genres)
+            [49:59] genre_tzanetakis probability distribution (10 genres)
 
         Returns:
-            List of 36 floats.
+            List of 59 floats.
         """
         timbre_val = 1.0 if self.timbre == "bright" else 0.0
         voice_val = (
@@ -142,6 +155,9 @@ class RecordingFeatures:
                 voice_val,
                 self.gender_female,
             ]
+            + self.genre_electronic_vector
+            + self.genre_rosamerica_vector
+            + self.genre_tzanetakis_vector
         )
 
 
@@ -174,6 +190,24 @@ def _parse_highlevel(mbid: str, data: dict) -> RecordingFeatures:
     rhythm_all = hl.get("ismir04_rhythm", {}).get("all", {})
     rhythm_vector = [rhythm_all.get(label, 0.0) for label in RHYTHM_LABELS]
 
+    # Genre electronic subgenre
+    genre_electronic_all = hl.get("genre_electronic", {}).get("all", {})
+    genre_electronic_vector = [
+        genre_electronic_all.get(label, 0.0) for label in GENRE_ELECTRONIC_LABELS
+    ]
+
+    # Genre rosamerica
+    genre_rosamerica_all = hl.get("genre_rosamerica", {}).get("all", {})
+    genre_rosamerica_vector = [
+        genre_rosamerica_all.get(label, 0.0) for label in GENRE_ROSAMERICA_LABELS
+    ]
+
+    # Genre tzanetakis
+    genre_tzanetakis_all = hl.get("genre_tzanetakis", {}).get("all", {})
+    genre_tzanetakis_vector = [
+        genre_tzanetakis_all.get(label, 0.0) for label in GENRE_TZANETAKIS_LABELS
+    ]
+
     # Gender
     gender_all = hl.get("gender", {}).get("all", {})
     gender_female = gender_all.get("female", 0.5)
@@ -204,6 +238,9 @@ def _parse_highlevel(mbid: str, data: dict) -> RecordingFeatures:
         tonal=tonal,
         voice_instrumental=voice_instrumental,
         voice_instrumental_probability=voice_instrumental_probability,
+        genre_electronic_vector=genre_electronic_vector,
+        genre_rosamerica_vector=genre_rosamerica_vector,
+        genre_tzanetakis_vector=genre_tzanetakis_vector,
     )
 
 
@@ -494,7 +531,7 @@ class ArtistAudioProfile:
     primary_genre: str
     primary_genre_probability: float
     voice_instrumental_ratio: float  # fraction of recordings that are vocal
-    feature_centroid: list[float]  # averaged 36-element feature vector
+    feature_centroid: list[float]  # averaged 59-element feature vector
 
     @classmethod
     def from_recordings(cls, recordings: list[RecordingFeatures]) -> ArtistAudioProfile:
@@ -522,7 +559,7 @@ class ArtistAudioProfile:
         voice_ratio = vocal_count / n
 
         # Average feature vectors
-        vec_len = 36
+        vec_len = FEATURE_VECTOR_DIM
         centroid = [0.0] * vec_len
         for r in recordings:
             vec = r.feature_vector()
@@ -600,6 +637,48 @@ def build_audio_profiles(
             features_map = loader.batch_get_features(mbids)
             recordings = list(features_map.values())
 
+        if len(recordings) < min_recordings:
+            continue
+
+        profiles[artist_id] = ArtistAudioProfile.from_recordings(recordings)
+
+        if i % 500 == 0:
+            logger.info(
+                "  Audio profiles: %d/%d artists processed, %d profiles built",
+                i,
+                total,
+                len(profiles),
+            )
+
+    logger.info(
+        "Audio profiles complete: %d/%d artists have profiles (min_recordings=%d)",
+        len(profiles),
+        total,
+        min_recordings,
+    )
+    return profiles
+
+
+def build_audio_profiles_from_features(
+    artist_features: dict[int, list[RecordingFeatures]],
+    min_recordings: int = 3,
+) -> dict[int, ArtistAudioProfile]:
+    """Build audio profiles from pre-resolved per-artist feature lists.
+
+    Used by the PG-based AcousticBrainz path where features are already
+    grouped by artist from the JOIN query.
+
+    Args:
+        artist_features: Mapping of artist ID → list of RecordingFeatures.
+        min_recordings: Minimum recordings required to create a profile.
+
+    Returns:
+        Dict mapping artist ID to ArtistAudioProfile.
+    """
+    profiles: dict[int, ArtistAudioProfile] = {}
+    total = len(artist_features)
+
+    for i, (artist_id, recordings) in enumerate(artist_features.items(), 1):
         if len(recordings) < min_recordings:
             continue
 

--- a/semantic_index/acousticbrainz_client.py
+++ b/semantic_index/acousticbrainz_client.py
@@ -1,0 +1,243 @@
+"""AcousticBrainz PostgreSQL client for audio feature retrieval.
+
+Queries ``ab_recording`` in the musicbrainz-cache PostgreSQL database,
+joining with ``mb_artist_recording`` for per-artist feature retrieval.
+Replaces the two-step MusicBrainzClient + TarLoader flow with a single
+JOIN query.
+"""
+
+import json
+import logging
+
+import psycopg
+
+from semantic_index.acousticbrainz import (
+    GENRE_ELECTRONIC_LABELS,
+    GENRE_LABELS,
+    GENRE_ROSAMERICA_LABELS,
+    GENRE_TZANETAKIS_LABELS,
+    MIREX_LABELS,
+    RHYTHM_LABELS,
+    RecordingFeatures,
+)
+
+logger = logging.getLogger(__name__)
+
+# Column order in the SELECT query — must match _parse_row()
+_SELECT_COLS = """
+    mar.artist_id,
+    ar.recording_mbid::text,
+    ar.danceability,
+    ar.gender_value,
+    ar.gender_probability,
+    ar.genre_dortmund_value,
+    ar.genre_dortmund_prob,
+    ar.genre_electronic_value,
+    ar.genre_electronic_prob,
+    ar.genre_rosamerica_value,
+    ar.genre_rosamerica_prob,
+    ar.genre_tzanetakis_value,
+    ar.genre_tzanetakis_prob,
+    ar.ismir04_rhythm_value,
+    ar.ismir04_rhythm_prob,
+    ar.mood_acoustic,
+    ar.mood_aggressive,
+    ar.mood_electronic,
+    ar.mood_happy,
+    ar.mood_party,
+    ar.mood_relaxed,
+    ar.mood_sad,
+    ar.moods_mirex_value,
+    ar.moods_mirex_prob,
+    ar.timbre_value,
+    ar.timbre_probability,
+    ar.tonal,
+    ar.voice_instrumental_value,
+    ar.voice_instrumental_prob,
+    ar.classifier_distributions
+"""
+
+
+class AcousticBrainzClient:
+    """PostgreSQL client for AcousticBrainz features.
+
+    Queries ``ab_recording`` joined with ``mb_artist_recording`` to
+    retrieve per-artist audio features in a single query.
+
+    Args:
+        cache_dsn: PostgreSQL connection string for the musicbrainz database.
+    """
+
+    def __init__(self, cache_dsn: str) -> None:
+        self._cache_dsn = cache_dsn
+        self._conn: psycopg.Connection | None = None
+
+    def _get_conn(self) -> psycopg.Connection | None:
+        """Get or create the PostgreSQL connection."""
+        if self._conn is None or self._conn.closed:
+            try:
+                self._conn = psycopg.connect(self._cache_dsn, autocommit=True)
+            except Exception:
+                logger.warning("Failed to connect to musicbrainz database", exc_info=True)
+                return None
+        return self._conn
+
+    def get_features_for_artists(
+        self, mb_artist_ids: list[int]
+    ) -> dict[int, list[RecordingFeatures]]:
+        """Get audio features for a set of MusicBrainz artist IDs.
+
+        Joins ``ab_recording`` with ``mb_artist_recording`` to retrieve
+        all recordings per artist in a single query.
+
+        Args:
+            mb_artist_ids: List of MusicBrainz internal artist IDs.
+
+        Returns:
+            Dict mapping artist ID to list of RecordingFeatures.
+        """
+        if not mb_artist_ids:
+            return {}
+
+        conn = self._get_conn()
+        if conn is None:
+            return {}
+
+        try:
+            result: dict[int, list[RecordingFeatures]] = {}
+            batch_size = 1000
+            for i in range(0, len(mb_artist_ids), batch_size):
+                batch = mb_artist_ids[i : i + batch_size]
+                rows = conn.execute(
+                    f"SELECT {_SELECT_COLS} "
+                    "FROM mb_artist_recording mar "
+                    "JOIN ab_recording ar ON ar.recording_mbid = mar.recording_mbid "
+                    "WHERE mar.artist_id = ANY(%s)",
+                    (batch,),
+                ).fetchall()
+
+                for row in rows:
+                    artist_id = row[0]
+                    features = _parse_row(row)
+                    result.setdefault(artist_id, []).append(features)
+
+                if (i + batch_size) % 5000 == 0:
+                    logger.info(
+                        "  AB feature lookup: %d/%d artist batches",
+                        i // batch_size + 1,
+                        (len(mb_artist_ids) + batch_size - 1) // batch_size,
+                    )
+
+            total_recordings = sum(len(v) for v in result.values())
+            logger.info(
+                "AcousticBrainz features: %d recordings across %d artists",
+                total_recordings,
+                len(result),
+            )
+            return result
+        except Exception:
+            logger.warning("AcousticBrainz feature lookup failed", exc_info=True)
+            return {}
+
+
+def _parse_row(row: tuple) -> RecordingFeatures:
+    """Parse a PG result row into RecordingFeatures.
+
+    Uses the ``classifier_distributions`` JSONB column for probability
+    vectors, and structured columns for top-level values.
+    """
+    (
+        _artist_id,
+        recording_mbid,
+        danceability,
+        gender_value,
+        gender_probability,
+        genre_dortmund_value,
+        genre_dortmund_prob,
+        _genre_electronic_value,
+        _genre_electronic_prob,
+        _genre_rosamerica_value,
+        _genre_rosamerica_prob,
+        _genre_tzanetakis_value,
+        _genre_tzanetakis_prob,
+        _ismir04_rhythm_value,
+        _ismir04_rhythm_prob,
+        mood_acoustic,
+        mood_aggressive,
+        mood_electronic,
+        mood_happy,
+        mood_party,
+        mood_relaxed,
+        mood_sad,
+        _moods_mirex_value,
+        _moods_mirex_prob,
+        timbre_value,
+        timbre_probability,
+        tonal,
+        voice_instrumental_value,
+        voice_instrumental_prob,
+        classifier_distributions_raw,
+    ) = row
+
+    # Parse JSONB distributions
+    if isinstance(classifier_distributions_raw, str):
+        dists = json.loads(classifier_distributions_raw)
+    else:
+        dists = classifier_distributions_raw
+
+    genre_all = dists.get("genre_dortmund", {})
+    genre_vector = [genre_all.get(label, 0.0) for label in GENRE_LABELS]
+
+    mirex_all = dists.get("moods_mirex", {})
+    mirex_vector = [mirex_all.get(label, 0.0) for label in MIREX_LABELS]
+
+    rhythm_all = dists.get("ismir04_rhythm", {})
+    rhythm_vector = [rhythm_all.get(label, 0.0) for label in RHYTHM_LABELS]
+
+    gender_all_dist = dists.get("gender", {})
+    gender_female = gender_all_dist.get("female", 0.5)
+
+    genre_electronic_all = dists.get("genre_electronic", {})
+    genre_electronic_vector = [
+        genre_electronic_all.get(label, 0.0) for label in GENRE_ELECTRONIC_LABELS
+    ]
+
+    genre_rosamerica_all = dists.get("genre_rosamerica", {})
+    genre_rosamerica_vector = [
+        genre_rosamerica_all.get(label, 0.0) for label in GENRE_ROSAMERICA_LABELS
+    ]
+
+    genre_tzanetakis_all = dists.get("genre_tzanetakis", {})
+    genre_tzanetakis_vector = [
+        genre_tzanetakis_all.get(label, 0.0) for label in GENRE_TZANETAKIS_LABELS
+    ]
+
+    mood_vector = [
+        mood_acoustic,
+        mood_aggressive,
+        mood_electronic,
+        mood_happy,
+        mood_party,
+        mood_relaxed,
+        mood_sad,
+    ]
+
+    return RecordingFeatures(
+        recording_mbid=recording_mbid,
+        danceability=danceability,
+        genre=genre_dortmund_value,
+        genre_probability=genre_dortmund_prob,
+        genre_vector=genre_vector,
+        mood_vector=mood_vector,
+        mirex_vector=mirex_vector,
+        rhythm_vector=rhythm_vector,
+        gender_female=gender_female,
+        timbre=timbre_value,
+        timbre_probability=timbre_probability,
+        tonal=tonal,
+        voice_instrumental=voice_instrumental_value,
+        voice_instrumental_probability=voice_instrumental_prob,
+        genre_electronic_vector=genre_electronic_vector,
+        genre_rosamerica_vector=genre_rosamerica_vector,
+        genre_tzanetakis_vector=genre_tzanetakis_vector,
+    )

--- a/tests/unit/test_acousticbrainz.py
+++ b/tests/unit/test_acousticbrainz.py
@@ -8,6 +8,9 @@ from pathlib import Path
 import pytest
 
 from semantic_index.acousticbrainz import (
+    GENRE_ELECTRONIC_LABELS,
+    GENRE_ROSAMERICA_LABELS,
+    GENRE_TZANETAKIS_LABELS,
     AcousticBrainzLoader,
     ArtistAudioProfile,
     TarAcousticBrainzLoader,
@@ -73,6 +76,36 @@ def _make_highlevel_json(
                 "probability": electronic_prob,
                 "value": electronic_subgenre,
             },
+            "genre_rosamerica": {
+                "all": {
+                    "cla": 0.03,
+                    "dan": 0.05,
+                    "hip": 0.02,
+                    "jaz": 0.10,
+                    "pop": 0.15,
+                    "rhy": 0.05,
+                    "roc": 0.50,
+                    "spe": 0.10,
+                },
+                "probability": 0.50,
+                "value": "roc",
+            },
+            "genre_tzanetakis": {
+                "all": {
+                    "blu": 0.06,
+                    "cla": 0.04,
+                    "cou": 0.03,
+                    "dis": 0.05,
+                    "hip": 0.02,
+                    "jaz": 0.10,
+                    "met": 0.05,
+                    "pop": 0.15,
+                    "reg": 0.10,
+                    "roc": 0.40,
+                },
+                "probability": 0.40,
+                "value": "roc",
+            },
             "mood_acoustic": {
                 "all": {"acoustic": mood_acoustic, "not_acoustic": 1 - mood_acoustic},
                 "probability": max(mood_acoustic, 1 - mood_acoustic),
@@ -124,9 +157,9 @@ def _make_highlevel_json(
             "voice_instrumental": {
                 "all": {
                     "voice": 1 - voice_prob if voice_instrumental == "instrumental" else voice_prob,
-                    "instrumental": voice_prob
-                    if voice_instrumental == "instrumental"
-                    else 1 - voice_prob,
+                    "instrumental": (
+                        voice_prob if voice_instrumental == "instrumental" else 1 - voice_prob
+                    ),
                 },
                 "probability": voice_prob,
                 "value": voice_instrumental,
@@ -291,8 +324,50 @@ class TestRecordingFeaturesParsing:
 
         assert features is not None
         vec = features.feature_vector()
-        # 9 genre + 7 mood + 5 mirex + 10 rhythm + 5 scalar
-        assert len(vec) == 36
+        # 9 genre + 7 mood + 5 mirex + 10 rhythm + 5 scalar + 5 electronic + 8 rosamerica + 10 tzanetakis
+        assert len(vec) == 59
+
+    def test_genre_electronic_vector(self, ab_data_dir: Path) -> None:
+        loader = AcousticBrainzLoader(str(ab_data_dir))
+        features = loader.get_features(MBID_AUTECHRE_1)
+
+        assert features is not None
+        assert len(features.genre_electronic_vector) == len(GENRE_ELECTRONIC_LABELS)
+        # Ambient is dominant for this fixture
+        ambient_idx = GENRE_ELECTRONIC_LABELS.index("ambient")
+        assert features.genre_electronic_vector[ambient_idx] == pytest.approx(0.7, abs=0.01)
+
+    def test_genre_rosamerica_vector(self, ab_data_dir: Path) -> None:
+        loader = AcousticBrainzLoader(str(ab_data_dir))
+        features = loader.get_features(MBID_AUTECHRE_1)
+
+        assert features is not None
+        assert len(features.genre_rosamerica_vector) == len(GENRE_ROSAMERICA_LABELS)
+        roc_idx = GENRE_ROSAMERICA_LABELS.index("roc")
+        assert features.genre_rosamerica_vector[roc_idx] == pytest.approx(0.50, abs=0.01)
+
+    def test_genre_tzanetakis_vector(self, ab_data_dir: Path) -> None:
+        loader = AcousticBrainzLoader(str(ab_data_dir))
+        features = loader.get_features(MBID_AUTECHRE_1)
+
+        assert features is not None
+        assert len(features.genre_tzanetakis_vector) == len(GENRE_TZANETAKIS_LABELS)
+        roc_idx = GENRE_TZANETAKIS_LABELS.index("roc")
+        assert features.genre_tzanetakis_vector[roc_idx] == pytest.approx(0.40, abs=0.01)
+
+    def test_feature_vector_layout(self, ab_data_dir: Path) -> None:
+        """New genre classifiers occupy positions [36:59] in the feature vector."""
+        loader = AcousticBrainzLoader(str(ab_data_dir))
+        features = loader.get_features(MBID_AUTECHRE_1)
+        assert features is not None
+
+        vec = features.feature_vector()
+        # Positions [36:41] = genre_electronic (5 elements)
+        assert vec[36:41] == features.genre_electronic_vector
+        # Positions [41:49] = genre_rosamerica (8 elements)
+        assert vec[41:49] == features.genre_rosamerica_vector
+        # Positions [49:59] = genre_tzanetakis (10 elements)
+        assert vec[49:59] == features.genre_tzanetakis_vector
 
 
 # --- Batch lookup ---
@@ -334,8 +409,8 @@ class TestArtistAudioProfile:
         assert profile.avg_danceability == pytest.approx(0.4, abs=0.01)
         # Both recordings are instrumental
         assert profile.voice_instrumental_ratio == pytest.approx(0.0, abs=0.01)
-        # Feature centroid should be length 36
-        assert len(profile.feature_centroid) == 36
+        # Feature centroid should be length 59
+        assert len(profile.feature_centroid) == 59
 
     def test_single_recording_profile(self, ab_data_dir: Path) -> None:
         loader = AcousticBrainzLoader(str(ab_data_dir))

--- a/tests/unit/test_acousticbrainz_client.py
+++ b/tests/unit/test_acousticbrainz_client.py
@@ -1,0 +1,193 @@
+"""Tests for AcousticBrainz PostgreSQL client."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from semantic_index.acousticbrainz import FEATURE_VECTOR_DIM, RecordingFeatures
+from semantic_index.acousticbrainz_client import AcousticBrainzClient
+
+MBID_VOGUE = "33f7dd17-1b3e-4f1a-a60c-c0e32e48e9a0"
+MBID_MATERIAL = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+
+def _make_distributions() -> dict:
+    """Build a classifier_distributions JSONB value matching the PG schema."""
+    return {
+        "genre_dortmund": {
+            "alternative": 0.01,
+            "blues": 0.01,
+            "electronic": 0.90,
+            "folkcountry": 0.01,
+            "funksoulrnb": 0.02,
+            "jazz": 0.01,
+            "pop": 0.02,
+            "raphiphop": 0.01,
+            "rock": 0.01,
+        },
+        "genre_electronic": {
+            "ambient": 0.10,
+            "dnb": 0.05,
+            "house": 0.60,
+            "techno": 0.20,
+            "trance": 0.05,
+        },
+        "genre_rosamerica": {
+            "cla": 0.03,
+            "dan": 0.40,
+            "hip": 0.02,
+            "jaz": 0.05,
+            "pop": 0.20,
+            "rhy": 0.10,
+            "roc": 0.10,
+            "spe": 0.10,
+        },
+        "genre_tzanetakis": {
+            "blu": 0.03,
+            "cla": 0.02,
+            "cou": 0.02,
+            "dis": 0.30,
+            "hip": 0.05,
+            "jaz": 0.03,
+            "met": 0.02,
+            "pop": 0.30,
+            "reg": 0.03,
+            "roc": 0.20,
+        },
+        "moods_mirex": {
+            "Cluster1": 0.15,
+            "Cluster2": 0.25,
+            "Cluster3": 0.20,
+            "Cluster4": 0.30,
+            "Cluster5": 0.10,
+        },
+        "ismir04_rhythm": {
+            "ChaChaCha": 0.05,
+            "Jive": 0.15,
+            "Quickstep": 0.10,
+            "Rumba-American": 0.05,
+            "Rumba-International": 0.05,
+            "Rumba-Misc": 0.05,
+            "Samba": 0.20,
+            "Tango": 0.15,
+            "VienneseWaltz": 0.10,
+            "Waltz": 0.10,
+        },
+        "gender": {"female": 0.70, "male": 0.30},
+    }
+
+
+def _make_pg_row(
+    *,
+    mbid: str = MBID_VOGUE,
+    artist_id: int = 42,
+) -> tuple:
+    """Build a mock PG row matching the client's SELECT column order."""
+    import json
+
+    return (
+        artist_id,  # mar.artist_id
+        mbid,  # ar.recording_mbid
+        0.75,  # danceability
+        "female",  # gender_value
+        0.70,  # gender_probability
+        "electronic",  # genre_dortmund_value
+        0.90,  # genre_dortmund_prob
+        "house",  # genre_electronic_value
+        0.60,  # genre_electronic_prob
+        "dan",  # genre_rosamerica_value
+        0.40,  # genre_rosamerica_prob
+        "dis",  # genre_tzanetakis_value
+        0.30,  # genre_tzanetakis_prob
+        "Jive",  # ismir04_rhythm_value
+        0.15,  # ismir04_rhythm_prob
+        0.20,  # mood_acoustic
+        0.10,  # mood_aggressive
+        0.80,  # mood_electronic
+        0.60,  # mood_happy
+        0.70,  # mood_party
+        0.30,  # mood_relaxed
+        0.15,  # mood_sad
+        "Cluster4",  # moods_mirex_value
+        0.30,  # moods_mirex_prob
+        "bright",  # timbre_value
+        0.85,  # timbre_probability
+        0.65,  # tonal
+        "voice",  # voice_instrumental_value
+        0.80,  # voice_instrumental_prob
+        json.dumps(_make_distributions()),  # classifier_distributions
+    )
+
+
+class TestAcousticBrainzClient:
+    """Test AcousticBrainz PostgreSQL client."""
+
+    def test_get_features_for_artists_parses_recording(self) -> None:
+        """RecordingFeatures is correctly parsed from a PG row."""
+        client = AcousticBrainzClient(cache_dsn="postgresql://localhost/musicbrainz")
+        row = _make_pg_row()
+
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value.fetchall.return_value = [row]
+
+        with patch.object(client, "_get_conn", return_value=mock_conn):
+            result = client.get_features_for_artists([42])
+
+        assert 42 in result
+        recordings = result[42]
+        assert len(recordings) == 1
+        rf = recordings[0]
+        assert isinstance(rf, RecordingFeatures)
+        assert rf.recording_mbid == MBID_VOGUE
+        assert rf.danceability == pytest.approx(0.75)
+        assert rf.genre == "electronic"
+        assert rf.timbre == "bright"
+        assert rf.voice_instrumental == "voice"
+
+    def test_feature_vector_has_59_dims(self) -> None:
+        """Features parsed from PG produce a 59-dim vector."""
+        client = AcousticBrainzClient(cache_dsn="postgresql://localhost/musicbrainz")
+        row = _make_pg_row()
+
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value.fetchall.return_value = [row]
+
+        with patch.object(client, "_get_conn", return_value=mock_conn):
+            result = client.get_features_for_artists([42])
+
+        rf = result[42][0]
+        vec = rf.feature_vector()
+        assert len(vec) == FEATURE_VECTOR_DIM
+
+    def test_multiple_artists(self) -> None:
+        """Multiple artists' recordings are grouped correctly."""
+        client = AcousticBrainzClient(cache_dsn="postgresql://localhost/musicbrainz")
+        row1 = _make_pg_row(mbid=MBID_VOGUE, artist_id=42)
+        row2 = _make_pg_row(mbid=MBID_MATERIAL, artist_id=99)
+
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value.fetchall.return_value = [row1, row2]
+
+        with patch.object(client, "_get_conn", return_value=mock_conn):
+            result = client.get_features_for_artists([42, 99])
+
+        assert len(result) == 2
+        assert len(result[42]) == 1
+        assert len(result[99]) == 1
+        assert result[42][0].recording_mbid == MBID_VOGUE
+        assert result[99][0].recording_mbid == MBID_MATERIAL
+
+    def test_empty_artist_list(self) -> None:
+        """Empty input returns empty dict without querying."""
+        client = AcousticBrainzClient(cache_dsn="postgresql://localhost/musicbrainz")
+        result = client.get_features_for_artists([])
+        assert result == {}
+
+    def test_connection_failure_returns_empty(self) -> None:
+        """Connection failure returns empty dict gracefully."""
+        client = AcousticBrainzClient(cache_dsn="postgresql://localhost/nonexistent")
+
+        with patch.object(client, "_get_conn", return_value=None):
+            result = client.get_features_for_artists([42])
+
+        assert result == {}

--- a/tests/unit/test_import_acousticbrainz.py
+++ b/tests/unit/test_import_acousticbrainz.py
@@ -1,0 +1,331 @@
+"""Tests for AcousticBrainz ETL import script."""
+
+import io
+import json
+import sqlite3
+import tarfile
+from pathlib import Path
+
+import pytest
+
+# --- Fixtures ---
+
+
+def _make_ab_json(
+    *,
+    danceability: float = 0.75,
+    genre: str = "electronic",
+    genre_prob: float = 0.90,
+) -> dict:
+    """Build a minimal AcousticBrainz high-level JSON for import testing."""
+    return {
+        "highlevel": {
+            "danceability": {
+                "all": {"danceable": danceability, "not_danceable": 1 - danceability},
+                "probability": max(danceability, 1 - danceability),
+                "value": "danceable" if danceability > 0.5 else "not_danceable",
+            },
+            "gender": {
+                "all": {"female": 0.4, "male": 0.6},
+                "probability": 0.6,
+                "value": "male",
+            },
+            "genre_dortmund": {
+                "all": {
+                    "alternative": 0.01,
+                    "blues": 0.01,
+                    "electronic": genre_prob if genre == "electronic" else 0.01,
+                    "folkcountry": 0.01,
+                    "funksoulrnb": 0.01,
+                    "jazz": genre_prob if genre == "jazz" else 0.01,
+                    "pop": 0.01,
+                    "raphiphop": 0.01,
+                    "rock": genre_prob if genre == "rock" else 0.01,
+                },
+                "probability": genre_prob,
+                "value": genre,
+            },
+            "genre_electronic": {
+                "all": {
+                    "ambient": 0.10,
+                    "dnb": 0.05,
+                    "house": 0.60,
+                    "techno": 0.20,
+                    "trance": 0.05,
+                },
+                "probability": 0.60,
+                "value": "house",
+            },
+            "genre_rosamerica": {
+                "all": {
+                    "cla": 0.03,
+                    "dan": 0.40,
+                    "hip": 0.02,
+                    "jaz": 0.05,
+                    "pop": 0.20,
+                    "rhy": 0.10,
+                    "roc": 0.10,
+                    "spe": 0.10,
+                },
+                "probability": 0.40,
+                "value": "dan",
+            },
+            "genre_tzanetakis": {
+                "all": {
+                    "blu": 0.03,
+                    "cla": 0.02,
+                    "cou": 0.02,
+                    "dis": 0.30,
+                    "hip": 0.05,
+                    "jaz": 0.03,
+                    "met": 0.02,
+                    "pop": 0.30,
+                    "reg": 0.03,
+                    "roc": 0.20,
+                },
+                "probability": 0.30,
+                "value": "dis",
+            },
+            "ismir04_rhythm": {
+                "all": {
+                    "ChaChaCha": 0.05,
+                    "Jive": 0.15,
+                    "Quickstep": 0.10,
+                    "Rumba-American": 0.05,
+                    "Rumba-International": 0.05,
+                    "Rumba-Misc": 0.05,
+                    "Samba": 0.20,
+                    "Tango": 0.15,
+                    "VienneseWaltz": 0.10,
+                    "Waltz": 0.10,
+                },
+                "probability": 0.20,
+                "value": "Samba",
+            },
+            "mood_acoustic": {
+                "all": {"acoustic": 0.3, "not_acoustic": 0.7},
+                "probability": 0.7,
+                "value": "not_acoustic",
+            },
+            "mood_aggressive": {
+                "all": {"aggressive": 0.1, "not_aggressive": 0.9},
+                "probability": 0.9,
+                "value": "not_aggressive",
+            },
+            "mood_electronic": {
+                "all": {"electronic": 0.8, "not_electronic": 0.2},
+                "probability": 0.8,
+                "value": "electronic",
+            },
+            "mood_happy": {
+                "all": {"happy": 0.6, "not_happy": 0.4},
+                "probability": 0.6,
+                "value": "happy",
+            },
+            "mood_party": {
+                "all": {"party": 0.7, "not_party": 0.3},
+                "probability": 0.7,
+                "value": "party",
+            },
+            "mood_relaxed": {
+                "all": {"relaxed": 0.3, "not_relaxed": 0.7},
+                "probability": 0.7,
+                "value": "not_relaxed",
+            },
+            "mood_sad": {
+                "all": {"sad": 0.15, "not_sad": 0.85},
+                "probability": 0.85,
+                "value": "not_sad",
+            },
+            "moods_mirex": {
+                "all": {
+                    "Cluster1": 0.15,
+                    "Cluster2": 0.25,
+                    "Cluster3": 0.20,
+                    "Cluster4": 0.30,
+                    "Cluster5": 0.10,
+                },
+                "probability": 0.30,
+                "value": "Cluster4",
+            },
+            "timbre": {
+                "all": {"bright": 0.85, "dark": 0.15},
+                "probability": 0.85,
+                "value": "bright",
+            },
+            "tonal_atonal": {
+                "all": {"tonal": 0.65, "atonal": 0.35},
+                "probability": 0.65,
+                "value": "tonal",
+            },
+            "voice_instrumental": {
+                "all": {"voice": 0.80, "instrumental": 0.20},
+                "probability": 0.80,
+                "value": "voice",
+            },
+        },
+        "metadata": {
+            "audio_properties": {
+                "length": 240.5,
+                "codec": "mp3",
+                "analysis_sample_rate": 44100,
+                "bit_rate": 320000,
+                "replay_gain": -8.5,
+            },
+            "tags": {
+                "artist": ["Autechre"],
+                "title": ["Gantz Graf"],
+                "musicbrainz_recordingid": ["0e11c0fd-a1da-4b88-a438-7ef55c5809ec"],
+            },
+        },
+    }
+
+
+def _make_tar_with_recordings(tar_path: Path, recordings: dict[str, dict]) -> None:
+    """Create a tar file with AB JSON files keyed by MBID."""
+    with tarfile.open(tar_path, "w") as tf:
+        for mbid, data in recordings.items():
+            content = json.dumps(data).encode()
+            member_name = f"highlevel/{mbid[:2]}/{mbid[2]}/{mbid}-0.json"
+            info = tarfile.TarInfo(name=member_name)
+            info.size = len(content)
+            tf.addfile(info, io.BytesIO(content))
+
+
+class TestParseRecordingJson:
+    """Test JSON parsing for import."""
+
+    def test_parse_extracts_all_classifiers(self) -> None:
+        from scripts.import_acousticbrainz import parse_recording_json
+
+        data = _make_ab_json()
+        mbid = "0e11c0fd-a1da-4b88-a438-7ef55c5809ec"
+        row = parse_recording_json(mbid, data, "test.tar")
+
+        assert row["recording_mbid"] == mbid
+        assert row["danceability"] == pytest.approx(0.75)
+        assert row["genre_dortmund_value"] == "electronic"
+        assert row["genre_dortmund_prob"] == pytest.approx(0.90)
+        assert row["genre_electronic_value"] == "house"
+        assert row["genre_rosamerica_value"] == "dan"
+        assert row["genre_tzanetakis_value"] == "dis"
+        assert row["timbre_value"] == "bright"
+        assert row["voice_instrumental_value"] == "voice"
+        assert row["mood_acoustic"] == pytest.approx(0.3)
+        assert row["mood_electronic"] == pytest.approx(0.8)
+        assert row["tar_file"] == "test.tar"
+
+    def test_parse_extracts_audio_properties(self) -> None:
+        from scripts.import_acousticbrainz import parse_recording_json
+
+        data = _make_ab_json()
+        row = parse_recording_json("abc", data, "test.tar")
+
+        assert row["audio_length"] == pytest.approx(240.5)
+        assert row["audio_codec"] == "mp3"
+        assert row["audio_sample_rate"] == 44100
+        assert row["audio_bit_rate"] == 320000
+        assert row["replay_gain"] == pytest.approx(-8.5)
+
+    def test_parse_extracts_classifier_distributions(self) -> None:
+        from scripts.import_acousticbrainz import parse_recording_json
+
+        data = _make_ab_json()
+        row = parse_recording_json("abc", data, "test.tar")
+
+        dists = json.loads(row["classifier_distributions"])
+        assert "genre_dortmund" in dists
+        assert "genre_electronic" in dists
+        assert "genre_rosamerica" in dists
+        assert "genre_tzanetakis" in dists
+        assert "moods_mirex" in dists
+        assert "ismir04_rhythm" in dists
+        assert "gender" in dists
+
+    def test_parse_extracts_metadata_tags(self) -> None:
+        from scripts.import_acousticbrainz import parse_recording_json
+
+        data = _make_ab_json()
+        row = parse_recording_json("abc", data, "test.tar")
+
+        tags = json.loads(row["metadata_tags"])
+        assert tags["artist"] == ["Autechre"]
+        assert tags["title"] == ["Gantz Graf"]
+
+
+class TestCheckpointLogic:
+    """Test checkpoint skip and tracking logic."""
+
+    def test_completed_tar_is_skipped(self, tmp_path: Path) -> None:
+        from scripts.import_acousticbrainz import get_completed_tars
+
+        checkpoint_path = tmp_path / "checkpoint.db"
+        conn = sqlite3.connect(str(checkpoint_path))
+        conn.execute(
+            "CREATE TABLE progress (tar_file TEXT PRIMARY KEY, status TEXT, "
+            "rows_imported INTEGER, completed_at TEXT)"
+        )
+        conn.execute("INSERT INTO progress VALUES ('done.tar', 'complete', 1000, '2025-01-01')")
+        conn.commit()
+        conn.close()
+
+        completed = get_completed_tars(str(checkpoint_path))
+        assert "done.tar" in completed
+
+    def test_mark_tar_complete(self, tmp_path: Path) -> None:
+        from scripts.import_acousticbrainz import (
+            get_completed_tars,
+            init_checkpoint,
+            mark_tar_complete,
+        )
+
+        checkpoint_path = str(tmp_path / "checkpoint.db")
+        init_checkpoint(checkpoint_path)
+        mark_tar_complete(checkpoint_path, "test.tar", 500)
+
+        completed = get_completed_tars(checkpoint_path)
+        assert "test.tar" in completed
+
+    def test_failed_tar_not_in_completed(self, tmp_path: Path) -> None:
+        from scripts.import_acousticbrainz import (
+            get_completed_tars,
+            init_checkpoint,
+            mark_tar_failed,
+        )
+
+        checkpoint_path = str(tmp_path / "checkpoint.db")
+        init_checkpoint(checkpoint_path)
+        mark_tar_failed(checkpoint_path, "bad.tar", "OSError: NAS dropped")
+
+        completed = get_completed_tars(checkpoint_path)
+        assert "bad.tar" not in completed
+
+
+class TestTarProcessing:
+    """Test processing recordings from tar files."""
+
+    def test_process_tar_extracts_recordings(self, tmp_path: Path) -> None:
+        from scripts.import_acousticbrainz import process_tar
+
+        mbid = "0e11c0fd-a1da-4b88-a438-7ef55c5809ec"
+        tar_path = tmp_path / "test.tar"
+        _make_tar_with_recordings(tar_path, {mbid: _make_ab_json()})
+
+        rows = process_tar(str(tar_path))
+        assert len(rows) == 1
+        assert rows[0]["recording_mbid"] == mbid
+
+    def test_process_tar_multiple_recordings(self, tmp_path: Path) -> None:
+        from scripts.import_acousticbrainz import process_tar
+
+        mbids = {
+            "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee": _make_ab_json(genre="rock"),
+            "11111111-2222-3333-4444-555555555555": _make_ab_json(genre="jazz"),
+        }
+        tar_path = tmp_path / "multi.tar"
+        _make_tar_with_recordings(tar_path, mbids)
+
+        rows = process_tar(str(tar_path))
+        assert len(rows) == 2
+        extracted_mbids = {r["recording_mbid"] for r in rows}
+        assert extracted_mbids == set(mbids.keys())


### PR DESCRIPTION
## Summary

- Add PostgreSQL-backed AcousticBrainz path: ETL script imports ~4M recordings from tar archives into `ab_recording` table, new `AcousticBrainzClient` replaces two-step tar loader with single JOIN query
- Expand feature vector from 36 to 59 dimensions by including all 18 AcousticBrainz classifiers (adds `genre_electronic`, `genre_rosamerica`, `genre_tzanetakis`)
- Deprecate `--acousticbrainz-dir` tar path in favor of `--musicbrainz-cache-dsn` PG path

Closes #150

## Test plan

- [x] 28 existing acousticbrainz tests updated and passing with 59-dim vectors
- [x] 5 new PG client tests passing (mocked psycopg)
- [x] 9 new ETL import tests passing (parsing, checkpointing, tar processing)
- [x] Full unit suite: 555 passed, 0 failures
- [x] Pre-commit hooks: ruff, black, mypy all pass
- [ ] ETL import of remaining 25/30 tars in progress (2.3M/~10M rows imported so far)