### PR TITLE
Deduplicate database connection, caching, and batch patterns

### DIFF
--- a/scripts/recover_audio_profiles.py
+++ b/scripts/recover_audio_profiles.py
@@ -226,10 +226,12 @@ def recover(
         conn.close()
 
         # Close PG connections
-        if mb_client._cache_conn and not mb_client._cache_conn.closed:
-            mb_client._cache_conn.close()
-        if ab_client._conn and not ab_client._conn.closed:
-            ab_client._conn.close()
+        pg_conn = mb_client._pg._conn
+        if pg_conn and not pg_conn.closed:
+            pg_conn.close()
+        pg_conn = ab_client._pg._conn
+        if pg_conn and not pg_conn.closed:
+            pg_conn.close()
 
         # Step 9: Checkpoint and swap
         checkpoint_and_close(str(temp_path))

--- a/semantic_index/acousticbrainz_client.py
+++ b/semantic_index/acousticbrainz_client.py
@@ -9,8 +9,6 @@ JOIN query.
 import json
 import logging
 
-import psycopg
-
 from semantic_index.acousticbrainz import (
     GENRE_ELECTRONIC_LABELS,
     GENRE_LABELS,
@@ -20,6 +18,7 @@ from semantic_index.acousticbrainz import (
     RHYTHM_LABELS,
     RecordingFeatures,
 )
+from semantic_index.utils import LazyPgConnection, batched_with_log
 
 logger = logging.getLogger(__name__)
 
@@ -69,18 +68,11 @@ class AcousticBrainzClient:
     """
 
     def __init__(self, cache_dsn: str) -> None:
-        self._cache_dsn = cache_dsn
-        self._conn: psycopg.Connection | None = None
+        self._pg = LazyPgConnection(cache_dsn, "musicbrainz database")
 
-    def _get_conn(self) -> psycopg.Connection | None:
+    def _get_conn(self):
         """Get or create the PostgreSQL connection."""
-        if self._conn is None or self._conn.closed:
-            try:
-                self._conn = psycopg.connect(self._cache_dsn, autocommit=True)
-            except Exception:
-                logger.warning("Failed to connect to musicbrainz database", exc_info=True)
-                return None
-        return self._conn
+        return self._pg.get()
 
     def get_features_for_artists(
         self, mb_artist_ids: list[int]
@@ -105,9 +97,7 @@ class AcousticBrainzClient:
 
         try:
             result: dict[int, list[RecordingFeatures]] = {}
-            batch_size = 1000
-            for i in range(0, len(mb_artist_ids), batch_size):
-                batch = mb_artist_ids[i : i + batch_size]
+            for batch in batched_with_log(mb_artist_ids, label="AB feature lookup"):
                 rows = conn.execute(
                     f"SELECT {_SELECT_COLS} "
                     "FROM mb_artist_recording mar "
@@ -120,13 +110,6 @@ class AcousticBrainzClient:
                     artist_id = row[0]
                     features = _parse_row(row)
                     result.setdefault(artist_id, []).append(features)
-
-                if (i + batch_size) % 5000 == 0:
-                    logger.info(
-                        "  AB feature lookup: %d/%d artist batches",
-                        i // batch_size + 1,
-                        (len(mb_artist_ids) + batch_size - 1) // batch_size,
-                    )
 
             total_recordings = sum(len(v) for v in result.values())
             logger.info(

--- a/semantic_index/api/bio.py
+++ b/semantic_index/api/bio.py
@@ -15,7 +15,7 @@ from datetime import UTC, datetime
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Request
 
-from semantic_index.api.database import get_db
+from semantic_index.api.database import get_db, open_cache_db
 from semantic_index.api.schemas import BandcampAlbumResponse, BioResponse
 
 logger = logging.getLogger(__name__)
@@ -197,12 +197,7 @@ _WIKI_USER_AGENT = "WXYCSemanticIndex/0.1 (https://wxyc.org; engineering@wxyc.or
 
 def _get_cache_db(db_path: str) -> sqlite3.Connection:
     """Open a writable connection to the sidecar bio cache database."""
-    cache_path = db_path + ".bio-cache.db"
-    conn = sqlite3.connect(cache_path, check_same_thread=False)
-    conn.row_factory = sqlite3.Row
-    conn.execute("PRAGMA journal_mode=WAL")
-    conn.executescript(_CACHE_SCHEMA)
-    return conn
+    return open_cache_db(db_path, "bio", _CACHE_SCHEMA)
 
 
 def _generated_summary(detail: dict) -> str:

--- a/semantic_index/api/database.py
+++ b/semantic_index/api/database.py
@@ -24,3 +24,22 @@ def get_db(request: Request):
     """Yield a read-only SQLite connection scoped to a single request."""
     with _open_db(request.app.state.db_path) as conn:
         yield conn
+
+
+def open_cache_db(db_path: str, suffix: str, schema: str) -> sqlite3.Connection:
+    """Open a writable connection to a sidecar cache database.
+
+    Creates ``{db_path}.{suffix}-cache.db`` with WAL mode and ``sqlite3.Row``
+    row factory, then runs *schema* via ``executescript``.
+
+    Args:
+        db_path: Path to the main graph database.
+        suffix: Cache name inserted into the sidecar filename.
+        schema: SQL DDL to execute (idempotent ``CREATE TABLE IF NOT EXISTS``).
+    """
+    cache_path = db_path + f".{suffix}-cache.db"
+    conn = sqlite3.connect(cache_path, check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.executescript(schema)
+    return conn

--- a/semantic_index/api/narrative.py
+++ b/semantic_index/api/narrative.py
@@ -56,7 +56,11 @@ CREATE TABLE IF NOT EXISTS narrative_cache (
 
 
 def _get_cache_db(db_path: str) -> sqlite3.Connection:
-    """Open a writable connection to the sidecar narrative cache database."""
+    """Open a writable connection to the sidecar narrative cache database.
+
+    Includes a migration that drops the old schema (PK without ``edge_type``)
+    before creating the current one. Safe because this is a regenerable cache.
+    """
     cache_path = db_path + ".narrative-cache.db"
     conn = sqlite3.connect(cache_path, check_same_thread=False)
     conn.row_factory = sqlite3.Row

--- a/semantic_index/api/preview.py
+++ b/semantic_index/api/preview.py
@@ -16,7 +16,7 @@ from datetime import UTC, datetime
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Request
 
-from semantic_index.api.database import get_db
+from semantic_index.api.database import get_db, open_cache_db
 from semantic_index.api.schemas import PreviewResponse
 
 logger = logging.getLogger(__name__)
@@ -40,12 +40,7 @@ CREATE TABLE IF NOT EXISTS preview_cache (
 
 def _get_cache_db(db_path: str) -> sqlite3.Connection:
     """Open a writable connection to the sidecar preview cache database."""
-    cache_path = db_path + ".preview-cache.db"
-    conn = sqlite3.connect(cache_path, check_same_thread=False)
-    conn.row_factory = sqlite3.Row
-    conn.execute("PRAGMA journal_mode=WAL")
-    conn.executescript(_CACHE_SCHEMA)
-    return conn
+    return open_cache_db(db_path, "preview", _CACHE_SCHEMA)
 
 
 def _http_get(url: str, **kwargs) -> httpx.Response:

--- a/semantic_index/discogs_client.py
+++ b/semantic_index/discogs_client.py
@@ -32,6 +32,7 @@ from semantic_index.models import (
     SharedPersonnelEdge,
     SharedStyleEdge,
 )
+from semantic_index.utils import LazyPgConnection
 
 logger = logging.getLogger(__name__)
 
@@ -49,22 +50,13 @@ class DiscogsClient:
     """
 
     def __init__(self, cache_dsn: str | None, api_base_url: str | None) -> None:
-        self._cache_dsn = cache_dsn
         self._api_base_url = api_base_url.rstrip("/") if api_base_url else None
         self._last_api_call: float = 0
-        self._cache_conn: psycopg.Connection | None = None
+        self._pg = LazyPgConnection(cache_dsn, "discogs-cache")
 
     def _get_cache_conn(self) -> psycopg.Connection | None:
         """Get or create the cache PostgreSQL connection."""
-        if self._cache_dsn is None:
-            return None
-        if self._cache_conn is None or self._cache_conn.closed:
-            try:
-                self._cache_conn = psycopg.connect(self._cache_dsn, autocommit=True)
-            except Exception:
-                logger.warning("Failed to connect to discogs-cache", exc_info=True)
-                return None
-        return self._cache_conn
+        return self._pg.get()
 
     def _get_http_client(self) -> httpx.Client | None:
         """Create an HTTP client for the API."""
@@ -211,39 +203,52 @@ class DiscogsClient:
             return False
 
     @staticmethod
+    def _fetch_grouped(execute, query: str, params: tuple, value_fn) -> dict[str, list]:
+        """Run *query* and group results by the first column.
+
+        Args:
+            execute: Callable that accepts ``(query, params)`` and returns a
+                cursor with ``.fetchall()``.
+            query: SQL query whose first column is the grouping key.
+            params: Bind parameters for *query*.
+            value_fn: Extracts the value(s) from each row (receives the full row tuple).
+
+        Returns:
+            Dict mapping the first column's value to a list of extracted values.
+        """
+        rows = execute(query, params).fetchall()
+        grouped: dict[str, list] = {}
+        for row in rows:
+            grouped.setdefault(row[0], []).append(value_fn(row))
+        return grouped
+
+    @staticmethod
     def _enrich_from_summaries(conn: object, batch: list[str]) -> dict[str, dict]:
         """Fast enrichment using pre-joined summary tables."""
         execute = conn.execute  # type: ignore[attr-defined]
-        result: dict[str, dict] = {}
+        fg = DiscogsClient._fetch_grouped
 
-        # Styles: artist_name → style
-        style_rows = execute(
+        artist_styles = fg(
+            execute,
             "SELECT artist_name, style FROM artist_style_summary WHERE artist_name = ANY(%s)",
             (batch,),
-        ).fetchall()
-        artist_styles: dict[str, list[str]] = {}
-        for name, style in style_rows:
-            artist_styles.setdefault(name, []).append(style)
-
-        # Personnel: artist_name → personnel_name, role
-        extra_rows = execute(
+            lambda row: row[1],
+        )
+        artist_extras = fg(
+            execute,
             "SELECT artist_name, personnel_name, role FROM artist_personnel_summary WHERE artist_name = ANY(%s)",
             (batch,),
-        ).fetchall()
-        artist_extras: dict[str, list[tuple[str, str | None]]] = {}
-        for name, personnel, role in extra_rows:
-            artist_extras.setdefault(name, []).append((personnel, role))
-
-        # Labels: artist_name → label_id, label_name
-        label_rows = execute(
+            lambda row: (row[1], row[2]),
+        )
+        artist_labels = fg(
+            execute,
             "SELECT artist_name, label_id, label_name FROM artist_label_summary WHERE artist_name = ANY(%s)",
             (batch,),
-        ).fetchall()
-        artist_labels: dict[str, list[tuple[int | None, str]]] = {}
-        for name, label_id, label_name in label_rows:
-            artist_labels.setdefault(name, []).append((label_id, label_name))
+            lambda row: (row[1], row[2]),
+        )
 
         # Build result for all artists that had any data
+        result: dict[str, dict] = {}
         all_names = set(artist_styles) | set(artist_extras) | set(artist_labels)
         for name in all_names:
             result[name] = {
@@ -260,51 +265,43 @@ class DiscogsClient:
         """Slow enrichment path: join release tables by release_id."""
         execute = conn.execute  # type: ignore[attr-defined]
         result: dict[str, dict] = {}
+        fg = DiscogsClient._fetch_grouped
 
-        rows = execute(
+        artist_releases = fg(
+            execute,
             f"SELECT ra.artist_name, ra.release_id FROM {RELEASE_ARTIST_TABLE} ra WHERE ra.extra = 0 AND lower(ra.artist_name) = ANY(%s)",  # noqa: S608
             (batch,),
-        ).fetchall()
-
-        artist_releases: dict[str, list[int]] = {}
-        for artist_name, release_id in rows:
-            artist_releases.setdefault(artist_name, []).append(release_id)
+            lambda row: row[1],
+        )
 
         all_release_ids = list({rid for rids in artist_releases.values() for rid in rids})
         if not all_release_ids:
             return {}
 
-        style_rows = execute(
+        release_styles = fg(
+            execute,
             f"SELECT release_id, style FROM {RELEASE_STYLE_TABLE} WHERE release_id = ANY(%s)",  # noqa: S608
             (all_release_ids,),
-        ).fetchall()
-        release_styles: dict[int, list[str]] = {}
-        for rid, style in style_rows:
-            release_styles.setdefault(rid, []).append(style)
-
-        extra_rows = execute(
+            lambda row: row[1],
+        )
+        release_extras = fg(
+            execute,
             f"SELECT release_id, artist_name, role FROM {RELEASE_ARTIST_TABLE} WHERE extra = 1 AND release_id = ANY(%s)",  # noqa: S608
             (all_release_ids,),
-        ).fetchall()
-        release_extras: dict[int, list[tuple[str, str | None]]] = {}
-        for rid, name, role in extra_rows:
-            release_extras.setdefault(rid, []).append((name, role))
-
-        label_rows = execute(
+            lambda row: (row[1], row[2]),
+        )
+        release_labels = fg(
+            execute,
             f"SELECT release_id, label_id, label_name FROM {RELEASE_LABEL_TABLE} WHERE release_id = ANY(%s)",  # noqa: S608
             (all_release_ids,),
-        ).fetchall()
-        release_labels: dict[int, list[tuple[int | None, str]]] = {}
-        for rid, label_id, label_name in label_rows:
-            release_labels.setdefault(rid, []).append((label_id, label_name))
-
-        track_artist_rows = execute(
+            lambda row: (row[1], row[2]),
+        )
+        release_track_artists = fg(
+            execute,
             f"SELECT release_id, artist_name FROM {RELEASE_TRACK_ARTIST_TABLE} WHERE release_id = ANY(%s)",  # noqa: S608
             (all_release_ids,),
-        ).fetchall()
-        release_track_artists: dict[int, list[str]] = {}
-        for rid, name in track_artist_rows:
-            release_track_artists.setdefault(rid, []).append(name)
+            lambda row: row[1],
+        )
 
         for artist_name, rids in artist_releases.items():
             styles: set[str] = set()

--- a/semantic_index/musicbrainz_client.py
+++ b/semantic_index/musicbrainz_client.py
@@ -8,7 +8,7 @@ moved to LML.
 
 import logging
 
-import psycopg
+from semantic_index.utils import LazyPgConnection, batched_with_log
 
 logger = logging.getLogger(__name__)
 
@@ -21,18 +21,11 @@ class MusicBrainzClient:
     """
 
     def __init__(self, cache_dsn: str) -> None:
-        self._cache_dsn = cache_dsn
-        self._cache_conn: psycopg.Connection | None = None
+        self._pg = LazyPgConnection(cache_dsn, "musicbrainz-cache")
 
-    def _get_conn(self) -> psycopg.Connection | None:
+    def _get_conn(self):
         """Get or create the cache connection."""
-        if self._cache_conn is None or self._cache_conn.closed:
-            try:
-                self._cache_conn = psycopg.connect(self._cache_dsn, autocommit=True)
-            except Exception:
-                logger.warning("Failed to connect to musicbrainz-cache", exc_info=True)
-                return None
-        return self._cache_conn
+        return self._pg.get()
 
     def resolve_gids_to_ids(self, gids: list[str]) -> dict[str, int]:
         """Resolve MusicBrainz artist GIDs (UUIDs) to integer IDs.
@@ -56,9 +49,7 @@ class MusicBrainzClient:
 
         try:
             result: dict[str, int] = {}
-            batch_size = 1000
-            for i in range(0, len(gids), batch_size):
-                batch = gids[i : i + batch_size]
+            for batch in batched_with_log(gids, label="GID resolution"):
                 rows = conn.execute(
                     "SELECT id, gid::text FROM mb_artist WHERE gid = ANY(%s)",
                     (batch,),
@@ -92,9 +83,7 @@ class MusicBrainzClient:
 
         try:
             result: dict[int, list[str]] = {}
-            batch_size = 1000
-            for i in range(0, len(mb_artist_ids), batch_size):
-                batch = mb_artist_ids[i : i + batch_size]
+            for batch in batched_with_log(mb_artist_ids, label="Recording lookup"):
                 rows = conn.execute(
                     "SELECT artist_id, recording_mbid::text "
                     "FROM mb_artist_recording "
@@ -103,13 +92,6 @@ class MusicBrainzClient:
                 ).fetchall()
                 for artist_id, mbid in rows:
                     result.setdefault(artist_id, []).append(mbid)
-
-                if (i + batch_size) % 5000 == 0:
-                    logger.info(
-                        "  Recording lookup: %d/%d artist batches",
-                        i // batch_size + 1,
-                        (len(mb_artist_ids) + batch_size - 1) // batch_size,
-                    )
 
             return result
         except Exception:

--- a/semantic_index/pipeline_db.py
+++ b/semantic_index/pipeline_db.py
@@ -417,123 +417,102 @@ class PipelineDB:
                ORDER BY wikidata_qid""").fetchall()
         return [(row[0], sorted(int(x) for x in row[1].split(","))) for row in rows]
 
-    def _rekey_symmetric_edges(self, keep_id: int, merge_id: int) -> int:
-        """Re-key symmetric edge tables, replacing merge_id with keep_id.
+    def _rekey_pair_edge_table(
+        self,
+        table: str,
+        col_a: str,
+        col_b: str,
+        keep_id: int,
+        merge_id: int,
+        *,
+        symmetric: bool = False,
+    ) -> int:
+        """Re-key a two-column edge table, replacing merge_id with keep_id.
 
-        For each table in ``_SYMMETRIC_EDGE_TABLES``:
-        1. Delete edges between merge_id and keep_id (would become self-referential).
-        2. Delete edges that would create PK conflicts after re-keying (checks both
-           ``(keep_id, X)`` and ``(X, keep_id)`` since tables are symmetric/unordered).
-        3. UPDATE remaining edges to use keep_id.
-        4. Delete any residual self-referential edges (defensive).
+        Works for both symmetric (``artist_a_id``/``artist_b_id``) and directed
+        (``source_id``/``target_id``) edge tables.
 
-        Returns the total number of edge rows re-keyed (step 3 only).
-        """
-        total = 0
-        for table in _SYMMETRIC_EDGE_TABLES:
-            if not self._has_table(table):
-                continue
-
-            # 1. Delete edges between merge_id and keep_id (would become self-loops)
-            self._conn.execute(
-                f"DELETE FROM {table} WHERE "  # noqa: S608
-                f"(artist_a_id = ? AND artist_b_id = ?) OR "
-                f"(artist_a_id = ? AND artist_b_id = ?)",
-                (merge_id, keep_id, keep_id, merge_id),
-            )
-
-            # 2a. Delete (merge_id, X) edges that would conflict with existing keep_id edges
-            self._conn.execute(
-                f"DELETE FROM {table} WHERE artist_a_id = ?1 AND ("  # noqa: S608
-                f"  EXISTS (SELECT 1 FROM {table} t2"
-                f"    WHERE t2.artist_a_id = ?2 AND t2.artist_b_id = {table}.artist_b_id)"
-                f"  OR EXISTS (SELECT 1 FROM {table} t2"
-                f"    WHERE t2.artist_a_id = {table}.artist_b_id AND t2.artist_b_id = ?2)"
-                f")",
-                (merge_id, keep_id),
-            )
-
-            # 2b. Delete (X, merge_id) edges that would conflict with existing keep_id edges
-            self._conn.execute(
-                f"DELETE FROM {table} WHERE artist_b_id = ?1 AND ("  # noqa: S608
-                f"  EXISTS (SELECT 1 FROM {table} t2"
-                f"    WHERE t2.artist_a_id = {table}.artist_a_id AND t2.artist_b_id = ?2)"
-                f"  OR EXISTS (SELECT 1 FROM {table} t2"
-                f"    WHERE t2.artist_a_id = ?2 AND t2.artist_b_id = {table}.artist_a_id)"
-                f")",
-                (merge_id, keep_id),
-            )
-
-            # 3. Re-key remaining edges
-            cur = self._conn.execute(
-                f"UPDATE {table} SET artist_a_id = ? WHERE artist_a_id = ?",  # noqa: S608
-                (keep_id, merge_id),
-            )
-            total += cur.rowcount
-            cur = self._conn.execute(
-                f"UPDATE {table} SET artist_b_id = ? WHERE artist_b_id = ?",  # noqa: S608
-                (keep_id, merge_id),
-            )
-            total += cur.rowcount
-
-            # 4. Safety: delete any self-referential edges
-            self._conn.execute(f"DELETE FROM {table} WHERE artist_a_id = artist_b_id")  # noqa: S608
-        return total
-
-    def _rekey_directed_edges(self, keep_id: int, merge_id: int) -> int:
-        """Re-key directed edge tables, replacing merge_id with keep_id.
-
-        For each table in ``_DIRECTED_EDGE_TABLES`` (keyed by ``source_id``/``target_id``):
+        Steps:
         1. Delete edges between merge_id and keep_id (would become self-referential).
         2. Delete edges that would create PK conflicts after re-keying.
         3. UPDATE remaining edges to use keep_id.
         4. Delete any residual self-referential edges (defensive).
 
-        Returns the total number of edge rows re-keyed (step 3 only).
+        Returns the number of rows re-keyed (step 3 only).
         """
+        if not self._has_table(table):
+            return 0
+
+        # 1. Delete edges between merge_id and keep_id
+        self._conn.execute(
+            f"DELETE FROM {table} WHERE "  # noqa: S608
+            f"({col_a} = ? AND {col_b} = ?) OR "
+            f"({col_a} = ? AND {col_b} = ?)",
+            (merge_id, keep_id, keep_id, merge_id),
+        )
+
+        # 2a. Delete (merge_id, X) edges that conflict with existing (keep_id, X)
+        conflict_a = (
+            f"DELETE FROM {table} WHERE {col_a} = ?1 AND ("  # noqa: S608
+            f"  EXISTS (SELECT 1 FROM {table} t2"
+            f"    WHERE t2.{col_a} = ?2 AND t2.{col_b} = {table}.{col_b})"
+        )
+        if symmetric:
+            conflict_a += (
+                f"  OR EXISTS (SELECT 1 FROM {table} t2"
+                f"    WHERE t2.{col_a} = {table}.{col_b} AND t2.{col_b} = ?2)"
+            )
+        conflict_a += ")"
+        self._conn.execute(conflict_a, (merge_id, keep_id))
+
+        # 2b. Delete (X, merge_id) edges that conflict with existing (X, keep_id)
+        conflict_b = (
+            f"DELETE FROM {table} WHERE {col_b} = ?1 AND "  # noqa: S608
+            f"EXISTS (SELECT 1 FROM {table} t2"
+            f"  WHERE t2.{col_a} = {table}.{col_a} AND t2.{col_b} = ?2)"
+        )
+        if symmetric:
+            conflict_b = (
+                f"DELETE FROM {table} WHERE {col_b} = ?1 AND ("  # noqa: S608
+                f"  EXISTS (SELECT 1 FROM {table} t2"
+                f"    WHERE t2.{col_a} = {table}.{col_a} AND t2.{col_b} = ?2)"
+                f"  OR EXISTS (SELECT 1 FROM {table} t2"
+                f"    WHERE t2.{col_a} = ?2 AND t2.{col_b} = {table}.{col_a})"
+                f")"
+            )
+        self._conn.execute(conflict_b, (merge_id, keep_id))
+
+        # 3. Re-key remaining edges
+        total = 0
+        cur = self._conn.execute(
+            f"UPDATE {table} SET {col_a} = ? WHERE {col_a} = ?",  # noqa: S608
+            (keep_id, merge_id),
+        )
+        total += cur.rowcount
+        cur = self._conn.execute(
+            f"UPDATE {table} SET {col_b} = ? WHERE {col_b} = ?",  # noqa: S608
+            (keep_id, merge_id),
+        )
+        total += cur.rowcount
+
+        # 4. Safety: delete any self-referential edges
+        self._conn.execute(f"DELETE FROM {table} WHERE {col_a} = {col_b}")  # noqa: S608
+        return total
+
+    def _rekey_symmetric_edges(self, keep_id: int, merge_id: int) -> int:
+        """Re-key symmetric edge tables, replacing merge_id with keep_id."""
+        total = 0
+        for table in _SYMMETRIC_EDGE_TABLES:
+            total += self._rekey_pair_edge_table(
+                table, "artist_a_id", "artist_b_id", keep_id, merge_id, symmetric=True
+            )
+        return total
+
+    def _rekey_directed_edges(self, keep_id: int, merge_id: int) -> int:
+        """Re-key directed edge tables, replacing merge_id with keep_id."""
         total = 0
         for table in _DIRECTED_EDGE_TABLES:
-            if not self._has_table(table):
-                continue
-
-            # 1. Delete edges between merge_id and keep_id
-            self._conn.execute(
-                f"DELETE FROM {table} WHERE "  # noqa: S608
-                f"(source_id = ? AND target_id = ?) OR "
-                f"(source_id = ? AND target_id = ?)",
-                (merge_id, keep_id, keep_id, merge_id),
-            )
-
-            # 2a. Delete (merge_id, X) edges that conflict with existing (keep_id, X)
-            self._conn.execute(
-                f"DELETE FROM {table} WHERE source_id = ?1 AND "  # noqa: S608
-                f"EXISTS (SELECT 1 FROM {table} t2"
-                f"  WHERE t2.source_id = ?2 AND t2.target_id = {table}.target_id)",
-                (merge_id, keep_id),
-            )
-
-            # 2b. Delete (X, merge_id) edges that conflict with existing (X, keep_id)
-            self._conn.execute(
-                f"DELETE FROM {table} WHERE target_id = ?1 AND "  # noqa: S608
-                f"EXISTS (SELECT 1 FROM {table} t2"
-                f"  WHERE t2.source_id = {table}.source_id AND t2.target_id = ?2)",
-                (merge_id, keep_id),
-            )
-
-            # 3. Re-key remaining edges
-            cur = self._conn.execute(
-                f"UPDATE {table} SET source_id = ? WHERE source_id = ?",  # noqa: S608
-                (keep_id, merge_id),
-            )
-            total += cur.rowcount
-            cur = self._conn.execute(
-                f"UPDATE {table} SET target_id = ? WHERE target_id = ?",  # noqa: S608
-                (keep_id, merge_id),
-            )
-            total += cur.rowcount
-
-            # 4. Safety: delete any self-referential edges
-            self._conn.execute(f"DELETE FROM {table} WHERE source_id = target_id")  # noqa: S608
+            total += self._rekey_pair_edge_table(table, "source_id", "target_id", keep_id, merge_id)
         return total
 
     def _rekey_single_artist_tables(self, keep_id: int, merge_id: int) -> int:

--- a/semantic_index/utils.py
+++ b/semantic_index/utils.py
@@ -4,8 +4,72 @@ from __future__ import annotations
 
 import logging
 import sqlite3
+from collections.abc import Iterator
+
+import psycopg
 
 logger = logging.getLogger(__name__)
+
+
+class LazyPgConnection:
+    """Lazy, reconnecting PostgreSQL connection wrapper.
+
+    Defers connection creation until first use and transparently reconnects
+    when the connection is closed. Returns ``None`` when no DSN is configured
+    or on connection failure, matching the graceful-degradation pattern used
+    by the pipeline's PostgreSQL clients.
+
+    Args:
+        dsn: PostgreSQL connection string, or ``None`` to disable.
+        label: Human-readable name for log messages (e.g. ``"discogs-cache"``).
+    """
+
+    def __init__(self, dsn: str | None, label: str) -> None:
+        self._dsn = dsn
+        self._label = label
+        self._conn: psycopg.Connection | None = None
+
+    def get(self) -> psycopg.Connection | None:
+        """Return an open connection, or ``None`` if unavailable."""
+        if self._dsn is None:
+            return None
+        if self._conn is None or self._conn.closed:
+            try:
+                self._conn = psycopg.connect(self._dsn, autocommit=True)
+            except Exception:
+                logger.warning("Failed to connect to %s", self._label, exc_info=True)
+                return None
+        return self._conn
+
+
+def batched_with_log(
+    items: list,
+    batch_size: int = 1000,
+    *,
+    log_every: int = 5000,
+    label: str = "items",
+) -> Iterator[list]:
+    """Yield batches of *items* with periodic progress logging.
+
+    Args:
+        items: Full list to iterate.
+        batch_size: Number of items per batch.
+        log_every: Log progress every this many items (must be a multiple of
+            *batch_size* for consistent reporting).
+        label: Prefix for the log message.
+    """
+    total = len(items)
+    total_batches = (total + batch_size - 1) // batch_size
+    for i in range(0, total, batch_size):
+        yield items[i : i + batch_size]
+        if (i + batch_size) % log_every == 0:
+            logger.info(
+                "  %s: %d/%d batches",
+                label,
+                i // batch_size + 1,
+                total_batches,
+            )
+
 
 # ---- Schema migration ----
 

--- a/semantic_index/wikidata_client.py
+++ b/semantic_index/wikidata_client.py
@@ -14,13 +14,13 @@ import re
 import time
 
 import httpx
-import psycopg
 
 from semantic_index.models import (
     WikidataEntity,
     WikidataInfluence,
     WikidataLabelHierarchy,
 )
+from semantic_index.utils import LazyPgConnection
 
 logger = logging.getLogger(__name__)
 
@@ -84,20 +84,11 @@ class WikidataClient:
         self._user_agent = user_agent or self._DEFAULT_USER_AGENT
         self._batch_size = batch_size
         self._last_request: float = 0
-        self._cache_dsn = cache_dsn
-        self._cache_conn: psycopg.Connection | None = None
+        self._pg = LazyPgConnection(cache_dsn, "wikidata-cache")
 
-    def _get_cache_conn(self) -> psycopg.Connection | None:
+    def _get_cache_conn(self):
         """Get or create the wikidata-cache PostgreSQL connection."""
-        if self._cache_dsn is None:
-            return None
-        if self._cache_conn is None or self._cache_conn.closed:
-            try:
-                self._cache_conn = psycopg.connect(self._cache_dsn, autocommit=True)
-            except Exception:
-                logger.warning("Failed to connect to wikidata-cache", exc_info=True)
-                return None
-        return self._cache_conn
+        return self._pg.get()
 
     def _rate_limit(self) -> None:
         """Sleep to respect Wikidata's rate limit (~1 req/s)."""

--- a/tests/unit/test_api_routes.py
+++ b/tests/unit/test_api_routes.py
@@ -365,36 +365,26 @@ class TestNeighbors:
         assert "Cat Power" in names
 
     @pytest.mark.asyncio
-    async def test_heat_cool_ranks_by_raw_count(
-        self, client: AsyncClient, artist_ids: dict[str, int]
+    @pytest.mark.parametrize(
+        ("heat", "field"),
+        [
+            pytest.param(0.0, "raw_count", id="cool_ranks_by_raw_count"),
+            pytest.param(1.0, "pmi", id="hot_ranks_by_pmi"),
+        ],
+    )
+    async def test_heat_ranking(
+        self, client: AsyncClient, artist_ids: dict[str, int], heat: float, field: str
     ) -> None:
-        """heat=0 (cool) ranks by raw_count, so higher raw_count appears first."""
+        """Extreme heat values rank neighbors by the corresponding field."""
         aid = artist_ids["Autechre"]
         resp = await client.get(
             f"/graph/artists/{aid}/neighbors",
-            params={"type": "djTransition", "heat": 0.0},
+            params={"type": "djTransition", "heat": heat},
         )
         assert resp.status_code == 200
         neighbors = resp.json()["neighbors"]
         assert len(neighbors) >= 2
-        # First neighbor should have higher raw_count
-        assert neighbors[0]["detail"]["raw_count"] >= neighbors[-1]["detail"]["raw_count"]
-
-    @pytest.mark.asyncio
-    async def test_heat_hot_ranks_by_pmi(
-        self, client: AsyncClient, artist_ids: dict[str, int]
-    ) -> None:
-        """heat=1 (hot) ranks by PMI, so higher PMI appears first."""
-        aid = artist_ids["Autechre"]
-        resp = await client.get(
-            f"/graph/artists/{aid}/neighbors",
-            params={"type": "djTransition", "heat": 1.0},
-        )
-        assert resp.status_code == 200
-        neighbors = resp.json()["neighbors"]
-        assert len(neighbors) >= 2
-        # First neighbor should have higher PMI
-        assert neighbors[0]["detail"]["pmi"] >= neighbors[-1]["detail"]["pmi"]
+        assert neighbors[0]["detail"][field] >= neighbors[-1]["detail"][field]
 
     @pytest.mark.asyncio
     async def test_heat_validation(self, client: AsyncClient, artist_ids: dict[str, int]) -> None:

--- a/tests/unit/test_recover_audio_profiles.py
+++ b/tests/unit/test_recover_audio_profiles.py
@@ -149,9 +149,9 @@ class TestRecover:
             patch("semantic_index.acousticbrainz_client.AcousticBrainzClient") as mock_ab_cls,
         ):
             mock_mb_cls.return_value.resolve_gids_to_ids.return_value = {GID_AUTECHRE: 12345}
-            mock_mb_cls.return_value._cache_conn = None
+            mock_mb_cls.return_value._pg._conn = None
             mock_ab_cls.return_value.get_features_for_artists.return_value = mock_features
-            mock_ab_cls.return_value._conn = None
+            mock_ab_cls.return_value._pg._conn = None
 
             stats = recover(
                 db_path=str(db_path),
@@ -183,9 +183,9 @@ class TestRecover:
                 GID_AUTECHRE: 12345,
                 GID_STEREOLAB: 67890,
             }
-            mock_mb_cls.return_value._cache_conn = None
+            mock_mb_cls.return_value._pg._conn = None
             mock_ab_cls.return_value.get_features_for_artists.return_value = mock_features
-            mock_ab_cls.return_value._conn = None
+            mock_ab_cls.return_value._pg._conn = None
 
             stats = recover(
                 db_path=str(db_path),
@@ -213,9 +213,9 @@ class TestRecover:
                 GID_AUTECHRE: 12345,
                 GID_STEREOLAB: 67890,
             }
-            mock_mb_cls.return_value._cache_conn = None
+            mock_mb_cls.return_value._pg._conn = None
             mock_ab_cls.return_value.get_features_for_artists.return_value = mock_features
-            mock_ab_cls.return_value._conn = None
+            mock_ab_cls.return_value._pg._conn = None
 
             stats = recover(
                 db_path=str(db_path),
@@ -237,9 +237,9 @@ class TestRecover:
             patch("semantic_index.acousticbrainz_client.AcousticBrainzClient") as mock_ab_cls,
         ):
             mock_mb_cls.return_value.resolve_gids_to_ids.return_value = {GID_AUTECHRE: 12345}
-            mock_mb_cls.return_value._cache_conn = None
+            mock_mb_cls.return_value._pg._conn = None
             mock_ab_cls.return_value.get_features_for_artists.return_value = mock_features
-            mock_ab_cls.return_value._conn = None
+            mock_ab_cls.return_value._pg._conn = None
 
             stats = recover(
                 db_path=str(db_path),

--- a/tests/unit/test_wikidata_client.py
+++ b/tests/unit/test_wikidata_client.py
@@ -283,9 +283,8 @@ class TestGracefulDegradation:
 def _make_cache_client(mock_conn: MagicMock) -> WikidataClient:
     """Create a WikidataClient with a mocked cache connection."""
     mock_conn.closed = False
-    client = WikidataClient()
-    client._cache_dsn = "mock"
-    client._cache_conn = mock_conn
+    client = WikidataClient(cache_dsn="mock")
+    client._pg._conn = mock_conn
     return client
 
 


### PR DESCRIPTION
## Summary

- Extract `LazyPgConnection` utility replacing 4 identical lazy-connect implementations across PG clients
- Extract `open_cache_db` replacing 3 identical sidecar SQLite cache setup functions
- Extract `batched_with_log` generator replacing manual batch+logging loops
- Extract `_fetch_grouped` replacing 8 identical setdefault aggregation blocks in `discogs_client`
- Consolidate `_rekey_symmetric_edges` and `_rekey_directed_edges` into a single parameterized `_rekey_pair_edge_table`
- Parameterize heat ranking tests

Net zero: 269 insertions, 269 deletions across 14 files. All 639 unit tests pass.

Closes #177

## Test plan

- [x] All 639 unit tests pass
- [x] ruff check passes
- [x] ruff format passes
- [x] mypy passes