### PR TITLE
Re-key Discogs edge tables during entity deduplication

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -604,10 +604,12 @@ def run(args: argparse.Namespace) -> None:
         dedup_report = pipeline_db.deduplicate_by_qid()
         if dedup_report.groups_found > 0:
             log.info(
-                "Entity deduplication: %d groups, %d entities merged, %d artists reassigned",
+                "Entity deduplication: %d groups, %d entities merged, "
+                "%d artists reassigned, %d edges re-keyed",
                 dedup_report.groups_found,
                 dedup_report.entities_merged,
                 dedup_report.artists_reassigned,
+                dedup_report.edges_rekeyed,
             )
 
     # 6. Extract adjacency pairs
@@ -1027,6 +1029,7 @@ def run(args: argparse.Namespace) -> None:
         print(f"  Dedup groups:            {dedup_report.groups_found:>12,}")
         print(f"  Entities merged:         {dedup_report.entities_merged:>12,}")
         print(f"  Artists reassigned:      {dedup_report.artists_reassigned:>12,}")
+        print(f"  Edges re-keyed:          {dedup_report.edges_rekeyed:>12,}")
     print(f"  Graph nodes:             {graph.number_of_nodes():>12,}")
     print(f"  Graph edges:             {graph.number_of_edges():>12,}")
     print(f"  GEXF output:             {gexf_path}")

--- a/semantic_index/models.py
+++ b/semantic_index/models.py
@@ -288,3 +288,4 @@ class DeduplicationReport(BaseModel):
     groups_found: int  # QIDs with 2+ entities
     entities_merged: int  # Total entities merged (deleted)
     artists_reassigned: int  # Total artist rows re-parented
+    edges_rekeyed: int = 0  # Discogs edge table rows re-keyed during consolidation

