### PR TITLE
Remove discovery endpoint, scope acoustic similarity to narrative

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,14 +43,14 @@ SQLite ──→ api (FastAPI + aiosqlite) ──→ JSON responses
 | `semantic_index/acousticbrainz.py` | Load AcousticBrainz high-level features, aggregate per-artist audio profiles (59-dim feature vector across 18 classifiers), compute cosine similarity edges. Supports both PG and tar-based loading. |
 | `semantic_index/acousticbrainz_client.py` | PostgreSQL client for AcousticBrainz features. Queries `ab_recording` in musicbrainz-cache, joining with `mb_artist_recording` for per-artist feature retrieval. Preferred over tar-based loading. |
 | `semantic_index/musicbrainz_client.py` | MusicBrainz cache client: recording MBID resolution via `mb_artist_recording` materialized view. Identity resolution methods (lookup_by_name, batch_lookup) have been moved to LML. |
-| `semantic_index/graph_metrics.py` | Compute and persist Louvain communities, betweenness centrality, PageRank, and discovery scores to the SQLite database. Uses `wxyc_etl.text.is_compilation_artist` to filter compilation entries. Idempotent post-processing step runnable standalone or as a pipeline step. |
+| `semantic_index/graph_metrics.py` | Compute and persist Louvain communities, betweenness centrality, and PageRank to the SQLite database. Uses `wxyc_etl.text.is_compilation_artist` to filter compilation entries. Idempotent post-processing step runnable standalone or as a pipeline step. |
 | `semantic_index/graph_export.py` | Build NetworkX graph and export GEXF. |
 | `semantic_index/sqlite_export.py` | Build and export SQLite graph database with enrichment and edge tables. Supports optional PipelineDB integration for persistent artist identities. |
 | `semantic_index/facet_export.py` | Export play-level data and pre-materialized aggregate tables for dynamic faceted PMI computation. Creates dj, play, artist_month_count, artist_dj_count, month_total, and dj_total tables. |
 | `semantic_index/api/app.py` | FastAPI application factory. Takes a SQLite database path, returns a configured app. |
 | `semantic_index/api/database.py` | Request-scoped SQLite connection dependency for FastAPI. |
-| `semantic_index/api/schemas.py` | Pydantic response models for the Graph API (ArtistSummary, ArtistDetail, EntityArtists, SearchResponse, NeighborsResponse, ExplainResponse, FacetsResponse, DjSummary, NarrativeResponse, CommunitiesResponse, DiscoveryResponse, PreviewResponse). |
-| `semantic_index/api/routes.py` | Graph API query endpoints: search, artist detail, neighbors by edge type (with optional month/DJ facet filters), explain relationships, entity artist groups, available facets, community metadata, discovery (underplayed sonic fits). |
+| `semantic_index/api/schemas.py` | Pydantic response models for the Graph API (ArtistSummary, ArtistDetail, EntityArtists, SearchResponse, NeighborsResponse, ExplainResponse, FacetsResponse, DjSummary, NarrativeResponse, CommunitiesResponse, PreviewResponse). |
+| `semantic_index/api/routes.py` | Graph API query endpoints: search, artist detail, neighbors by edge type (with optional month/DJ facet filters), explain relationships, entity artist groups, available facets, community metadata. |
 | `semantic_index/api/narrative.py` | LLM-generated edge narrative endpoint. Calls Claude Haiku to explain artist relationships in plain English. Caches results in a sidecar SQLite database. Facet-aware. |
 | `semantic_index/api/preview.py` | Audio preview URL endpoint with multi-source fallback (iTunes lookup, Spotify, Bandcamp, Deezer, iTunes search). Caches results in a sidecar SQLite database. Powers the in-card transition player in the graph explorer. |
 | `semantic_index/pg_source.py` | Query Backend-Service PostgreSQL (`wxyc_schema.*`) for pipeline input data. Returns the same types as `sql_parser.py` (FlowsheetEntry, LibraryCode, LibraryRelease). Used by the nightly sync instead of SQL dump parsing. |
@@ -91,9 +91,6 @@ CREATE TABLE artist (
     community_id INTEGER,          -- Louvain community assignment
     betweenness REAL,              -- Betweenness centrality
     pagerank REAL,                 -- PageRank score
-    discovery_score REAL,          -- acoustic_neighbor_count / (dj_edge_count + 1)
-    dj_edge_count INTEGER,         -- Undirected degree in transition graph
-    acoustic_neighbor_count INTEGER, -- Acoustic neighbors at similarity >= 0.95
     request_ratio REAL NOT NULL DEFAULT 0.0,
     show_count INTEGER NOT NULL DEFAULT 0
 );
