### PR TITLE
Handle mixed-format MB IDs and add --rebuild-all to recovery script

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -841,24 +841,33 @@ def run(args: argparse.Namespace) -> None:
             _ab_conn.close()
 
             if mb_rows:
-                # Resolve GIDs (UUIDs) to MB integer IDs via mb_artist table
-                gids = [row[1] for row in mb_rows]
-                mb_client = _MBClient(cache_dsn=args.musicbrainz_cache_dsn)
-                gid_to_int = mb_client.resolve_gids_to_ids(gids)
-
+                # Resolve MB IDs to integer IDs. The column contains a mix:
+                # - UUID/GID strings (from LML): need resolution via mb_artist
+                # - Integer strings (legacy): already are MB integer IDs
                 graph_id_to_mb: dict[int, int] = {}
+                uuid_rows: list[tuple] = []
                 for row in mb_rows:
-                    graph_id, gid = row[0], row[1]
-                    if gid in gid_to_int:
-                        graph_id_to_mb[graph_id] = gid_to_int[gid]
+                    if row[1].isdigit():
+                        graph_id_to_mb[row[0]] = int(row[1])
+                    else:
+                        uuid_rows.append(row)
+
+                if uuid_rows:
+                    mb_client = _MBClient(cache_dsn=args.musicbrainz_cache_dsn)
+                    gid_to_int = mb_client.resolve_gids_to_ids([r[1] for r in uuid_rows])
+                    for row in uuid_rows:
+                        if row[1] in gid_to_int:
+                            graph_id_to_mb[row[0]] = gid_to_int[row[1]]
+
                 mb_to_graph_id = {v: k for k, v in graph_id_to_mb.items()}
                 mb_ids = list(graph_id_to_mb.values())
 
                 skipped = len(mb_rows) - len(graph_id_to_mb)
                 log.info(
-                    "  Resolved %d/%d GIDs to MB integer IDs (%d skipped)",
+                    "  %d MB IDs resolved (%d legacy int, %d UUID; %d skipped)",
                     len(graph_id_to_mb),
-                    len(mb_rows),
+                    len(mb_rows) - len(uuid_rows),
+                    len(graph_id_to_mb) - (len(mb_rows) - len(uuid_rows)),
                     skipped,
                 )
 
@@ -922,23 +931,30 @@ def run(args: argparse.Namespace) -> None:
             _ab_conn.close()
 
             if mb_rows:
-                # Resolve GIDs (UUIDs) to MB integer IDs via mb_artist table
-                gids = [row[1] for row in mb_rows]
-                gid_to_int = mb_client.resolve_gids_to_ids(gids)
-
+                # Resolve MB IDs to integer IDs (mixed format — see PG path above)
                 graph_id_to_mb: dict[int, int] = {}
+                uuid_rows: list[tuple] = []
                 for row in mb_rows:
-                    graph_id, gid = row[0], row[1]
-                    if gid in gid_to_int:
-                        graph_id_to_mb[graph_id] = gid_to_int[gid]
+                    if row[1].isdigit():
+                        graph_id_to_mb[row[0]] = int(row[1])
+                    else:
+                        uuid_rows.append(row)
+
+                if uuid_rows:
+                    gid_to_int = mb_client.resolve_gids_to_ids([r[1] for r in uuid_rows])
+                    for row in uuid_rows:
+                        if row[1] in gid_to_int:
+                            graph_id_to_mb[row[0]] = gid_to_int[row[1]]
+
                 mb_to_graph_id = {v: k for k, v in graph_id_to_mb.items()}
                 mb_ids = list(graph_id_to_mb.values())
 
                 skipped = len(mb_rows) - len(graph_id_to_mb)
                 log.info(
-                    "  Resolved %d/%d GIDs to MB integer IDs (%d skipped)",
+                    "  %d MB IDs resolved (%d legacy int, %d UUID; %d skipped)",
                     len(graph_id_to_mb),
-                    len(mb_rows),
+                    len(mb_rows) - len(uuid_rows),
+                    len(graph_id_to_mb) - (len(mb_rows) - len(uuid_rows)),
                     skipped,
                 )
 

