### PR TITLE
Add slow marker to pytest configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,8 +87,9 @@ markers = [
     "integration: needs external service or fixture data",
     "e2e: full pipeline end-to-end test",
     "parity: old vs new implementation comparison",
+    "slow: marks tests as slow",
 ]
-addopts = "-m 'not integration and not postgres and not e2e and not parity'"
+addopts = "-m 'not integration and not postgres and not e2e and not parity and not slow'"
 console_output_style = "progress"
 testpaths = ["tests"]
 pythonpath = ["."]


### PR DESCRIPTION
## Summary

Adds the \`slow\` marker to align with the canonical 6-marker WXYC ETL block defined in the org-local \`plans/test-patterns.md\`. Updates \`addopts\` to deselect \`slow\` from the default \`pytest\` run so \`pytest\` with no arguments continues to surface only unit tests.

The \`slow\` marker is already in active use in this repo — both README and CLAUDE.md reference \`pytest -m slow\` for running tests against the production dump. Declaring it explicitly here removes the unknown-marker warning that was previously emitted on every invocation.

Part of WXYC/wxyc-etl#23 (test pattern standardization across ETL repos). PR-A6 of the planned chain.

## Test plan

- [x] \`pytest --markers\` lists all 6 canonical markers including \`slow\`
- [x] \`pytest -m slow --co\` no longer reports an unknown-marker warning
- [ ] CI green