### PR TITLE
Extend entity dedup re-keying to all artist-referencing tables

### DIFF
--- a/semantic_index/pipeline_db.py
+++ b/semantic_index/pipeline_db.py
@@ -99,9 +99,31 @@ CREATE TABLE IF NOT EXISTS reconciliation_log (
 CREATE INDEX IF NOT EXISTS idx_reconciliation_artist ON reconciliation_log(artist_id);
 """
 
-# Discogs-derived symmetric edge tables that need re-keying during entity dedup.
+# Symmetric edge tables that need re-keying during entity dedup.
 # Each stores undirected edges as (artist_a_id, artist_b_id) composite PKs.
-_DISCOGS_EDGE_TABLES = ("shared_personnel", "shared_style", "label_family", "compilation")
+_SYMMETRIC_EDGE_TABLES = (
+    "shared_personnel",
+    "shared_style",
+    "label_family",
+    "compilation",
+    "acoustic_similarity",
+)
+
+# Directed edge tables keyed by (source_id, target_id).
+_DIRECTED_EDGE_TABLES = ("wikidata_influence",)
+
+# Single-artist tables with artist_id as sole PK.
+_SINGLE_ARTIST_PK_TABLES = ("audio_profile",)
+
+# Single-artist tables with composite PK including artist_id.
+# Tuples of (table_name, pk_column_besides_artist_id).
+_SINGLE_ARTIST_COMPOSITE_PK_TABLES = (
+    ("artist_style", "style_tag"),
+    ("artist_label", "label_name"),
+)
+
+# Single-artist tables with no PK constraint (just an FK).
+_SINGLE_ARTIST_FK_TABLES = ("artist_personnel",)
 
 _ENTITY_INDEXES = """
 CREATE INDEX IF NOT EXISTS idx_entity_spotify ON entity(spotify_artist_id) WHERE spotify_artist_id IS NOT NULL;
@@ -395,10 +417,10 @@ class PipelineDB:
                ORDER BY wikidata_qid""").fetchall()
         return [(row[0], sorted(int(x) for x in row[1].split(","))) for row in rows]
 
-    def _rekey_discogs_edges(self, keep_id: int, merge_id: int) -> int:
-        """Re-key Discogs edge tables, replacing merge_id with keep_id.
+    def _rekey_symmetric_edges(self, keep_id: int, merge_id: int) -> int:
+        """Re-key symmetric edge tables, replacing merge_id with keep_id.
 
-        For each table in ``_DISCOGS_EDGE_TABLES``:
+        For each table in ``_SYMMETRIC_EDGE_TABLES``:
         1. Delete edges between merge_id and keep_id (would become self-referential).
         2. Delete edges that would create PK conflicts after re-keying (checks both
            ``(keep_id, X)`` and ``(X, keep_id)`` since tables are symmetric/unordered).
@@ -408,7 +430,7 @@ class PipelineDB:
         Returns the total number of edge rows re-keyed (step 3 only).
         """
         total = 0
-        for table in _DISCOGS_EDGE_TABLES:
+        for table in _SYMMETRIC_EDGE_TABLES:
             if not self._has_table(table):
                 continue
 
@@ -458,13 +480,128 @@ class PipelineDB:
             self._conn.execute(f"DELETE FROM {table} WHERE artist_a_id = artist_b_id")  # noqa: S608
         return total
 
+    def _rekey_directed_edges(self, keep_id: int, merge_id: int) -> int:
+        """Re-key directed edge tables, replacing merge_id with keep_id.
+
+        For each table in ``_DIRECTED_EDGE_TABLES`` (keyed by ``source_id``/``target_id``):
+        1. Delete edges between merge_id and keep_id (would become self-referential).
+        2. Delete edges that would create PK conflicts after re-keying.
+        3. UPDATE remaining edges to use keep_id.
+        4. Delete any residual self-referential edges (defensive).
+
+        Returns the total number of edge rows re-keyed (step 3 only).
+        """
+        total = 0
+        for table in _DIRECTED_EDGE_TABLES:
+            if not self._has_table(table):
+                continue
+
+            # 1. Delete edges between merge_id and keep_id
+            self._conn.execute(
+                f"DELETE FROM {table} WHERE "  # noqa: S608
+                f"(source_id = ? AND target_id = ?) OR "
+                f"(source_id = ? AND target_id = ?)",
+                (merge_id, keep_id, keep_id, merge_id),
+            )
+
+            # 2a. Delete (merge_id, X) edges that conflict with existing (keep_id, X)
+            self._conn.execute(
+                f"DELETE FROM {table} WHERE source_id = ?1 AND "  # noqa: S608
+                f"EXISTS (SELECT 1 FROM {table} t2"
+                f"  WHERE t2.source_id = ?2 AND t2.target_id = {table}.target_id)",
+                (merge_id, keep_id),
+            )
+
+            # 2b. Delete (X, merge_id) edges that conflict with existing (X, keep_id)
+            self._conn.execute(
+                f"DELETE FROM {table} WHERE target_id = ?1 AND "  # noqa: S608
+                f"EXISTS (SELECT 1 FROM {table} t2"
+                f"  WHERE t2.source_id = {table}.source_id AND t2.target_id = ?2)",
+                (merge_id, keep_id),
+            )
+
+            # 3. Re-key remaining edges
+            cur = self._conn.execute(
+                f"UPDATE {table} SET source_id = ? WHERE source_id = ?",  # noqa: S608
+                (keep_id, merge_id),
+            )
+            total += cur.rowcount
+            cur = self._conn.execute(
+                f"UPDATE {table} SET target_id = ? WHERE target_id = ?",  # noqa: S608
+                (keep_id, merge_id),
+            )
+            total += cur.rowcount
+
+            # 4. Safety: delete any self-referential edges
+            self._conn.execute(f"DELETE FROM {table} WHERE source_id = target_id")  # noqa: S608
+        return total
+
+    def _rekey_single_artist_tables(self, keep_id: int, merge_id: int) -> int:
+        """Re-key single-artist tables, replacing merge_id with keep_id.
+
+        Handles three table categories:
+        - PK tables (``artist_id`` is the sole PK): delete merge_id row if
+          keep_id already exists, otherwise UPDATE.
+        - Composite PK tables (PK includes ``artist_id`` + another column):
+          delete duplicates, then UPDATE remaining.
+        - FK-only tables (no PK constraint): simple UPDATE.
+
+        Returns the total number of rows re-keyed.
+        """
+        total = 0
+
+        # Tables where artist_id is the sole PK
+        for table in _SINGLE_ARTIST_PK_TABLES:
+            if not self._has_table(table):
+                continue
+            # Delete merge_id's row if keep_id already has one (PK conflict)
+            self._conn.execute(
+                f"DELETE FROM {table} WHERE artist_id = ?1 AND "  # noqa: S608
+                f"EXISTS (SELECT 1 FROM {table} t2 WHERE t2.artist_id = ?2)",
+                (merge_id, keep_id),
+            )
+            cur = self._conn.execute(
+                f"UPDATE {table} SET artist_id = ? WHERE artist_id = ?",  # noqa: S608
+                (keep_id, merge_id),
+            )
+            total += cur.rowcount
+
+        # Tables with composite PK (artist_id, other_column)
+        for table, other_col in _SINGLE_ARTIST_COMPOSITE_PK_TABLES:
+            if not self._has_table(table):
+                continue
+            # Delete merge_id rows that would conflict with existing keep_id rows
+            self._conn.execute(
+                f"DELETE FROM {table} WHERE artist_id = ?1 AND "  # noqa: S608
+                f"EXISTS (SELECT 1 FROM {table} t2"
+                f"  WHERE t2.artist_id = ?2 AND t2.{other_col} = {table}.{other_col})",
+                (merge_id, keep_id),
+            )
+            cur = self._conn.execute(
+                f"UPDATE {table} SET artist_id = ? WHERE artist_id = ?",  # noqa: S608
+                (keep_id, merge_id),
+            )
+            total += cur.rowcount
+
+        # Tables with no PK constraint (just FK)
+        for table in _SINGLE_ARTIST_FK_TABLES:
+            if not self._has_table(table):
+                continue
+            cur = self._conn.execute(
+                f"UPDATE {table} SET artist_id = ? WHERE artist_id = ?",  # noqa: S608
+                (keep_id, merge_id),
+            )
+            total += cur.rowcount
+
+        return total
+
     def _consolidate_entity_edges(self, entity_id: int) -> int:
-        """Re-key Discogs edges so all artists sharing entity_id use one survivor.
+        """Re-key all artist-referencing tables so aliases use one survivor.
 
         Picks the artist with the lowest id as the survivor. For each remaining
-        alias artist, re-keys its Discogs edge references to the survivor.
+        alias artist, re-keys its edge and enrichment references to the survivor.
 
-        Returns the total number of edge rows re-keyed.
+        Returns the total number of rows re-keyed.
         """
         rows = self._conn.execute(
             "SELECT id FROM artist WHERE entity_id = ? ORDER BY id", (entity_id,)
@@ -474,13 +611,16 @@ class PipelineDB:
         keep_artist_id = rows[0][0]
         total = 0
         for row in rows[1:]:
-            total += self._rekey_discogs_edges(keep_artist_id, row[0])
+            merge_artist_id = row[0]
+            total += self._rekey_symmetric_edges(keep_artist_id, merge_artist_id)
+            total += self._rekey_directed_edges(keep_artist_id, merge_artist_id)
+            total += self._rekey_single_artist_tables(keep_artist_id, merge_artist_id)
         return total
 
     def merge_entities(self, keep_id: int, merge_id: int) -> int:
-        """Merge two entities: re-parent artists, re-key edges, delete merged entity.
+        """Merge two entities: re-parent artists, re-key all references, delete merged entity.
 
-        Returns the number of Discogs edge rows re-keyed.
+        Returns the number of rows re-keyed across all artist-referencing tables.
         """
         if keep_id == merge_id:
             raise ValueError("Cannot merge an entity into itself")

--- a/tests/unit/test_pipeline_db.py
+++ b/tests/unit/test_pipeline_db.py
@@ -1,9 +1,9 @@
-"""Tests for PipelineDB entity deduplication with Discogs edge re-keying.
+"""Tests for PipelineDB entity deduplication with edge re-keying.
 
-Verifies that deduplicate_by_qid() re-keys the 4 Discogs edge tables
-(shared_personnel, shared_style, label_family, compilation) when merging
-entities that share a Wikidata QID, handling self-referential edges and
-PK conflicts.
+Verifies that deduplicate_by_qid() re-keys all artist-referencing tables
+(Discogs edges, acoustic similarity, wikidata influence, audio profile,
+artist style, artist personnel, artist label) when merging entities that
+share a Wikidata QID, handling self-referential edges and PK conflicts.
 """
 
 import json
@@ -15,15 +15,37 @@ from semantic_index.sqlite_export import (
     _EDGE_ENRICHMENT_SCHEMA,
 )
 
+# Schema for tables not included in _EDGE_ENRICHMENT_SCHEMA.
+_AUDIO_TABLES_SCHEMA = """
+CREATE TABLE IF NOT EXISTS audio_profile (
+    artist_id INTEGER PRIMARY KEY REFERENCES artist(id),
+    avg_danceability REAL,
+    primary_genre TEXT,
+    primary_genre_probability REAL,
+    voice_instrumental_ratio REAL,
+    feature_centroid TEXT,
+    recording_count INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+CREATE TABLE IF NOT EXISTS acoustic_similarity (
+    artist_a_id INTEGER NOT NULL REFERENCES artist(id),
+    artist_b_id INTEGER NOT NULL REFERENCES artist(id),
+    similarity REAL NOT NULL,
+    PRIMARY KEY (artist_a_id, artist_b_id)
+);
+"""
+
 # -- Fixtures ----------------------------------------------------------------
 
 
 @pytest.fixture
 def db(tmp_path):
-    """PipelineDB with Discogs edge tables initialized."""
+    """PipelineDB with all edge and enrichment tables initialized."""
     pdb = PipelineDB(str(tmp_path / "test.db"))
     pdb.initialize()
     pdb._conn.executescript(_EDGE_ENRICHMENT_SCHEMA)
+    pdb._conn.executescript(_AUDIO_TABLES_SCHEMA)
     return pdb
 
 
@@ -200,10 +222,10 @@ class TestDuplicatePkResolution:
 
 
 class TestAllTablesRekeyed:
-    """Verify that all 4 Discogs edge tables are re-keyed."""
+    """Verify that all artist-referencing tables are re-keyed."""
 
-    def test_all_four_tables_rekeyed(self, db):
-        """Each of shared_personnel, shared_style, label_family, compilation is updated."""
+    def test_all_symmetric_tables_rekeyed(self, db):
+        """Each symmetric edge table (Discogs + acoustic) is updated."""
         ids = _set_up_alias_pair(db)
         le_sonyr = ids["Le Sony'r Ra"]
         sun_ra = ids["Sun Ra"]
@@ -225,14 +247,86 @@ class TestAllTablesRekeyed:
             "INSERT INTO compilation VALUES (?, ?, 1, ?)",
             (le_sonyr, autechre, json.dumps(["Comp 1"])),
         )
+        db._conn.execute(
+            "INSERT INTO acoustic_similarity VALUES (?, ?, 0.95)",
+            (le_sonyr, autechre),
+        )
         db._conn.commit()
 
         db.deduplicate_by_qid()
 
-        for table in ("shared_personnel", "shared_style", "label_family", "compilation"):
+        for table in (
+            "shared_personnel",
+            "shared_style",
+            "label_family",
+            "compilation",
+            "acoustic_similarity",
+        ):
             edges = _get_edges(db, table)
             assert len(edges) == 1, f"Expected 1 edge in {table}, got {len(edges)}"
             assert edges[0] == (sun_ra, autechre), f"Edge not re-keyed in {table}"
+
+    def test_all_table_types_rekeyed_in_one_dedup(self, db):
+        """All table types (symmetric, directed, single-artist) re-keyed in one pass."""
+        ids = _set_up_alias_pair(db)
+        le_sonyr = ids["Le Sony'r Ra"]
+        sun_ra = ids["Sun Ra"]
+        autechre = ids["Autechre"]
+
+        # Symmetric edge
+        db._conn.execute(
+            "INSERT INTO shared_personnel VALUES (?, ?, 1, ?)",
+            (le_sonyr, autechre, json.dumps(["member"])),
+        )
+        # Directed edge
+        db._conn.execute(
+            "INSERT INTO wikidata_influence VALUES (?, ?, 'Q312545', 'Q2774')",
+            (le_sonyr, autechre),
+        )
+        # Single-artist PK
+        db._conn.execute(
+            "INSERT INTO audio_profile (artist_id, avg_danceability, recording_count) "
+            "VALUES (?, 0.5, 10)",
+            (le_sonyr,),
+        )
+        # Composite PK
+        db._conn.execute("INSERT INTO artist_style VALUES (?, 'Free Jazz')", (le_sonyr,))
+        # FK-only
+        db._conn.execute(
+            "INSERT INTO artist_personnel VALUES (?, 'Marshall Allen', 'alto sax')",
+            (le_sonyr,),
+        )
+        # Composite PK
+        db._conn.execute(
+            "INSERT INTO artist_label VALUES (?, 'Saturn Records', NULL)",
+            (le_sonyr,),
+        )
+        db._conn.commit()
+
+        report = db.deduplicate_by_qid()
+
+        # All rows re-keyed: 1 symmetric + 1 directed + 1 audio_profile
+        # + 1 artist_style + 1 artist_personnel + 1 artist_label = 6
+        assert report.edges_rekeyed == 6
+
+        # Verify each table
+        edges = _get_edges(db, "shared_personnel")
+        assert edges[0] == (sun_ra, autechre)
+
+        inf = _get_influence_edges(db)
+        assert inf[0] == (sun_ra, autechre)
+
+        ap = db._conn.execute("SELECT artist_id FROM audio_profile").fetchall()
+        assert ap[0][0] == sun_ra
+
+        styles = db._conn.execute("SELECT artist_id FROM artist_style").fetchall()
+        assert styles[0][0] == sun_ra
+
+        personnel = db._conn.execute("SELECT artist_id FROM artist_personnel").fetchall()
+        assert personnel[0][0] == sun_ra
+
+        labels = db._conn.execute("SELECT artist_id FROM artist_label").fetchall()
+        assert labels[0][0] == sun_ra
 
 
 class TestEdgeCases:
@@ -315,3 +409,322 @@ class TestDeduplicationReport:
         assert report.entities_merged == 0
         assert report.artists_reassigned == 0
         assert report.edges_rekeyed == 0
+
+
+# -- Acoustic similarity re-keying ------------------------------------------
+
+
+class TestAcousticSimilarityRekey:
+    """Verify that acoustic_similarity edges are re-keyed during dedup."""
+
+    def test_rekey_acoustic_similarity(self, db):
+        """Acoustic similarity edge (merge_id, X) becomes (keep_id, X)."""
+        ids = _set_up_alias_pair(db)
+        sun_ra = ids["Sun Ra"]
+        le_sonyr = ids["Le Sony'r Ra"]
+        autechre = ids["Autechre"]
+
+        db._conn.execute(
+            "INSERT INTO acoustic_similarity VALUES (?, ?, 0.97)",
+            (le_sonyr, autechre),
+        )
+        db._conn.commit()
+
+        db.deduplicate_by_qid()
+
+        edges = _get_edges(db, "acoustic_similarity")
+        assert len(edges) == 1
+        assert edges[0] == (sun_ra, autechre)
+
+    def test_acoustic_similarity_self_loop_deleted(self, db):
+        """Acoustic similarity between alias artists is removed."""
+        ids = _set_up_alias_pair(db)
+        sun_ra = ids["Sun Ra"]
+        le_sonyr = ids["Le Sony'r Ra"]
+
+        db._conn.execute(
+            "INSERT INTO acoustic_similarity VALUES (?, ?, 0.99)",
+            (sun_ra, le_sonyr),
+        )
+        db._conn.commit()
+
+        db.deduplicate_by_qid()
+
+        edges = _get_edges(db, "acoustic_similarity")
+        assert len(edges) == 0
+
+    def test_acoustic_similarity_pk_conflict(self, db):
+        """When both aliases have similarity to same artist, only one survives."""
+        ids = _set_up_alias_pair(db)
+        sun_ra = ids["Sun Ra"]
+        le_sonyr = ids["Le Sony'r Ra"]
+        autechre = ids["Autechre"]
+
+        db._conn.execute(
+            "INSERT INTO acoustic_similarity VALUES (?, ?, 0.95)",
+            (sun_ra, autechre),
+        )
+        db._conn.execute(
+            "INSERT INTO acoustic_similarity VALUES (?, ?, 0.92)",
+            (le_sonyr, autechre),
+        )
+        db._conn.commit()
+
+        db.deduplicate_by_qid()
+
+        edges = _get_edges(db, "acoustic_similarity")
+        assert len(edges) == 1
+        a, b = edges[0]
+        assert {a, b} == {sun_ra, autechre}
+
+
+# -- Wikidata influence re-keying -------------------------------------------
+
+
+def _get_influence_edges(db: PipelineDB) -> list[tuple[int, int]]:
+    """Return all (source_id, target_id) pairs from wikidata_influence."""
+    return db._conn.execute("SELECT source_id, target_id FROM wikidata_influence").fetchall()
+
+
+class TestWikidataInfluenceRekey:
+    """Verify that wikidata_influence edges are re-keyed during dedup."""
+
+    def test_rekey_influence_source(self, db):
+        """Influence edge with merge_id as source becomes keep_id."""
+        ids = _set_up_alias_pair(db)
+        sun_ra = ids["Sun Ra"]
+        le_sonyr = ids["Le Sony'r Ra"]
+        autechre = ids["Autechre"]
+
+        db._conn.execute(
+            "INSERT INTO wikidata_influence VALUES (?, ?, 'Q312545', 'Q2774')",
+            (le_sonyr, autechre),
+        )
+        db._conn.commit()
+
+        db.deduplicate_by_qid()
+
+        edges = _get_influence_edges(db)
+        assert len(edges) == 1
+        assert edges[0] == (sun_ra, autechre)
+
+    def test_rekey_influence_target(self, db):
+        """Influence edge with merge_id as target becomes keep_id."""
+        ids = _set_up_alias_pair(db)
+        sun_ra = ids["Sun Ra"]
+        le_sonyr = ids["Le Sony'r Ra"]
+        autechre = ids["Autechre"]
+
+        db._conn.execute(
+            "INSERT INTO wikidata_influence VALUES (?, ?, 'Q2774', 'Q312545')",
+            (autechre, le_sonyr),
+        )
+        db._conn.commit()
+
+        db.deduplicate_by_qid()
+
+        edges = _get_influence_edges(db)
+        assert len(edges) == 1
+        assert edges[0] == (autechre, sun_ra)
+
+    def test_influence_self_loop_deleted(self, db):
+        """Influence edge between alias artists is removed."""
+        ids = _set_up_alias_pair(db)
+        sun_ra = ids["Sun Ra"]
+        le_sonyr = ids["Le Sony'r Ra"]
+
+        db._conn.execute(
+            "INSERT INTO wikidata_influence VALUES (?, ?, 'Q312545', 'Q312545')",
+            (sun_ra, le_sonyr),
+        )
+        db._conn.commit()
+
+        db.deduplicate_by_qid()
+
+        edges = _get_influence_edges(db)
+        assert len(edges) == 0
+
+    def test_influence_pk_conflict(self, db):
+        """When both aliases have influence to same artist, only one survives."""
+        ids = _set_up_alias_pair(db)
+        sun_ra = ids["Sun Ra"]
+        le_sonyr = ids["Le Sony'r Ra"]
+        autechre = ids["Autechre"]
+
+        db._conn.execute(
+            "INSERT INTO wikidata_influence VALUES (?, ?, 'Q312545', 'Q2774')",
+            (sun_ra, autechre),
+        )
+        db._conn.execute(
+            "INSERT INTO wikidata_influence VALUES (?, ?, 'Q312545', 'Q2774')",
+            (le_sonyr, autechre),
+        )
+        db._conn.commit()
+
+        db.deduplicate_by_qid()
+
+        edges = _get_influence_edges(db)
+        assert len(edges) == 1
+        assert edges[0] == (sun_ra, autechre)
+
+
+# -- Audio profile re-keying ------------------------------------------------
+
+
+class TestAudioProfileRekey:
+    """Verify that audio_profile rows are re-keyed during dedup."""
+
+    def test_rekey_audio_profile(self, db):
+        """Audio profile for merge_id is reassigned to keep_id."""
+        ids = _set_up_alias_pair(db)
+        sun_ra = ids["Sun Ra"]
+        le_sonyr = ids["Le Sony'r Ra"]
+
+        db._conn.execute(
+            "INSERT INTO audio_profile (artist_id, avg_danceability, recording_count) "
+            "VALUES (?, 0.42, 15)",
+            (le_sonyr,),
+        )
+        db._conn.commit()
+
+        db.deduplicate_by_qid()
+
+        rows = db._conn.execute("SELECT artist_id FROM audio_profile").fetchall()
+        assert len(rows) == 1
+        assert rows[0][0] == sun_ra
+
+    def test_audio_profile_pk_conflict_keeps_survivor(self, db):
+        """When both aliases have audio profiles, keep_id's profile survives."""
+        ids = _set_up_alias_pair(db)
+        sun_ra = ids["Sun Ra"]
+        le_sonyr = ids["Le Sony'r Ra"]
+
+        db._conn.execute(
+            "INSERT INTO audio_profile (artist_id, avg_danceability, recording_count) "
+            "VALUES (?, 0.42, 15)",
+            (sun_ra,),
+        )
+        db._conn.execute(
+            "INSERT INTO audio_profile (artist_id, avg_danceability, recording_count) "
+            "VALUES (?, 0.38, 5)",
+            (le_sonyr,),
+        )
+        db._conn.commit()
+
+        db.deduplicate_by_qid()
+
+        rows = db._conn.execute("SELECT artist_id, recording_count FROM audio_profile").fetchall()
+        assert len(rows) == 1
+        assert rows[0][0] == sun_ra
+        # keep_id's profile (15 recordings) survives, merge_id's is deleted
+        assert rows[0][1] == 15
+
+
+# -- Artist style re-keying -------------------------------------------------
+
+
+class TestArtistStyleRekey:
+    """Verify that artist_style rows are re-keyed during dedup."""
+
+    def test_rekey_artist_style(self, db):
+        """Style tags for merge_id are reassigned to keep_id."""
+        ids = _set_up_alias_pair(db)
+        sun_ra = ids["Sun Ra"]
+        le_sonyr = ids["Le Sony'r Ra"]
+
+        db._conn.execute("INSERT INTO artist_style VALUES (?, 'Free Jazz')", (le_sonyr,))
+        db._conn.commit()
+
+        db.deduplicate_by_qid()
+
+        rows = db._conn.execute("SELECT artist_id, style_tag FROM artist_style").fetchall()
+        assert len(rows) == 1
+        assert rows[0] == (sun_ra, "Free Jazz")
+
+    def test_artist_style_pk_conflict(self, db):
+        """When both aliases have the same style tag, only one row survives."""
+        ids = _set_up_alias_pair(db)
+        sun_ra = ids["Sun Ra"]
+        le_sonyr = ids["Le Sony'r Ra"]
+
+        db._conn.execute("INSERT INTO artist_style VALUES (?, 'Free Jazz')", (sun_ra,))
+        db._conn.execute("INSERT INTO artist_style VALUES (?, 'Free Jazz')", (le_sonyr,))
+        db._conn.commit()
+
+        db.deduplicate_by_qid()
+
+        rows = db._conn.execute("SELECT artist_id, style_tag FROM artist_style").fetchall()
+        assert len(rows) == 1
+        assert rows[0] == (sun_ra, "Free Jazz")
+
+
+# -- Artist personnel re-keying ---------------------------------------------
+
+
+class TestArtistPersonnelRekey:
+    """Verify that artist_personnel rows are re-keyed during dedup."""
+
+    def test_rekey_artist_personnel(self, db):
+        """Personnel rows for merge_id are reassigned to keep_id."""
+        ids = _set_up_alias_pair(db)
+        sun_ra = ids["Sun Ra"]
+        le_sonyr = ids["Le Sony'r Ra"]
+
+        db._conn.execute(
+            "INSERT INTO artist_personnel VALUES (?, 'Marshall Allen', 'alto sax')",
+            (le_sonyr,),
+        )
+        db._conn.commit()
+
+        db.deduplicate_by_qid()
+
+        rows = db._conn.execute("SELECT artist_id, personnel_name FROM artist_personnel").fetchall()
+        assert len(rows) == 1
+        assert rows[0] == (sun_ra, "Marshall Allen")
+
+
+# -- Artist label re-keying --------------------------------------------------
+
+
+class TestArtistLabelRekey:
+    """Verify that artist_label rows are re-keyed during dedup."""
+
+    def test_rekey_artist_label(self, db):
+        """Label rows for merge_id are reassigned to keep_id."""
+        ids = _set_up_alias_pair(db)
+        sun_ra = ids["Sun Ra"]
+        le_sonyr = ids["Le Sony'r Ra"]
+
+        db._conn.execute(
+            "INSERT INTO artist_label VALUES (?, 'Saturn Records', NULL)",
+            (le_sonyr,),
+        )
+        db._conn.commit()
+
+        db.deduplicate_by_qid()
+
+        rows = db._conn.execute("SELECT artist_id, label_name FROM artist_label").fetchall()
+        assert len(rows) == 1
+        assert rows[0] == (sun_ra, "Saturn Records")
+
+    def test_artist_label_pk_conflict(self, db):
+        """When both aliases have the same label, only one row survives."""
+        ids = _set_up_alias_pair(db)
+        sun_ra = ids["Sun Ra"]
+        le_sonyr = ids["Le Sony'r Ra"]
+
+        db._conn.execute(
+            "INSERT INTO artist_label VALUES (?, 'Saturn Records', 100)",
+            (sun_ra,),
+        )
+        db._conn.execute(
+            "INSERT INTO artist_label VALUES (?, 'Saturn Records', 100)",
+            (le_sonyr,),
+        )
+        db._conn.commit()
+
+        db.deduplicate_by_qid()
+
+        rows = db._conn.execute("SELECT artist_id, label_name FROM artist_label").fetchall()
+        assert len(rows) == 1
+        assert rows[0] == (sun_ra, "Saturn Records")


### PR DESCRIPTION
Closes #163

## Summary

- Extends entity deduplication re-keying from only the 4 Discogs edge tables to all artist-referencing tables that persist across pipeline runs: `acoustic_similarity`, `wikidata_influence`, `audio_profile`, `artist_style`, `artist_label`, `artist_personnel`
- Refactors `_rekey_discogs_edges` into three methods by table shape: `_rekey_symmetric_edges` (undirected `artist_a_id`/`artist_b_id` edges), `_rekey_directed_edges` (`source_id`/`target_id` edges), `_rekey_single_artist_tables` (sole PK, composite PK, FK-only)
- Adds 15 new tests covering each table type's re-keying, self-loop deletion, and PK conflict resolution

## Test plan

- [x] All 26 unit tests pass (11 existing + 15 new)
- [x] ruff and black pass on changed files
- [ ] CI passes