### PR TITLE
Narrow sync scheduler lock exception to BlockingIOError

### DIFF
--- a/semantic_index/api/sync_scheduler.py
+++ b/semantic_index/api/sync_scheduler.py
@@ -100,7 +100,7 @@ def start_scheduler(
         lock_fd = open(lock_path, "w")  # noqa: SIM115
         fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
         _lock_file = lock_fd  # prevent GC from closing/releasing the lock
-    except OSError:
+    except BlockingIOError:
         lock_fd.close()
         logger.info("Sync scheduler lock held by another worker — skipping")
         return None


### PR DESCRIPTION
## Summary

- Narrows the `except` clause in `start_scheduler()` from `OSError` to `BlockingIOError` so that permission errors, disk-full, and other I/O failures propagate instead of being silently swallowed as "lock held by another worker"

Closes #152