--- a/semantic_index/pipeline_db.py
+++ b/semantic_index/pipeline_db.py
@@ -99,6 +99,10 @@ CREATE TABLE IF NOT EXISTS reconciliation_log (
 CREATE INDEX IF NOT EXISTS idx_reconciliation_artist ON reconciliation_log(artist_id);
 """
 
+# Discogs-derived symmetric edge tables that need re-keying during entity dedup.
+# Each stores undirected edges as (artist_a_id, artist_b_id) composite PKs.
+_DISCOGS_EDGE_TABLES = ("shared_personnel", "shared_style", "label_family", "compilation")
+
 _ENTITY_INDEXES = """
 CREATE INDEX IF NOT EXISTS idx_entity_spotify ON entity(spotify_artist_id) WHERE spotify_artist_id IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_entity_apple_music ON entity(apple_music_artist_id) WHERE apple_music_artist_id IS NOT NULL;
@@ -208,16 +212,14 @@ class PipelineDB:
         logger.info("Rebuilding entity table to remove UNIQUE constraint on wikidata_qid")
         self._conn.execute("PRAGMA foreign_keys=OFF")
         self._conn.execute("ALTER TABLE entity RENAME TO _entity_old")
-        self._conn.execute(
-            """CREATE TABLE entity (
+        self._conn.execute("""CREATE TABLE entity (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 wikidata_qid TEXT,
                 name TEXT NOT NULL,
                 entity_type TEXT NOT NULL DEFAULT 'artist',
                 created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
                 updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
-            )"""
-        )
+            )""")
         self._conn.execute("INSERT INTO entity SELECT * FROM _entity_old")
         self._conn.execute("DROP TABLE _entity_old")
         self._conn.execute("PRAGMA foreign_keys=ON")
@@ -258,11 +260,9 @@ class PipelineDB:
         added = _ensure_columns(self._conn, "artist", _NEW_ARTIST_COLUMNS)
 
         if "created_at" in added or "updated_at" in added:
-            self._conn.execute(
-                """UPDATE artist
+            self._conn.execute("""UPDATE artist
                    SET created_at = COALESCE(created_at, strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
-                       updated_at = COALESCE(updated_at, strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))"""
-            )
+                       updated_at = COALESCE(updated_at, strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))""")
 
     # ------------------------------------------------------------------
     # Artist CRUD
@@ -387,18 +387,101 @@ class PipelineDB:
 
     def find_duplicate_qid_groups(self) -> list[tuple[str, list[int]]]:
         """Find groups of entities sharing the same non-NULL Wikidata QID."""
-        rows = self._conn.execute(
-            """SELECT wikidata_qid, GROUP_CONCAT(id)
+        rows = self._conn.execute("""SELECT wikidata_qid, GROUP_CONCAT(id)
                FROM entity
                WHERE wikidata_qid IS NOT NULL
                GROUP BY wikidata_qid
                HAVING COUNT(*) > 1
-               ORDER BY wikidata_qid"""
-        ).fetchall()
+               ORDER BY wikidata_qid""").fetchall()
         return [(row[0], sorted(int(x) for x in row[1].split(","))) for row in rows]
 
-    def merge_entities(self, keep_id: int, merge_id: int) -> None:
-        """Merge two entities: re-parent artists from merge_id to keep_id, then delete merge_id."""
+    def _rekey_discogs_edges(self, keep_id: int, merge_id: int) -> int:
+        """Re-key Discogs edge tables, replacing merge_id with keep_id.
+
+        For each table in ``_DISCOGS_EDGE_TABLES``:
+        1. Delete edges between merge_id and keep_id (would become self-referential).
+        2. Delete edges that would create PK conflicts after re-keying (checks both
+           ``(keep_id, X)`` and ``(X, keep_id)`` since tables are symmetric/unordered).
+        3. UPDATE remaining edges to use keep_id.
+        4. Delete any residual self-referential edges (defensive).
+
+        Returns the total number of edge rows re-keyed (step 3 only).
+        """
+        total = 0
+        for table in _DISCOGS_EDGE_TABLES:
+            if not self._has_table(table):
+                continue
+
+            # 1. Delete edges between merge_id and keep_id (would become self-loops)
+            self._conn.execute(
+                f"DELETE FROM {table} WHERE "  # noqa: S608
+                f"(artist_a_id = ? AND artist_b_id = ?) OR "
+                f"(artist_a_id = ? AND artist_b_id = ?)",
+                (merge_id, keep_id, keep_id, merge_id),
+            )
+
+            # 2a. Delete (merge_id, X) edges that would conflict with existing keep_id edges
+            self._conn.execute(
+                f"DELETE FROM {table} WHERE artist_a_id = ?1 AND ("  # noqa: S608
+                f"  EXISTS (SELECT 1 FROM {table} t2"
+                f"    WHERE t2.artist_a_id = ?2 AND t2.artist_b_id = {table}.artist_b_id)"
+                f"  OR EXISTS (SELECT 1 FROM {table} t2"
+                f"    WHERE t2.artist_a_id = {table}.artist_b_id AND t2.artist_b_id = ?2)"
+                f")",
+                (merge_id, keep_id),
+            )
+
+            # 2b. Delete (X, merge_id) edges that would conflict with existing keep_id edges
+            self._conn.execute(
+                f"DELETE FROM {table} WHERE artist_b_id = ?1 AND ("  # noqa: S608
+                f"  EXISTS (SELECT 1 FROM {table} t2"
+                f"    WHERE t2.artist_a_id = {table}.artist_a_id AND t2.artist_b_id = ?2)"
+                f"  OR EXISTS (SELECT 1 FROM {table} t2"
+                f"    WHERE t2.artist_a_id = ?2 AND t2.artist_b_id = {table}.artist_a_id)"
+                f")",
+                (merge_id, keep_id),
+            )
+
+            # 3. Re-key remaining edges
+            cur = self._conn.execute(
+                f"UPDATE {table} SET artist_a_id = ? WHERE artist_a_id = ?",  # noqa: S608
+                (keep_id, merge_id),
+            )
+            total += cur.rowcount
+            cur = self._conn.execute(
+                f"UPDATE {table} SET artist_b_id = ? WHERE artist_b_id = ?",  # noqa: S608
+                (keep_id, merge_id),
+            )
+            total += cur.rowcount
+
+            # 4. Safety: delete any self-referential edges
+            self._conn.execute(f"DELETE FROM {table} WHERE artist_a_id = artist_b_id")  # noqa: S608
+        return total
+
+    def _consolidate_entity_edges(self, entity_id: int) -> int:
+        """Re-key Discogs edges so all artists sharing entity_id use one survivor.
+
+        Picks the artist with the lowest id as the survivor. For each remaining
+        alias artist, re-keys its Discogs edge references to the survivor.
+
+        Returns the total number of edge rows re-keyed.
+        """
+        rows = self._conn.execute(
+            "SELECT id FROM artist WHERE entity_id = ? ORDER BY id", (entity_id,)
+        ).fetchall()
+        if len(rows) <= 1:
+            return 0
+        keep_artist_id = rows[0][0]
+        total = 0
+        for row in rows[1:]:
+            total += self._rekey_discogs_edges(keep_artist_id, row[0])
+        return total
+
+    def merge_entities(self, keep_id: int, merge_id: int) -> int:
+        """Merge two entities: re-parent artists, re-key edges, delete merged entity.
+
+        Returns the number of Discogs edge rows re-keyed.
+        """
         if keep_id == merge_id:
             raise ValueError("Cannot merge an entity into itself")
 
@@ -410,14 +493,17 @@ class PipelineDB:
         self._conn.execute(
             "UPDATE artist SET entity_id = ? WHERE entity_id = ?", (keep_id, merge_id)
         )
+        edges_rekeyed = self._consolidate_entity_edges(keep_id)
         self._conn.execute("DELETE FROM entity WHERE id = ?", (merge_id,))
         self._conn.commit()
+        return edges_rekeyed
 
     def deduplicate_by_qid(self) -> DeduplicationReport:
         """Find entities sharing a Wikidata QID and merge duplicates."""
         groups = self.find_duplicate_qid_groups()
         entities_merged = 0
         artists_reassigned = 0
+        edges_rekeyed = 0
 
         for qid, entity_ids in groups:
             keep_id = entity_ids[0]
@@ -426,7 +512,7 @@ class PipelineDB:
                     "SELECT COUNT(*) FROM artist WHERE entity_id = ?", (merge_id,)
                 ).fetchone()[0]
                 artists_reassigned += count
