### PR TITLE
Close lock file descriptor on flock failure

### DIFF
--- a/semantic_index/api/sync_scheduler.py
+++ b/semantic_index/api/sync_scheduler.py
@@ -101,6 +101,7 @@ def start_scheduler(
         fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
         _lock_file = lock_fd  # prevent GC from closing/releasing the lock
     except OSError:
+        lock_fd.close()
         logger.info("Sync scheduler lock held by another worker — skipping")
         return None
 


### PR DESCRIPTION
## Summary

Close the file descriptor in the `except OSError` block of `start_scheduler()` to prevent a leak when another worker already holds the lock.

## Context

Follow-up from PR #166 review: if `open()` succeeds but `fcntl.flock()` raises `OSError`, the fd was left open until GC collected it.