@@ -386,7 +383,6 @@ app = create_app("data/wxyc_artist_graph.db")
 | `GET` | `/graph/entities/{id}/artists` | All artists sharing an entity (alias group). Returns entity metadata and a list of artist summaries. |
 | `GET` | `/graph/facets` | Available facet values (months with data, DJ list) for filtering. Gracefully returns empty lists on databases without facet tables. |
 | `GET` | `/graph/communities?min_size=5&limit=50` | Louvain community metadata (size, label, top genres, top artists). Gracefully returns empty on databases without the `community` table. |
-| `GET` | `/graph/discovery?limit=25&community_id=&genre=` | Underplayed sonic fits: artists with high acoustic similarity but few DJ transitions, ordered by discovery score descending. Optional community/genre filters. Returns empty on databases without graph metrics. |
 | `GET` | `/graph/artists/{id}/explain/{target_id}/narrative?month=&dj_id=` | LLM-generated natural-language explanation of the relationship between two artists. Uses Claude Haiku. Cached in sidecar SQLite DB. Returns 501 when `ANTHROPIC_API_KEY` is not set. |
 | `GET` | `/graph/artists/{id}/preview` | Audio preview URL for an artist. Multi-source fallback: iTunes lookup (by Apple Music ID) -> Spotify top tracks (by Spotify ID, requires credentials) -> Bandcamp (by bandcamp_id, scrapes track stream) -> Deezer search (by name) -> iTunes search (by name). Cached in sidecar `.preview-cache.db`. |
 