-                self.merge_entities(keep_id, merge_id)
+                edges_rekeyed += self.merge_entities(keep_id, merge_id)
                 entities_merged += 1
             logger.info(
                 "Deduplicated QID %s: kept entity %d, merged %d entities",
@@ -437,10 +523,12 @@ class PipelineDB:
 
         if groups:
             logger.info(
-                "Entity deduplication: %d groups, %d entities merged, %d artists reassigned",
+                "Entity deduplication: %d groups, %d entities merged, "
+                "%d artists reassigned, %d edges re-keyed",
                 len(groups),
                 entities_merged,
                 artists_reassigned,
+                edges_rekeyed,
             )
         else:
             logger.info("Entity deduplication: no duplicate QIDs found")
@@ -449,6 +537,7 @@ class PipelineDB:
             groups_found=len(groups),
             entities_merged=entities_merged,
             artists_reassigned=artists_reassigned,
+            edges_rekeyed=edges_rekeyed,
         )
 
     # ------------------------------------------------------------------

--- a/tests/unit/test_pipeline_db.py
+++ b/tests/unit/test_pipeline_db.py
@@ -1,0 +1,317 @@
+"""Tests for PipelineDB entity deduplication with Discogs edge re-keying.
+
+Verifies that deduplicate_by_qid() re-keys the 4 Discogs edge tables
+(shared_personnel, shared_style, label_family, compilation) when merging
+entities that share a Wikidata QID, handling self-referential edges and
+PK conflicts.
+"""
+
+import json
+
+import pytest
+
+from semantic_index.pipeline_db import PipelineDB
+from semantic_index.sqlite_export import (
+    _EDGE_ENRICHMENT_SCHEMA,
+)
+
+# -- Fixtures ----------------------------------------------------------------
+
+
+@pytest.fixture
+def db(tmp_path):
+    """PipelineDB with Discogs edge tables initialized."""
+    pdb = PipelineDB(str(tmp_path / "test.db"))
+    pdb.initialize()
+    pdb._conn.executescript(_EDGE_ENRICHMENT_SCHEMA)
+    return pdb
+
+
+def _create_entity(db: PipelineDB, entity_id: int, name: str, qid: str) -> None:
+    """Insert an entity row directly."""
+    db._conn.execute(
+        "INSERT INTO entity (id, name, entity_type, wikidata_qid, created_at, updated_at) "
+        "VALUES (?, ?, 'artist', ?, strftime('%Y-%m-%dT%H:%M:%SZ', 'now'), "
+        "strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))",
+        (entity_id, name, qid),
+    )
+    db._conn.commit()
+
+
+def _set_up_alias_pair(db: PipelineDB) -> dict[str, int]:
+    """Create Sun Ra / Le Sony'r Ra as alias artists sharing QID Q312545.
+
+    Also creates Autechre and Stereolab as third-party artists for edges.
+
+    Returns:
+        Dict mapping canonical names to artist IDs.
+    """
+    _create_entity(db, 1, "Sun Ra", "Q312545")
+    _create_entity(db, 2, "Le Sony'r Ra", "Q312545")
+
+    ids: dict[str, int] = {}
+    ids["Sun Ra"] = db.upsert_artist("Sun Ra", entity_id=1)
+    ids["Le Sony'r Ra"] = db.upsert_artist("Le Sony'r Ra", entity_id=2)
+    ids["Autechre"] = db.upsert_artist("Autechre")
+    ids["Stereolab"] = db.upsert_artist("Stereolab")
+    return ids
+
+
+def _get_edges(db: PipelineDB, table: str) -> list[tuple[int, int]]:
+    """Return all (artist_a_id, artist_b_id) pairs from an edge table."""
+    return db._conn.execute(f"SELECT artist_a_id, artist_b_id FROM {table}").fetchall()
+
+
+# -- Tests -------------------------------------------------------------------
+
+
+class TestRekeyUpdatesArtistIds:
+    """Verify that re-keying replaces merge_id with keep_id in both columns."""
+
+    def test_rekey_updates_artist_a_id(self, db):
+        """Edge (merge_id, X) becomes (keep_id, X) after dedup."""
+        ids = _set_up_alias_pair(db)
+        sun_ra = ids["Sun Ra"]
+        le_sonyr = ids["Le Sony'r Ra"]
+        autechre = ids["Autechre"]
+
+        db._conn.execute(
+            "INSERT INTO shared_personnel VALUES (?, ?, 2, ?)",
+            (le_sonyr, autechre, json.dumps(["Marshall Allen"])),
+        )
+        db._conn.commit()
+
+        db.deduplicate_by_qid()
+
+        edges = _get_edges(db, "shared_personnel")
+        assert len(edges) == 1
+        assert edges[0] == (sun_ra, autechre)
+
+    def test_rekey_updates_artist_b_id(self, db):
+        """Edge (X, merge_id) becomes (X, keep_id) after dedup."""
+        ids = _set_up_alias_pair(db)
+        sun_ra = ids["Sun Ra"]
+        le_sonyr = ids["Le Sony'r Ra"]
+        autechre = ids["Autechre"]
+
+        db._conn.execute(
+            "INSERT INTO shared_personnel VALUES (?, ?, 1, ?)",
+            (autechre, le_sonyr, json.dumps(["Pat Patrick"])),
+        )
+        db._conn.commit()
+
+        db.deduplicate_by_qid()
+
+        edges = _get_edges(db, "shared_personnel")
+        assert len(edges) == 1
+        assert edges[0] == (autechre, sun_ra)
+
+
+class TestSelfReferentialEdges:
+    """Verify that edges between alias artists are removed (would become self-loops)."""
+
+    def test_self_referential_deleted(self, db):
+        """Edge between merge and keep is removed after dedup."""
+        ids = _set_up_alias_pair(db)
+        sun_ra = ids["Sun Ra"]
+        le_sonyr = ids["Le Sony'r Ra"]
+
+        db._conn.execute(
+            "INSERT INTO shared_personnel VALUES (?, ?, 5, ?)",
+            (sun_ra, le_sonyr, json.dumps(["Marshall Allen", "John Gilmore"])),
+        )
+        db._conn.commit()
+
+        db.deduplicate_by_qid()
+
+        edges = _get_edges(db, "shared_personnel")
+        assert len(edges) == 0
+
+    def test_self_referential_reverse_deleted(self, db):
+        """Edge (merge, keep) in reverse direction is also removed."""
+        ids = _set_up_alias_pair(db)
+        sun_ra = ids["Sun Ra"]
+        le_sonyr = ids["Le Sony'r Ra"]
+
+        db._conn.execute(
+            "INSERT INTO shared_style VALUES (?, ?, 0.95, ?)",
+            (le_sonyr, sun_ra, json.dumps(["Free Jazz", "Avant-Garde"])),
+        )
+        db._conn.commit()
+
+        db.deduplicate_by_qid()
+
+        edges = _get_edges(db, "shared_style")
+        assert len(edges) == 0
+
+
+class TestDuplicatePkResolution:
+    """Verify that PK conflicts after re-keying are resolved."""
+
+    def test_duplicate_pk_resolved(self, db):
+        """When both (merge_id, X) and (keep_id, X) exist, only one survives."""
+        ids = _set_up_alias_pair(db)
+        sun_ra = ids["Sun Ra"]
+        le_sonyr = ids["Le Sony'r Ra"]
+        autechre = ids["Autechre"]
+
+        # Both Sun Ra and Le Sony'r Ra have shared_personnel edges to Autechre
+        db._conn.execute(
+            "INSERT INTO shared_personnel VALUES (?, ?, 3, ?)",
+            (sun_ra, autechre, json.dumps(["Marshall Allen"])),
+        )
+        db._conn.execute(
+            "INSERT INTO shared_personnel VALUES (?, ?, 1, ?)",
+            (le_sonyr, autechre, json.dumps(["Pat Patrick"])),
+        )
+        db._conn.commit()
+
+        db.deduplicate_by_qid()
+
+        edges = _get_edges(db, "shared_personnel")
+        assert len(edges) == 1
+        a, b = edges[0]
+        assert {a, b} == {sun_ra, autechre}
+
+    def test_reverse_duplicate_resolved(self, db):
+        """When (merge_id, X) and (X, keep_id) exist, only one survives."""
+        ids = _set_up_alias_pair(db)
+        sun_ra = ids["Sun Ra"]
+        le_sonyr = ids["Le Sony'r Ra"]
+        stereolab = ids["Stereolab"]
+
+        # (Le Sony'r Ra, Stereolab) and (Stereolab, Sun Ra) — same edge after re-key
+        db._conn.execute(
+            "INSERT INTO label_family VALUES (?, ?, ?)",
+            (le_sonyr, stereolab, json.dumps(["Evidence"])),
+        )
+        db._conn.execute(
+            "INSERT INTO label_family VALUES (?, ?, ?)",
+            (stereolab, sun_ra, json.dumps(["Evidence"])),
+        )
+        db._conn.commit()
+
+        db.deduplicate_by_qid()
+
+        edges = _get_edges(db, "label_family")
+        assert len(edges) == 1
+        a, b = edges[0]
+        assert {a, b} == {sun_ra, stereolab}
+
+
+class TestAllTablesRekeyed:
+    """Verify that all 4 Discogs edge tables are re-keyed."""
+
+    def test_all_four_tables_rekeyed(self, db):
+        """Each of shared_personnel, shared_style, label_family, compilation is updated."""
+        ids = _set_up_alias_pair(db)
+        le_sonyr = ids["Le Sony'r Ra"]
+        sun_ra = ids["Sun Ra"]
+        autechre = ids["Autechre"]
+
+        db._conn.execute(
+            "INSERT INTO shared_personnel VALUES (?, ?, 1, ?)",
+            (le_sonyr, autechre, json.dumps(["member"])),
+        )
+        db._conn.execute(
+            "INSERT INTO shared_style VALUES (?, ?, 0.5, ?)",
+            (le_sonyr, autechre, json.dumps(["Jazz"])),
+        )
+        db._conn.execute(
+            "INSERT INTO label_family VALUES (?, ?, ?)",
+            (le_sonyr, autechre, json.dumps(["Warp"])),
+        )
+        db._conn.execute(
+            "INSERT INTO compilation VALUES (?, ?, 1, ?)",
+            (le_sonyr, autechre, json.dumps(["Comp 1"])),
+        )
+        db._conn.commit()
+
+        db.deduplicate_by_qid()
+
+        for table in ("shared_personnel", "shared_style", "label_family", "compilation"):
+            edges = _get_edges(db, table)
+            assert len(edges) == 1, f"Expected 1 edge in {table}, got {len(edges)}"
+            assert edges[0] == (sun_ra, autechre), f"Edge not re-keyed in {table}"
+
+
+class TestEdgeCases:
+    """Verify graceful handling of edge cases."""
+
+    def test_missing_tables_no_error(self, tmp_path):
+        """Dedup works when edge tables don't exist (fresh DB)."""
+        pdb = PipelineDB(str(tmp_path / "bare.db"))
+        pdb.initialize()
+        # No _EDGE_ENRICHMENT_SCHEMA — edge tables don't exist
+
+        _create_entity(pdb, 1, "Sun Ra", "Q312545")
+        _create_entity(pdb, 2, "Le Sony'r Ra", "Q312545")
+        pdb.upsert_artist("Sun Ra", entity_id=1)
+        pdb.upsert_artist("Le Sony'r Ra", entity_id=2)
+
+        report = pdb.deduplicate_by_qid()
+        assert report.groups_found == 1
+        assert report.entities_merged == 1
+        assert report.edges_rekeyed == 0
+
+    def test_single_artist_per_entity_noop(self, db):
+        """No re-keying when entity has only one artist row."""
+        _create_entity(db, 10, "Autechre", "Q2774")
+        _create_entity(db, 11, "Autechre (duplicate)", "Q2774")
+        autechre_id = db.upsert_artist("Autechre", entity_id=10)
+        stereolab_id = db.upsert_artist("Stereolab")
+        # No second artist with entity_id=11
+
+        db._conn.execute(
+            "INSERT INTO shared_personnel VALUES (?, ?, 1, ?)",
+            (autechre_id, stereolab_id, json.dumps(["member"])),
+        )
+        db._conn.commit()
+
+        report = db.deduplicate_by_qid()
+        assert report.edges_rekeyed == 0
+
+        # Edge is unchanged
+        edges = _get_edges(db, "shared_personnel")
+        assert len(edges) == 1
+        assert edges[0] == (autechre_id, stereolab_id)
+
+
+class TestDeduplicationReport:
+    """Verify the DeduplicationReport includes edges_rekeyed."""
+
+    def test_dedup_report_edges_rekeyed(self, db):
+        """Full deduplicate_by_qid() round-trip: report has correct edges_rekeyed."""
+        ids = _set_up_alias_pair(db)
+        le_sonyr = ids["Le Sony'r Ra"]
+        autechre = ids["Autechre"]
+        stereolab = ids["Stereolab"]
+
+        # Two edges from Le Sony'r Ra (merge target)
+        db._conn.execute(
+            "INSERT INTO shared_personnel VALUES (?, ?, 2, ?)",
+            (le_sonyr, autechre, json.dumps(["Marshall Allen"])),
+        )
+        db._conn.execute(
+            "INSERT INTO shared_style VALUES (?, ?, 0.8, ?)",
+            (stereolab, le_sonyr, json.dumps(["Free Jazz"])),
+        )
+        db._conn.commit()
+
+        report = db.deduplicate_by_qid()
+
+        assert report.groups_found == 1
+        assert report.entities_merged == 1
+        assert report.edges_rekeyed == 2
+
+    def test_dedup_no_qids_noop(self, db):
+        """Empty DB with no QIDs is a no-op (existing behavior preserved)."""
+        db.upsert_artist("Autechre")
+        db.upsert_artist("Stereolab")
+
+        report = db.deduplicate_by_qid()
+
+        assert report.groups_found == 0
+        assert report.entities_merged == 0
+        assert report.artists_reassigned == 0
+        assert report.edges_rekeyed == 0


### PR DESCRIPTION
Closes #155

## Summary

- Extends `merge_entities()` to consolidate Discogs edge tables when entities sharing a Wikidata QID are merged
- After entity merge, picks the lowest-ID artist per entity as the survivor and re-keys all 4 Discogs edge tables (`shared_personnel`, `shared_style`, `label_family`, `compilation`) to point to the survivor
- Handles self-referential edges (between alias artists), PK conflicts, and reverse duplicates
- Adds `edges_rekeyed` field to `DeduplicationReport`

## Test plan

- [x] 11 new unit tests in `tests/unit/test_pipeline_db.py` covering: re-keying both columns, self-referential deletion, PK conflict resolution, reverse duplicate resolution, all 4 tables, missing tables graceful handling, single-artist no-op, report field, no-QID no-op
- [x] 167 existing unit tests still pass
- [x] ruff + black clean