--- a/scripts/recover_audio_profiles.py
+++ b/scripts/recover_audio_profiles.py
@@ -60,6 +60,7 @@ def recover(
     min_recordings: int = DEFAULT_MIN_RECORDINGS,
     similarity_threshold: float = DEFAULT_SIMILARITY_THRESHOLD,
     dry_run: bool = False,
+    rebuild_all: bool = False,
 ) -> dict[str, int]:
     """Run the audio profile recovery pipeline.
 
@@ -69,6 +70,7 @@ def recover(
         min_recordings: Minimum recordings to build a profile.
         similarity_threshold: Cosine similarity threshold for edges.
         dry_run: If True, write to temp but skip the atomic swap.
+        rebuild_all: If True, clear existing profiles before finding candidates.
 
     Returns:
         Dict with recovery statistics (profiles_before, profiles_after,
@@ -101,6 +103,17 @@ def recover(
             "SELECT COUNT(*) FROM acoustic_similarity"
         ).fetchone()[0]
 
+        # Clear existing profiles if rebuilding all (e.g. for dimension migration)
+        if rebuild_all:
+            conn.execute("DELETE FROM acoustic_similarity")
+            conn.execute("DELETE FROM audio_profile")
+            conn.commit()
+            logger.info(
+                "Cleared %d profiles and %d similarity edges for rebuild",
+                stats["profiles_before"],
+                stats["similarity_before"],
+            )
+
         # Step 1: Find candidates
         candidates = find_recovery_candidates(conn)
         stats["candidates"] = len(candidates)
@@ -118,15 +131,40 @@ def recover(
             )
             return stats
 
-        # Step 2: Resolve GIDs → integer IDs
-        mb_client = MusicBrainzClient(cache_dsn=musicbrainz_cache_dsn)
-        gids = list({row[1] for row in candidates})
-        gid_to_int = mb_client.resolve_gids_to_ids(gids)
-        stats["resolved"] = len(gid_to_int)
-        logger.info("Resolved %d/%d unique GIDs to integer IDs", len(gid_to_int), len(gids))
+        # Step 2: Resolve MB IDs → integer IDs
+        # The musicbrainz_artist_id column contains a mix of formats:
+        # - UUID/GID strings (from LML identity import): need resolution via mb_artist
+        # - Integer strings (legacy, pre-LML): already are MB integer IDs
+        graph_id_to_int: dict[int, int] = {}
+        uuid_candidates: list[tuple[int, str]] = []
 
-        if not gid_to_int:
-            logger.warning("No GIDs resolved — check mb_artist.gid column (#153)")
+        for graph_id, mb_id in candidates:
+            if mb_id.isdigit():
+                graph_id_to_int[graph_id] = int(mb_id)
+            else:
+                uuid_candidates.append((graph_id, mb_id))
+
+        logger.info(
+            "%d legacy integer IDs, %d UUID GIDs to resolve",
+            len(graph_id_to_int),
+            len(uuid_candidates),
+        )
+
+        if uuid_candidates:
+            mb_client = MusicBrainzClient(cache_dsn=musicbrainz_cache_dsn)
+            gids = list({row[1] for row in uuid_candidates})
+            gid_to_int = mb_client.resolve_gids_to_ids(gids)
+            logger.info("Resolved %d/%d unique GIDs to integer IDs", len(gid_to_int), len(gids))
+
+            for graph_id, gid in uuid_candidates:
+                int_id = gid_to_int.get(gid)
+                if int_id is not None:
+                    graph_id_to_int[graph_id] = int_id
+
+        stats["resolved"] = len(graph_id_to_int)
+
+        if not graph_id_to_int:
+            logger.warning("No MB IDs resolved — check mb_artist.gid column (#153)")
             conn.close()
             temp_path.unlink(missing_ok=True)
             stats.update(
@@ -137,12 +175,6 @@ def recover(
             return stats
 
         # Step 3: Map graph IDs to MB integer IDs
-        graph_id_to_int: dict[int, int] = {}
-        for graph_id, gid in candidates:
-            int_id = gid_to_int.get(gid)
-            if int_id is not None:
-                graph_id_to_int[graph_id] = int_id
-
         int_to_graph_id = {v: k for k, v in graph_id_to_int.items()}
         mb_ids = list(graph_id_to_int.values())
         logger.info("%d candidate artists with resolved integer IDs", len(mb_ids))
@@ -248,6 +280,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help=f"Cosine similarity threshold for edges (default: {DEFAULT_SIMILARITY_THRESHOLD})",
     )
     parser.add_argument(
+        "--rebuild-all",
+        action="store_true",
+        help="Clear existing profiles and rebuild from scratch (e.g. for dimension migration)",
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         help="Run recovery but skip the atomic swap",
@@ -282,6 +319,7 @@ def main(argv: list[str] | None = None) -> None:
         min_recordings=args.min_recordings,
         similarity_threshold=args.acoustic_similarity_threshold,
         dry_run=args.dry_run,
+        rebuild_all=args.rebuild_all,
     )
     elapsed = time.time() - t0
     logger.info("Done in %.1fs: %s", elapsed, stats)


### PR DESCRIPTION
## Summary

- Partition `musicbrainz_artist_id` values by format: integer strings (legacy) are used directly as MB IDs, UUID strings (from LML) go through `resolve_gids_to_ids()`. Fixes `psycopg.errors.InvalidTextRepresentation` when casting integer strings as UUID.
- Add `--rebuild-all` flag to `recover_audio_profiles.py` for clearing existing profiles before rebuilding (needed for 36-dim to 59-dim migration)
- Fix both PG and tar code paths in `run_pipeline.py`

## Context

The `musicbrainz_artist_id` column contains ~10K legacy integer IDs and ~22K UUID/GID strings. The previous code sent all values to `resolve_gids_to_ids()`, which failed on integer strings like `"3054276"` with `invalid input syntax for type uuid`.

Successfully used `--rebuild-all` to rebuild all 22,301 audio profiles as 59-dim vectors with 101M similarity edges.

## Test plan

- [x] 645 unit tests pass
- [x] ruff, black, mypy pass
- [x] Full rebuild completed successfully with `--rebuild-all`