### PR TITLE
Replace black with ruff format

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,7 +247,7 @@ Summary tables (`artist_style_summary`, `artist_personnel_summary`, `artist_labe
 ### Code Style
 
 - Python 3.12+
-- black (100 char line length)
+- ruff format (100 char line length)
 - ruff (100 char, rules: E, W, F, I, N, UP, B, C4)
 - mypy with pydantic plugin
 - TDD: write failing test first, then implement

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The pipeline depends on `wxyc-etl`, a shared Rust/PyO3 package providing text no
 pytest                    # unit tests
 pytest -m integration     # integration tests (needs fixture dump)
 ruff check .              # lint
-black --check .           # format check
+ruff format --check .     # format check
 mypy .                    # type check
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ dev = [
     "pytest-cov>=4.0.0",
     "pytest-asyncio>=0.23",
     "httpx>=0.25",
-    "black>=23.0.0",
     "ruff>=0.4.0",
     "mypy>=1.0.0",
     "types-networkx>=3.0",
@@ -51,10 +50,6 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
 include = ["semantic_index*"]
-
-[tool.black]
-line-length = 100
-target-version = ['py312']
 
 [tool.ruff]
 line-length = 100


### PR DESCRIPTION
## Summary

- Remove `black` from dev dependencies — `ruff format` is already used by the pre-commit hook and produces identical output
- Remove `[tool.black]` config section from `pyproject.toml`
- Update `README.md` and `CLAUDE.md` to reference `ruff format`

## Test plan

- [x] Pre-commit hook passes (already uses `ruff format`)
- [x] All 639 unit tests pass
- [x] mypy passes