### PR TITLE
Guard nightly sync scheduler to run in only one uvicorn worker

### DIFF
--- a/semantic_index/api/sync_scheduler.py
+++ b/semantic_index/api/sync_scheduler.py
@@ -13,12 +13,18 @@ Controlled by environment variables:
 from __future__ import annotations
 
 import argparse
+import fcntl
 import logging
 import threading
 import time
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
 
 logger = logging.getLogger(__name__)
+
+# Held at module level so the lock persists for the lifetime of the process.
+# Closing this file releases the flock; the OS releases it if the process dies.
+_lock_file = None
 
 
 def _seconds_until_next_run(hour_utc: int) -> float:
@@ -27,7 +33,7 @@ def _seconds_until_next_run(hour_utc: int) -> float:
     target = now.replace(hour=hour_utc, minute=0, second=0, microsecond=0)
     if target <= now:
         # Already past today's window — schedule for tomorrow
-        target = target.replace(day=target.day + 1)
+        target = target + timedelta(days=1)
     delta = (target - now).total_seconds()
     return delta
 
@@ -71,8 +77,11 @@ def start_scheduler(
     dsn: str,
     min_count: int = 2,
     hour_utc: int = 9,
-) -> threading.Thread:
+) -> threading.Thread | None:
     """Start the sync scheduler as a daemon thread.
+
+    Uses a file lock to ensure only one uvicorn worker runs the
+    scheduler. Returns ``None`` if another worker already holds the lock.
 
     Args:
         db_path: Path to the production SQLite database.
@@ -81,8 +90,20 @@ def start_scheduler(
         hour_utc: Hour (UTC) to run the daily sync.
 
     Returns:
-        The daemon thread (already started).
+        The daemon thread (already started), or None if the lock is held.
     """
