### PR TITLE
Resolve MusicBrainz GIDs to integer IDs for AcousticBrainz JOIN

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -827,11 +827,12 @@ def run(args: argparse.Namespace) -> None:
                 store_audio_profiles,
             )
             from semantic_index.acousticbrainz_client import AcousticBrainzClient as _ABClient
+            from semantic_index.musicbrainz_client import MusicBrainzClient as _MBClient
 
             log.info("Building audio profiles from AcousticBrainz (PostgreSQL)...")
             ab_client = _ABClient(cache_dsn=args.musicbrainz_cache_dsn)
 
-            # Get MB artist IDs from the graph database
+            # Get MB artist GIDs from the graph database
             _ab_conn = _ab_sqlite3.connect(str(sqlite_path))
             mb_rows = _ab_conn.execute(
                 "SELECT id, musicbrainz_artist_id FROM artist "
@@ -840,10 +841,26 @@ def run(args: argparse.Namespace) -> None:
             _ab_conn.close()
 
             if mb_rows:
-                graph_id_to_mb = {row[0]: int(row[1]) for row in mb_rows}
+                # Resolve GIDs (UUIDs) to MB integer IDs via mb_artist table
+                gids = [row[1] for row in mb_rows]
+                mb_client = _MBClient(cache_dsn=args.musicbrainz_cache_dsn)
+                gid_to_int = mb_client.resolve_gids_to_ids(gids)
+
+                graph_id_to_mb: dict[int, int] = {}
+                for row in mb_rows:
+                    graph_id, gid = row[0], row[1]
+                    if gid in gid_to_int:
+                        graph_id_to_mb[graph_id] = gid_to_int[gid]
                 mb_to_graph_id = {v: k for k, v in graph_id_to_mb.items()}
                 mb_ids = list(graph_id_to_mb.values())
-                log.info("  %d artists with MusicBrainz IDs", len(mb_ids))
+
+                skipped = len(mb_rows) - len(graph_id_to_mb)
+                log.info(
+                    "  Resolved %d/%d GIDs to MB integer IDs (%d skipped)",
+                    len(graph_id_to_mb),
+                    len(mb_rows),
+                    skipped,
+                )
 
                 # Single JOIN query: ab_recording × mb_artist_recording
                 ab_features = ab_client.get_features_for_artists(mb_ids)
@@ -905,10 +922,25 @@ def run(args: argparse.Namespace) -> None:
             _ab_conn.close()
 
             if mb_rows:
-                graph_id_to_mb = {row[0]: int(row[1]) for row in mb_rows}
+                # Resolve GIDs (UUIDs) to MB integer IDs via mb_artist table
+                gids = [row[1] for row in mb_rows]
+                gid_to_int = mb_client.resolve_gids_to_ids(gids)
+
+                graph_id_to_mb: dict[int, int] = {}
+                for row in mb_rows:
+                    graph_id, gid = row[0], row[1]
+                    if gid in gid_to_int:
+                        graph_id_to_mb[graph_id] = gid_to_int[gid]
                 mb_to_graph_id = {v: k for k, v in graph_id_to_mb.items()}
                 mb_ids = list(graph_id_to_mb.values())
-                log.info("  %d artists with MusicBrainz IDs", len(mb_ids))
+
+                skipped = len(mb_rows) - len(graph_id_to_mb)
+                log.info(
+                    "  Resolved %d/%d GIDs to MB integer IDs (%d skipped)",
+                    len(graph_id_to_mb),
+                    len(mb_rows),
+                    skipped,
+                )
 
                 mb_recordings = mb_client.get_recording_mbids(mb_ids)
                 total_recordings = sum(len(v) for v in mb_recordings.values())

--- a/semantic_index/musicbrainz_client.py
+++ b/semantic_index/musicbrainz_client.py
@@ -34,6 +34,43 @@ class MusicBrainzClient:
                 return None
         return self._cache_conn
 
+    def resolve_gids_to_ids(self, gids: list[str]) -> dict[str, int]:
+        """Resolve MusicBrainz artist GIDs (UUIDs) to integer IDs.
+
+        Queries ``mb_artist`` in the musicbrainz-cache to map artist GID
+        strings to the internal integer IDs needed by ``mb_artist_recording``.
+
+        Args:
+            gids: List of MusicBrainz artist GID strings (UUIDs).
+
+        Returns:
+            Dict mapping GID string to integer artist ID. GIDs not found
+            in ``mb_artist`` are omitted.
+        """
+        if not gids:
+            return {}
+
+        conn = self._get_conn()
+        if conn is None:
+            return {}
+
+        try:
+            result: dict[str, int] = {}
+            batch_size = 1000
+            for i in range(0, len(gids), batch_size):
+                batch = gids[i : i + batch_size]
+                rows = conn.execute(
+                    "SELECT id, gid::text FROM mb_artist WHERE gid = ANY(%s)",
+                    (batch,),
+                ).fetchall()
+                for artist_id, gid in rows:
+                    result[gid] = artist_id
+
+            return result
+        except Exception:
+            logger.warning("GID-to-ID resolution failed", exc_info=True)
+            return {}
+
     def get_recording_mbids(self, mb_artist_ids: list[int]) -> dict[int, list[str]]:
         """Get recording MBIDs for a set of MusicBrainz artist IDs.
 

--- a/tests/unit/test_musicbrainz_client.py
+++ b/tests/unit/test_musicbrainz_client.py
@@ -1,0 +1,87 @@
+"""Tests for MusicBrainz cache client."""
+
+from unittest.mock import MagicMock, patch
+
+from semantic_index.musicbrainz_client import MusicBrainzClient
+
+GID_AUTECHRE = "410c9baf-5469-44f6-9852-826524b80c61"
+GID_STEREOLAB = "f22942a1-6f70-4f48-866c-3f3e3f4e3b5e"
+GID_BROADCAST = "aabbccdd-1122-3344-5566-778899aabbcc"
+
+
+class TestResolveGidsToIds:
+    """Tests for MusicBrainzClient.resolve_gids_to_ids()."""
+
+    def test_returns_gid_to_integer_mapping(self) -> None:
+        """GIDs are resolved to their integer IDs via mb_artist."""
+        client = MusicBrainzClient(cache_dsn="postgresql://localhost/musicbrainz")
+
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value.fetchall.return_value = [
+            (42, GID_AUTECHRE),
+            (99, GID_STEREOLAB),
+        ]
+
+        with patch.object(client, "_get_conn", return_value=mock_conn):
+            result = client.resolve_gids_to_ids([GID_AUTECHRE, GID_STEREOLAB])
+
+        assert result == {GID_AUTECHRE: 42, GID_STEREOLAB: 99}
+
+    def test_empty_input_returns_empty(self) -> None:
+        """Empty GID list returns empty dict without querying."""
+        client = MusicBrainzClient(cache_dsn="postgresql://localhost/musicbrainz")
+        result = client.resolve_gids_to_ids([])
+        assert result == {}
+
+    def test_connection_failure_returns_empty(self) -> None:
+        """Connection failure returns empty dict gracefully."""
+        client = MusicBrainzClient(cache_dsn="postgresql://localhost/nonexistent")
+
+        with patch.object(client, "_get_conn", return_value=None):
+            result = client.resolve_gids_to_ids([GID_AUTECHRE])
+
+        assert result == {}
+
+    def test_partial_match_omits_unresolved(self) -> None:
+        """GIDs not found in mb_artist are omitted from the result."""
+        client = MusicBrainzClient(cache_dsn="postgresql://localhost/musicbrainz")
+
+        mock_conn = MagicMock()
+        # Only 2 of 3 GIDs resolve
+        mock_conn.execute.return_value.fetchall.return_value = [
+            (42, GID_AUTECHRE),
+            (99, GID_STEREOLAB),
+        ]
+
+        with patch.object(client, "_get_conn", return_value=mock_conn):
+            result = client.resolve_gids_to_ids([GID_AUTECHRE, GID_STEREOLAB, GID_BROADCAST])
+
+        assert result == {GID_AUTECHRE: 42, GID_STEREOLAB: 99}
+        assert GID_BROADCAST not in result
+
+    def test_batching_over_1000(self) -> None:
+        """More than 1000 GIDs triggers multiple batched queries."""
+        client = MusicBrainzClient(cache_dsn="postgresql://localhost/musicbrainz")
+
+        gids = [f"00000000-0000-0000-0000-{i:012d}" for i in range(1500)]
+
+        mock_conn = MagicMock()
+        # Return matching rows for each batch
+        mock_conn.execute.return_value.fetchall.return_value = []
+
+        with patch.object(client, "_get_conn", return_value=mock_conn):
+            client.resolve_gids_to_ids(gids)
+
+        assert mock_conn.execute.call_count == 2
+
+    def test_query_failure_returns_empty(self) -> None:
+        """Query exception returns empty dict with logged warning."""
+        client = MusicBrainzClient(cache_dsn="postgresql://localhost/musicbrainz")
+
+        mock_conn = MagicMock()
+        mock_conn.execute.side_effect = Exception("query failed")
+
+        with patch.object(client, "_get_conn", return_value=mock_conn):
+            result = client.resolve_gids_to_ids([GID_AUTECHRE])
+
+        assert result == {}


### PR DESCRIPTION
## Summary

- Add `MusicBrainzClient.resolve_gids_to_ids()` to batch-query `mb_artist` for GID-to-integer mapping, fixing the broken `int(uuid_string)` crash in the AcousticBrainz enrichment step
- Fix both the PG and deprecated tar code paths in `run_pipeline.py` to use runtime GID resolution instead of the broken `int()` cast
- Add 6 unit tests covering happy path, empty input, connection failure, partial match, batching, and query failure

Closes #159

## Test plan

- [x] `pytest tests/unit/test_musicbrainz_client.py` — 6 new tests pass
- [x] `pytest tests/unit/test_acousticbrainz_client.py` — no regressions
- [x] `pytest tests/unit/` — 566 tests pass
- [x] `ruff check` and `black --check` pass
- [x] `mypy` passes on changed module
- [ ] Full pipeline run with `--musicbrainz-cache-dsn` produces audio profiles instead of crashing