### PR TITLE
Add entity deduplication to nightly sync pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ SQLite ──→ api (FastAPI + aiosqlite) ──→ JSON responses
 | `semantic_index/api/narrative.py` | LLM-generated edge narrative endpoint. Calls Claude Haiku to explain artist relationships in plain English. Caches results in a sidecar SQLite database. Facet-aware. |
 | `semantic_index/api/preview.py` | Audio preview URL endpoint with multi-source fallback (iTunes lookup, Spotify, Bandcamp, Deezer, iTunes search). Caches results in a sidecar SQLite database. Powers the in-card transition player in the graph explorer. |
 | `semantic_index/pg_source.py` | Query Backend-Service PostgreSQL (`wxyc_schema.*`) for pipeline input data. Returns the same types as `sql_parser.py` (FlowsheetEntry, LibraryCode, LibraryRelease). Used by the nightly sync instead of SQL dump parsing. |
-| `semantic_index/nightly_sync.py` | Nightly sync orchestrator: query PG → resolve → PMI → stats → export → facets → graph metrics → atomic DB swap. Preserves enrichment tables from the existing database. |
+| `semantic_index/nightly_sync.py` | Nightly sync orchestrator: query PG → resolve → PMI → stats → export → entity dedup → facets → graph metrics → atomic DB swap. Preserves enrichment tables from the existing database. |
 | `run_pipeline.py` | CLI entry point wiring the full pipeline (SQL dump mode). |
 | `scripts/nightly_sync.py` | CLI wrapper for `semantic_index.nightly_sync.main()`. |
 | `scripts/import_acousticbrainz.py` | ETL script: import AcousticBrainz high-level features from tar archives into PostgreSQL `ab_recording` table. Per-tar checkpointing, NAS-resilient, idempotent via `ON CONFLICT DO NOTHING`. |
@@ -399,7 +399,7 @@ The API service includes a built-in sync scheduler that runs `nightly_sync()` as
 - `DATABASE_URL_BACKEND=postgresql://...` — Backend-Service PG DSN (required when sync enabled)
 - `SYNC_MIN_COUNT=2` — minimum co-occurrence count for DJ transition edges
 
-The scheduler sleeps until the configured hour, runs the full pipeline (PG → resolve → PMI → export → facets → graph metrics), atomically swaps the database, then sleeps until the next day. The API continues serving requests during the rebuild. Runtime is ~5 minutes.
+The scheduler sleeps until the configured hour, runs the full pipeline (PG → resolve → PMI → export → entity dedup → facets → graph metrics), atomically swaps the database, then sleeps until the next day. The API continues serving requests during the rebuild. Runtime is ~5 minutes.
 
 The sync can also be run manually via CLI: `python scripts/nightly_sync.py --dsn postgresql://... --verbose`
 

--- a/semantic_index/nightly_sync.py
+++ b/semantic_index/nightly_sync.py
@@ -10,7 +10,7 @@ Atomic swap strategy:
     1. Copy existing production DB to a temp file
     2. Open as PipelineDB (enrichment tables intact)
     3. Clear recomputed edge tables
-    4. Run pipeline: PG → resolve → PMI → export → facets → metrics
+    4. Run pipeline: PG → resolve → PMI → export → entity dedup → facets → metrics
     5. WAL checkpoint, atomic ``os.replace``
 """
 
@@ -174,7 +174,7 @@ def _load_from_pg(dsn: str):
 
 
 def nightly_sync(args: argparse.Namespace) -> None:
-    """Main orchestration: PG → resolve → PMI → export → swap."""
+    """Main orchestration: PG → resolve → PMI → export → dedup → facets → metrics → swap."""
     from semantic_index.adjacency import extract_adjacency_pairs
     from semantic_index.artist_resolver import ArtistResolver
     from semantic_index.cross_reference import CrossReferenceExtractor
@@ -298,6 +298,18 @@ def nightly_sync(args: argparse.Namespace) -> None:
             min_count=min_count,
             pipeline_db=pipeline_db,
         )
+
+        # --- Step 7b: Entity deduplication ---
+        logger.info("Running entity deduplication...")
+        dedup_report = pipeline_db.deduplicate_by_qid()
+        if dedup_report.groups_found:
+            logger.info(
+                "  Dedup: %d groups, %d entities merged, %d artists reassigned, %d edges re-keyed",
+                dedup_report.groups_found,
+                dedup_report.entities_merged,
+                dedup_report.artists_reassigned,
+                dedup_report.edges_rekeyed,
+            )
 
         # --- Step 8: Facet tables ---
         logger.info("Exporting facet tables...")

--- a/tests/unit/test_nightly_sync.py
+++ b/tests/unit/test_nightly_sync.py
@@ -470,6 +470,6 @@ class TestNightlySyncDeduplication:
         dedup_idx = call_order.index("deduplicate_by_qid")
         facet_idx = call_order.index("export_facet_tables")
 
-        assert (
-            export_idx < dedup_idx < facet_idx
-        ), f"Expected export < dedup < facets, got: {call_order}"
+        assert export_idx < dedup_idx < facet_idx, (
+            f"Expected export < dedup < facets, got: {call_order}"
+        )

--- a/tests/unit/test_nightly_sync.py
+++ b/tests/unit/test_nightly_sync.py
@@ -5,8 +5,11 @@ _atomic_swap) and verifies enrichment data survives a pipeline re-run on
 a copied database.
 """
 