--- a/semantic_index/api/routes.py
+++ b/semantic_index/api/routes.py
@@ -22,8 +22,6 @@ from semantic_index.api.schemas import (
     BatchNeighborsResponse,
     CommunitiesResponse,
     CommunityDetail,
-    DiscoveryEntry,
-    DiscoveryResponse,
     DjSummary,
     EntityArtists,
     ExplainResponse,
@@ -276,48 +274,6 @@ def get_communities(
     except sqlite3.OperationalError:
         total = 0
     return CommunitiesResponse(communities=communities, total_artists=total)
-
-
-@router.get("/discovery", response_model=DiscoveryResponse)
-def get_discovery(
-    limit: int = Query(default=25, ge=1, le=100),
-    community_id: int | None = Query(default=None),
-    genre: str | None = Query(default=None),
-    db: sqlite3.Connection = Depends(get_db),
-) -> DiscoveryResponse:
-    """Return underplayed sonic fits — artists acoustically similar to many but rarely placed by DJs."""
-    _init_metrics_flag(db)
-    try:
-        sql = (
-            f"SELECT {_scols()}, discovery_score, dj_edge_count, acoustic_neighbor_count "  # noqa: S608
-            "FROM artist "
-            "WHERE discovery_score IS NOT NULL AND discovery_score > 0 "
-        )
-        params: list = []
-        if community_id is not None:
-            sql += "AND community_id = ? "
-            params.append(community_id)
-        if genre is not None:
-            sql += "AND genre = ? "
-            params.append(genre)
-        sql += "ORDER BY discovery_score DESC LIMIT ?"
-        params.append(limit)
-
-        rows = db.execute(sql, params).fetchall()
-    except sqlite3.OperationalError:
-        return DiscoveryResponse(results=[])
-
-    return DiscoveryResponse(
-        results=[
-            DiscoveryEntry(
-                artist=_artist_summary(r),
-                discovery_score=r["discovery_score"],
-                dj_edge_count=r["dj_edge_count"],
-                acoustic_neighbor_count=r["acoustic_neighbor_count"],
-            )
-            for r in rows
-        ]
-    )
 
 
 @router.get("/artists/{artist_id}", response_model=ArtistDetail)

--- a/semantic_index/api/schemas.py
+++ b/semantic_index/api/schemas.py
@@ -163,21 +163,6 @@ class CommunitiesResponse(BaseModel):
     total_artists: int = 0
 
 
-class DiscoveryEntry(BaseModel):
-    """An underplayed artist with high acoustic similarity."""
-
-    artist: ArtistSummary
-    discovery_score: float
-    dj_edge_count: int
-    acoustic_neighbor_count: int
-
-
-class DiscoveryResponse(BaseModel):
-    """Response for GET /graph/discovery."""
-
-    results: list[DiscoveryEntry]
-
-
 class PreviewResponse(BaseModel):
     """Response for GET /graph/artists/{id}/preview.
 

--- a/semantic_index/graph_metrics.py
+++ b/semantic_index/graph_metrics.py
@@ -30,9 +30,6 @@ _GRAPH_METRIC_COLUMNS = [
     ("community_id", "INTEGER"),
     ("betweenness", "REAL"),
     ("pagerank", "REAL"),
-    ("discovery_score", "REAL"),
-    ("dj_edge_count", "INTEGER"),
-    ("acoustic_neighbor_count", "INTEGER"),
 ]
 
 _COMMUNITY_TABLE_SCHEMA = """\
@@ -45,9 +42,6 @@ CREATE TABLE IF NOT EXISTS community (
 );
 CREATE INDEX IF NOT EXISTS idx_artist_community ON artist(community_id);
 """
-
-# Acoustic similarity threshold for discovery scoring
-_ACOUSTIC_DISCOVERY_THRESHOLD = 0.95
 
 
 @dataclass
@@ -118,45 +112,6 @@ def _compute_centrality(
     logger.info("  done in %.1fs", time.time() - t0)
 
     return betweenness, pagerank
-
-
-def _compute_discovery_scores(
-    conn: sqlite3.Connection,
-    g_undirected: nx.Graph,
-    graph_nodes: set[int],
-) -> dict[int, tuple[float, int, int]]:
-    """Compute discovery scores: acoustic_neighbor_count / (dj_degree + 1).
-
-    Returns {artist_id: (score, dj_edge_count, acoustic_neighbor_count)}.
-
-    acoustic_neighbor_count is computed by querying acoustic_similarity with
-    similarity >= 0.95. dj_edge_count is the undirected degree in the transition
-    graph. If acoustic_similarity table is empty or missing, all scores are 0.
-    """
-    # Count acoustic neighbors per artist (above threshold)
-    acoustic_degree: Counter[int] = Counter()
-    try:
-        rows = conn.execute(
-            "SELECT artist_a_id, artist_b_id FROM acoustic_similarity WHERE similarity >= ?",
-            (_ACOUSTIC_DISCOVERY_THRESHOLD,),
-        ).fetchall()
-        for a, b in rows:
-            if a in graph_nodes:
-                acoustic_degree[a] += 1
-            if b in graph_nodes:
-                acoustic_degree[b] += 1
-    except sqlite3.OperationalError:
-        # Table doesn't exist
-        logger.info("No acoustic_similarity table found, discovery scores will be 0")
-
-    results: dict[int, tuple[float, int, int]] = {}
-    for node in graph_nodes:
-        dj_deg = g_undirected.degree(node)
-        ac_deg = acoustic_degree.get(node, 0)
-        score = ac_deg / (dj_deg + 1) if ac_deg > 0 else 0.0
-        results[node] = (score, dj_deg, ac_deg)
-
-    return results
 
 
 def _build_community_metadata(
@@ -233,24 +188,17 @@ def _persist(
     communities_meta: list[dict],
     betweenness: dict[int, float],
     pagerank: dict[int, float],
-    discovery: dict[int, tuple[float, int, int]],
 ) -> None:
     """Clear old metrics and write new values."""
-    conn.execute(
-        "UPDATE artist SET community_id = NULL, betweenness = NULL, pagerank = NULL, "
-        "discovery_score = NULL, dj_edge_count = NULL, acoustic_neighbor_count = NULL"
-    )
+    conn.execute("UPDATE artist SET community_id = NULL, betweenness = NULL, pagerank = NULL")
     conn.execute("DELETE FROM community")
 
     for artist_id, comm_id in node_community.items():
         bc = betweenness.get(artist_id, 0.0)
         pr = pagerank.get(artist_id, 0.0)
-        score, dj_deg, ac_deg = discovery.get(artist_id, (0.0, 0, 0))
         conn.execute(
-            "UPDATE artist SET community_id = ?, betweenness = ?, pagerank = ?, "
-            "discovery_score = ?, dj_edge_count = ?, acoustic_neighbor_count = ? "
-            "WHERE id = ?",
-            (comm_id, bc, pr, score, dj_deg, ac_deg, artist_id),
+            "UPDATE artist SET community_id = ?, betweenness = ?, pagerank = ? WHERE id = ?",
+            (comm_id, bc, pr, artist_id),
         )
 
     # Insert community metadata
@@ -295,14 +243,11 @@ def compute_and_persist(db_path: str, *, seed: int = 42, bc_k: int = 2000) -> Gr
     logger.info("Computing centrality...")
     betweenness, pagerank = _compute_centrality(directed, undirected, bc_k=bc_k)
 
-    logger.info("Computing discovery scores...")
-    discovery = _compute_discovery_scores(conn, undirected, graph_nodes)
-
     logger.info("Building community metadata...")
     communities_meta = _build_community_metadata(communities, artists, conn)
 
     logger.info("Persisting results...")
-    _persist(conn, node_community, communities_meta, betweenness, pagerank, discovery)
+    _persist(conn, node_community, communities_meta, betweenness, pagerank)
 
     conn.close()
 

--- a/tests/unit/test_api_discovery.py
+++ b/tests/unit/test_api_discovery.py
@@ -145,41 +145,6 @@ class TestCommunities:
         assert resp.json()["communities"] == []
 
 
-class TestDiscovery:
-    @pytest.mark.asyncio
-    async def test_returns_scored_artists(self, client):
-        resp = await client.get("/graph/discovery", params={"limit": 10})
-        assert resp.status_code == 200
-        data = resp.json()
-        assert "results" in data
-        assert len(data["results"]) > 0
-        # Scores should be descending
-        scores = [r["discovery_score"] for r in data["results"]]
-        assert scores == sorted(scores, reverse=True)
-
-    @pytest.mark.asyncio
-    async def test_entry_has_expected_fields(self, client):
-        resp = await client.get("/graph/discovery", params={"limit": 1})
-        entry = resp.json()["results"][0]
-        assert "artist" in entry
-        assert "discovery_score" in entry
-        assert "dj_edge_count" in entry
-        assert "acoustic_neighbor_count" in entry
-        assert entry["discovery_score"] > 0
-
-    @pytest.mark.asyncio
-    async def test_community_filter(self, client):
-        resp = await client.get("/graph/discovery", params={"community_id": 9999})
-        assert resp.status_code == 200
-        assert resp.json()["results"] == []
-
-    @pytest.mark.asyncio
-    async def test_graceful_on_old_schema(self, plain_client):
-        resp = await plain_client.get("/graph/discovery")
-        assert resp.status_code == 200
-        assert resp.json()["results"] == []
-
-
 class TestArtistSummaryIncludesMetrics:
     @pytest.mark.asyncio
     async def test_search_includes_community_id(self, client):

--- a/tests/unit/test_graph_metrics.py
+++ b/tests/unit/test_graph_metrics.py
@@ -110,9 +110,6 @@ class TestEnsureSchema:
         assert "community_id" in cols
         assert "betweenness" in cols
         assert "pagerank" in cols
-        assert "discovery_score" in cols
-        assert "dj_edge_count" in cols
-        assert "acoustic_neighbor_count" in cols
         conn.close()
 
     def test_creates_community_table(self):
@@ -198,35 +195,6 @@ class TestComputeAndPersist:
         # Largest communities should have at least 3 members
         assert rows[0]["size"] >= 3
         assert rows[0]["label"] is not None
-        conn.close()
-
-    def test_discovery_scores_from_acoustic(self):
-        path = _build_fixture_db(with_acoustic=True)
-        compute_and_persist(path)
-
-        conn = sqlite3.connect(path)
-        conn.row_factory = sqlite3.Row
-        # Artists with within-cluster acoustic neighbors at >= 0.95 should have positive scores
-        rows = conn.execute(
-            "SELECT canonical_name, discovery_score, dj_edge_count, acoustic_neighbor_count "
-            "FROM artist WHERE discovery_score IS NOT NULL AND discovery_score > 0"
-        ).fetchall()
-        assert len(rows) > 0
-        for r in rows:
-            assert r["acoustic_neighbor_count"] > 0
-            assert r["dj_edge_count"] >= 0
-        conn.close()
-
-    def test_discovery_scores_zero_without_acoustic(self):
-        path = _build_fixture_db(with_acoustic=False)
-        compute_and_persist(path)
-
-        conn = sqlite3.connect(path)
-        conn.row_factory = sqlite3.Row
-        rows = conn.execute(
-            "SELECT discovery_score FROM artist WHERE discovery_score > 0"
-        ).fetchall()
-        assert len(rows) == 0
         conn.close()
 
     def test_returns_report(self):


### PR DESCRIPTION
## Summary

- Remove `/graph/discovery` endpoint and its supporting `DiscoveryEntry`/`DiscoveryResponse` schemas
- Remove discovery score computation (`discovery_score`, `dj_edge_count`, `acoustic_neighbor_count`) from `graph_metrics.py`
- Acoustic similarity stays in `EDGE_REGISTRY` for affinity scoring and explain/narrative context

## Context

DJ transitions are the sole navigation signal in the Freeform Map. Acoustic similarity (from AcousticBrainz classifiers trained on MusicBrainz genre/mood labels) embeds mainstream consensus that could gravitate the map away from WXYC's freeform curation. It remains available as narrative context for explaining DJ transitions and contributes to affinity scoring, but is no longer a standalone discovery axis.

## Test plan

- [x] 639 unit tests pass
- [x] ruff check/format, mypy pass
- [x] Discovery tests removed; community and acoustic similarity neighbor tests preserved