+    global _lock_file  # noqa: PLW0603
+
+    lock_path = Path(db_path).with_suffix(".sync.lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        lock_fd = open(lock_path, "w")  # noqa: SIM115
+        fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        _lock_file = lock_fd  # prevent GC from closing/releasing the lock
+    except OSError:
+        logger.info("Sync scheduler lock held by another worker — skipping")
+        return None
+
     thread = threading.Thread(
         target=_scheduler_loop,
         args=(db_path, dsn, min_count, hour_utc),

--- a/tests/unit/test_sync_scheduler.py
+++ b/tests/unit/test_sync_scheduler.py
@@ -1,0 +1,117 @@
+"""Tests for the nightly sync scheduler."""
+
+import fcntl
+import threading
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import semantic_index.api.sync_scheduler as sched_mod
+from semantic_index.api.sync_scheduler import _seconds_until_next_run, start_scheduler
+
+
+@pytest.fixture(autouse=True)
+def _reset_lock():
+    """Reset the module-level lock between tests."""
+    old = sched_mod._lock_file
+    sched_mod._lock_file = None
+    yield
+    # Close if a test left a lock open
+    if sched_mod._lock_file is not None:
+        try:
+            sched_mod._lock_file.close()
+        except Exception:
+            pass
+    sched_mod._lock_file = old
+
+
+class TestStartSchedulerLock:
+    """Test file-lock guard for single-worker scheduling."""
+
+    def test_first_call_returns_thread(self, tmp_path: Path) -> None:
+        """First worker to call start_scheduler gets a Thread."""
+        db_path = str(tmp_path / "graph.db")
+        with patch("semantic_index.api.sync_scheduler._scheduler_loop"):
+            result = start_scheduler(db_path, dsn="postgresql://localhost/test")
+
+        assert isinstance(result, threading.Thread)
+
+    def test_second_call_returns_none(self, tmp_path: Path) -> None:
+        """Second call returns None when lock is already held."""
+        db_path = str(tmp_path / "graph.db")
+        with patch("semantic_index.api.sync_scheduler._scheduler_loop"):
+            first = start_scheduler(db_path, dsn="postgresql://localhost/test")
+            second = start_scheduler(db_path, dsn="postgresql://localhost/test")
+
+        assert isinstance(first, threading.Thread)
+        assert second is None
+
+    def test_lock_released_after_file_close(self, tmp_path: Path) -> None:
+        """After the lock file is closed, a new scheduler can acquire it."""
+        db_path = str(tmp_path / "graph.db")
+        lock_path = Path(db_path).with_suffix(".sync.lock")
+
+        # Manually acquire and release a lock
+        lock_file = open(lock_path, "w")
+        fcntl.flock(lock_file, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        lock_file.close()  # releases the lock
+
+        # Now start_scheduler should succeed
+        with patch("semantic_index.api.sync_scheduler._scheduler_loop"):
+            result = start_scheduler(db_path, dsn="postgresql://localhost/test")
+
+        assert isinstance(result, threading.Thread)
+
+    def test_lock_file_created_adjacent_to_db(self, tmp_path: Path) -> None:
+        """Lock file is created in the same directory as the database."""
+        db_path = str(tmp_path / "data" / "graph.db")
+        Path(db_path).parent.mkdir(parents=True)
+
+        with patch("semantic_index.api.sync_scheduler._scheduler_loop"):
+            start_scheduler(db_path, dsn="postgresql://localhost/test")
+
+        lock_path = Path(db_path).with_suffix(".sync.lock")
+        assert lock_path.exists()
+        assert lock_path.parent == Path(db_path).parent
+
+
+class TestSecondsUntilNextRun:
+    """Test the scheduling time computation."""
+
+    def test_future_hour_today(self) -> None:
+        """If the target hour hasn't passed yet today, schedules for today."""
+        # Fix time to 06:00 UTC, target 09:00 UTC → 3 hours
+        fake_now = datetime(2026, 4, 19, 6, 0, 0, tzinfo=UTC)
+        with patch("semantic_index.api.sync_scheduler.datetime") as mock_dt:
+            mock_dt.now.return_value = fake_now
+            mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+            result = _seconds_until_next_run(9)
+
+        assert result == 3 * 3600
+
+    def test_past_hour_schedules_tomorrow(self) -> None:
+        """If the target hour already passed, schedules for tomorrow."""
+        fake_now = datetime(2026, 4, 19, 10, 0, 0, tzinfo=UTC)
+        with patch("semantic_index.api.sync_scheduler.datetime") as mock_dt:
+            mock_dt.now.return_value = fake_now
+            mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+            result = _seconds_until_next_run(9)
+
+        # Should be ~23 hours, not negative
+        assert result > 0
+        assert abs(result - 23 * 3600) < 1
+
+    def test_end_of_month_wraps_correctly(self) -> None:
+        """Scheduling past the last day of a month rolls to the next month."""
+        # 11:00 UTC on Jan 31 with target hour 9 → should schedule Feb 1 at 09:00
+        fake_now = datetime(2026, 1, 31, 11, 0, 0, tzinfo=UTC)
+        with patch("semantic_index.api.sync_scheduler.datetime") as mock_dt:
+            mock_dt.now.return_value = fake_now
+            mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+            result = _seconds_until_next_run(9)
+
+        # Should be 22 hours (to Feb 1 09:00)
+        assert result > 0
+        assert abs(result - 22 * 3600) < 1


### PR DESCRIPTION
## Summary

- Add `fcntl.flock()` file lock to `start_scheduler()` so only one uvicorn worker runs the nightly sync scheduler. Other workers skip silently.
- Fix `_seconds_until_next_run()` crash on the last day of each month (`day+1` overflow, replaced with `timedelta(days=1)`)

Closes #152

## Context

After switching to `uvicorn --workers 4`, each forked worker independently called `start_scheduler()` at import time, spawning 4 daemon threads that all compete to run `nightly_sync()` at the same hour. This wastes CPU/IO and orphans temp files.

## Test plan

- [x] `test_first_call_returns_thread` — first worker gets a Thread
- [x] `test_second_call_returns_none` — second call returns None when lock is held
- [x] `test_lock_released_after_file_close` — lock is released when file is closed
- [x] `test_lock_file_created_adjacent_to_db` — lock file in same directory as database
- [x] `test_future_hour_today` — schedules for today when hour hasn't passed
- [x] `test_past_hour_schedules_tomorrow` — schedules for tomorrow when hour is past
- [x] `test_end_of_month_wraps_correctly` — Jan 31 → Feb 1 (regression for day+1 bug)
- [x] All pre-commit checks pass (ruff, ruff format, mypy)