+import argparse
 import sqlite3
+import sys
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -20,8 +23,7 @@ def _create_test_db(path: Path, *, with_enrichment: bool = False) -> None:
     inserts sample data that should survive a nightly sync.
     """
     conn = sqlite3.connect(str(path))
-    conn.executescript(
-        """
+    conn.executescript("""
         CREATE TABLE artist (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             canonical_name TEXT NOT NULL UNIQUE,
@@ -45,8 +47,7 @@ def _create_test_db(path: Path, *, with_enrichment: bool = False) -> None:
             source TEXT NOT NULL,
             PRIMARY KEY (artist_a_id, artist_b_id, source)
         );
-        """
-    )
+        """)
 
     # Seed some edge data that should be cleared
     conn.execute("INSERT INTO artist (canonical_name, total_plays) VALUES ('Autechre', 500)")
@@ -55,8 +56,7 @@ def _create_test_db(path: Path, *, with_enrichment: bool = False) -> None:
     conn.execute("INSERT INTO cross_reference VALUES (1, 2, 'see also', 'library_code')")
 
     if with_enrichment:
-        conn.executescript(
-            """
+        conn.executescript("""
             CREATE TABLE entity (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 wikidata_qid TEXT,
@@ -78,8 +78,7 @@ def _create_test_db(path: Path, *, with_enrichment: bool = False) -> None:
                 recording_count INTEGER NOT NULL DEFAULT 0,
                 created_at TEXT NOT NULL DEFAULT '2025-01-01'
             );
-            """
-        )
+            """)
         conn.execute("INSERT INTO entity (wikidata_qid, name) VALUES ('Q210513', 'Autechre')")
         conn.execute("INSERT INTO wikidata_influence VALUES (1, 2, 'Q210513', 'Q484464')")
         conn.execute("INSERT INTO audio_profile VALUES (1, 0.35, 42, '2025-01-01')")
@@ -328,3 +327,149 @@ class TestAtomicSwap:
         _atomic_swap(temp, prod, dry_run=False)
 
         assert prod.exists()
+
+
+# ===========================================================================
+# Entity deduplication in nightly_sync
+# ===========================================================================
+
+
+def _stub_wxyc_etl():
+    """Pre-populate sys.modules with a stub wxyc_etl so lazy imports succeed."""
+    if "wxyc_etl" in sys.modules:
+        return
+    stub = MagicMock()
+    # text sub-module used by artist_resolver and graph_metrics
+    stub.text.normalize_artist_name = lambda name: name.lower().strip()
+    stub.text.is_compilation_artist = lambda name: name.lower() in ("various artists", "v/a")
+    stub.text.split_artist_name = lambda name: [name]
+    for name in (
+        "wxyc_etl",
+        "wxyc_etl.text",
+        "wxyc_etl.parser",
+        "wxyc_etl.schema",
+    ):
+        sys.modules.setdefault(name, stub)
+
+
+class TestNightlySyncDeduplication:
+    """Verify that nightly_sync calls deduplicate_by_qid after export and before facets."""
+
+    def _make_args(self, tmp_path: Path) -> argparse.Namespace:
+        return argparse.Namespace(
+            db_path=str(tmp_path / "prod.db"),
+            dsn="postgresql://fake",
+            min_count=2,
+            dry_run=True,
+        )
+
+    def _set_up_mocks(self, mock_pdb_cls, mock_load, mock_resolver_cls, mock_xref_cls):
+        """Configure common mocks for nightly_sync orchestration tests."""
+        from semantic_index.models import DeduplicationReport
+
+        mock_load.return_value = (
+            {},  # genres
+            [],  # codes
+            [],  # releases
+            [MagicMock(artist_name="Autechre", canonical_name="Autechre")],
+            {},  # show_to_dj
+            {},  # show_dj_names
+            [],  # artist_xrefs
+            [],  # release_xrefs
+        )
+
+        resolved = MagicMock()
+        resolved.resolution_method = "name_match"
+        resolved.canonical_name = "Autechre"
+        mock_resolver = mock_resolver_cls.return_value
+        mock_resolver.resolve.return_value = resolved
+        mock_resolver.re_resolve_with_play_counts.return_value = [resolved]
+
+        mock_xref = mock_xref_cls.return_value
+        mock_xref.extract_library_code_xrefs.return_value = []
+        mock_xref.extract_release_xrefs.return_value = []
+
+        mock_pdb = mock_pdb_cls.return_value
+        mock_pdb.bulk_upsert_artists.return_value = {"Autechre": 1}
+        mock_pdb.get_name_to_id_mapping.return_value = {"Autechre": 1}
+        mock_pdb.deduplicate_by_qid.return_value = DeduplicationReport(
+            groups_found=1,
+            entities_merged=1,
+            artists_reassigned=2,
+            edges_rekeyed=3,
+        )
+        return mock_pdb
+
+    def _run_nightly_sync(self, tmp_path, extra_setup=None):
+        """Run nightly_sync with all heavy dependencies mocked out.
+
+        Returns the mock PipelineDB instance for assertions.
+        """
+        _stub_wxyc_etl()
+
+        prod = tmp_path / "prod.db"
+        _create_test_db(prod)
+
+        with (
+            patch("semantic_index.nightly_sync._load_from_pg") as mock_load,
+            patch("semantic_index.pipeline_db.PipelineDB") as mock_pdb_cls,
+            patch("semantic_index.nightly_sync._clear_recomputed_tables"),
+            patch("semantic_index.artist_resolver.ArtistResolver") as mock_resolver_cls,
+            patch("semantic_index.cross_reference.CrossReferenceExtractor") as mock_xref_cls,
+            patch("semantic_index.adjacency.extract_adjacency_pairs", return_value=[]),
+            patch("semantic_index.pmi.compute_pmi", return_value=[]),
+            patch("semantic_index.node_attributes.compute_artist_stats", return_value={}),
+            patch("semantic_index.sqlite_export.export_sqlite") as mock_export,
+            patch("semantic_index.facet_export.export_facet_tables") as mock_facets,
+            patch("semantic_index.graph_metrics.compute_and_persist") as mock_metrics,
+        ):
+            mock_pdb = self._set_up_mocks(mock_pdb_cls, mock_load, mock_resolver_cls, mock_xref_cls)
+            mock_metrics.return_value = MagicMock(community_count=0, artists_scored=0)
+
+            if extra_setup:
+                extra_setup(
+                    mock_pdb=mock_pdb,
+                    mock_export=mock_export,
+                    mock_facets=mock_facets,
+                )
+
+            from semantic_index.nightly_sync import nightly_sync
+
+            args = self._make_args(tmp_path)
+            nightly_sync(args)
+
+        return mock_pdb
+
+    def test_dedup_called_after_export_before_facets(self, tmp_path):
+        mock_pdb = self._run_nightly_sync(tmp_path)
+        mock_pdb.deduplicate_by_qid.assert_called_once()
+
+    def test_dedup_runs_before_facets(self, tmp_path):
+        """Entity dedup must run before facet export so artist IDs are stable."""
+        from semantic_index.models import DeduplicationReport
+
+        call_order = []
+
+        def setup(mock_pdb, mock_export, mock_facets):
+            mock_export.side_effect = lambda *a, **kw: call_order.append("export_sqlite")
+            mock_pdb.deduplicate_by_qid.side_effect = lambda: (
+                call_order.append("deduplicate_by_qid")
+                or DeduplicationReport(
+                    groups_found=0, entities_merged=0, artists_reassigned=0, edges_rekeyed=0
+                )
+            )
+            mock_facets.side_effect = lambda *a, **kw: call_order.append("export_facet_tables")
+
+        self._run_nightly_sync(tmp_path, extra_setup=setup)
+
+        assert "export_sqlite" in call_order
+        assert "deduplicate_by_qid" in call_order
+        assert "export_facet_tables" in call_order
+
+        export_idx = call_order.index("export_sqlite")
+        dedup_idx = call_order.index("deduplicate_by_qid")
+        facet_idx = call_order.index("export_facet_tables")
+
+        assert (
+            export_idx < dedup_idx < facet_idx
+        ), f"Expected export < dedup < facets, got: {call_order}"


### PR DESCRIPTION
## Summary

- Add `deduplicate_by_qid()` call to the nightly sync pipeline after `export_sqlite()` (step 7) and before facet table export (step 8), so Wikidata QID-based entity merges happen automatically each night
- Add two tests verifying the call is made and runs in the correct order (export < dedup < facets)
- Update pipeline flow documentation in CLAUDE.md, module docstrings, and function docstrings

Closes #162

## Test plan

- [x] `test_dedup_called_after_export_before_facets` -- verifies `deduplicate_by_qid` is called once during the pipeline
- [x] `test_dedup_runs_before_facets` -- verifies ordering: export_sqlite < deduplicate_by_qid < export_facet_tables
- [x] All 19 tests pass (`pytest tests/unit/test_nightly_sync.py`)
- [x] `ruff check` and `black --check` pass on all changed files