### PR TITLE
Add --entity-source flag and fail loudly when LML PG is unavailable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -271,13 +271,14 @@ Use `--no-sqlite` to skip the SQLite export.
 
 ### Pipeline DB mode
 
-Pass `--db-path` to enable the pipeline database: artists are managed with persistent identity resolution from LML rather than created fresh on each run. The pipeline database becomes the SQLite output.
+Pass `--db-path` to enable the pipeline database: artists are managed with persistent identity resolution rather than created fresh on each run. The pipeline database becomes the SQLite output.
 
 ```bash
-python run_pipeline.py dump.sql --db-path output/wxyc_artist_graph.db --discogs-cache-dsn postgresql://...
+python run_pipeline.py dump.sql --db-path output/wxyc_artist_graph.db --entity-source lml --discogs-cache-dsn postgresql://...
 ```
 
-- `--db-path PATH` — Path to pipeline SQLite database. Creates it if needed. Identity resolution is read from LML's `entity.identity` PG table (requires `--discogs-cache-dsn`).
+- `--db-path PATH` — Path to pipeline SQLite database. Creates it if needed.
+- `--entity-source {local,lml}` — Where to source artist identity from. `local` (default) uses only the local SQLite pipeline DB and skips LML. `lml` reads identities from LML's `entity.identity` PG table (requires `--discogs-cache-dsn`). The `lml` mode **fails loudly** (raises `LmlEntitySourceError`) if LML PG is unreachable — silent fallback would mask config errors. To skip LML when PG is down, re-run with `--entity-source=local`.
 - `--compilation-track-artist-dump PATH` — Path to a SQL dump containing the `COMPILATION_TRACK_ARTIST` table. When provided, VA/compilation entries are resolved to per-track artists (Tier 0) before the FK chain.
 - `--compute-discogs-edges` — Compute Discogs-derived edges (shared personnel, styles, labels, compilations). Off by default.
 - `--compute-wikidata-influences` — Query Wikidata P737 (influenced by) and create directed influence edges. Requires `--db-path` with reconciled Wikidata QIDs.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This parses the SQL dump, computes PMI for all artist co-occurrences, extracts c
 ## Options
 
 ```
-python run_pipeline.py <dump_path> [--output-dir DIR] [--min-count N] [--no-sqlite] [--db-path PATH]
+python run_pipeline.py <dump_path> [--output-dir DIR] [--min-count N] [--no-sqlite] [--db-path PATH] [--entity-source {local,lml}]
 ```
 
 | Flag | Default | Description |
@@ -23,7 +23,8 @@ python run_pipeline.py <dump_path> [--output-dir DIR] [--min-count N] [--no-sqli
 | `--output-dir` | `output/` | Directory for output files |
 | `--min-count` | `2` | Minimum co-occurrence count for graph edges |
 | `--no-sqlite` | disabled | Skip SQLite database export |
-| `--db-path` | none | Path to pipeline SQLite database with persistent identity resolution from LML |
+| `--db-path` | none | Path to pipeline SQLite database with persistent identity resolution |
+| `--entity-source` | `local` | `local` skips LML; `lml` reads from LML's `entity.identity` PG table (requires `--discogs-cache-dsn`). `lml` fails loudly if PG is unreachable — pass `--entity-source=local` to bypass. |
 
 ## How it works
 

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -137,6 +137,17 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "with persistent identity resolution from LML. Creates the database if needed.",
     )
     parser.add_argument(
+        "--entity-source",
+        choices=["local", "lml"],
+        default="local",
+        help="Where to source entity (artist) identity from. "
+        "'local' (default): use only the local SQLite pipeline DB; skip LML. "
+        "'lml': read identities from LML's entity.identity PG table (requires "
+        "--discogs-cache-dsn). lml requires LML PG to be reachable; the pipeline "
+        "fails fast (raises LmlEntitySourceError) if it isn't. To skip LML when "
+        "PG is unavailable, pass --entity-source=local.",
+    )
+    parser.add_argument(
         "--compute-discogs-edges",
         action="store_true",
         help="Compute Discogs-derived edges (shared personnel, styles, labels, compilations). "
@@ -279,6 +290,51 @@ def _run_facet_only(
     log.info("Facet tables written to %s in %.1f seconds.", sqlite_path, elapsed)
 
 
+def _validate_lml_entity_source(args: argparse.Namespace) -> None:
+    """Validate LML PG connectivity early when --entity-source=lml is selected.
+
+    Connects to LML PG (via the discogs-cache DSN) and runs a trivial query to
+    verify reachability and authentication. On any failure, raises
+    :class:`LmlEntitySourceError` with a message that points the operator at
+    the workaround (``--entity-source=local``).
+
+    This runs before any expensive pipeline work so failures surface within
+    seconds, not after a 30-minute parse.
+    """
+    from semantic_index.lml_identity import LmlEntitySourceError, PgSource
+
+    if not args.discogs_cache_dsn:
+        raise LmlEntitySourceError(
+            "--entity-source=lml requires --discogs-cache-dsn (or the "
+            "DATABASE_URL_DISCOGS env var) so the pipeline can connect to LML's "
+            "entity.identity PG table. Either provide a DSN, or pass "
+            "--entity-source=local to skip LML entirely."
+        )
+
+    log.info("Validating LML PG reachability (--entity-source=lml)...")
+    pg_source = PgSource(args.discogs_cache_dsn)
+    try:
+        # Trivial probe: a 1-row SELECT against entity.identity. We don't need
+        # the result; we only need to confirm connect+auth+schema all work.
+        pg_source.fetchall("SELECT 1 FROM entity.identity LIMIT 1")
+    except Exception as exc:
+        log.error(
+            "LML entity source unavailable: %s. "
+            "To proceed without LML, re-run with --entity-source=local.",
+            exc,
+        )
+        raise LmlEntitySourceError(
+            "Failed to reach LML PG entity.identity table with "
+            "--entity-source=lml. Underlying error: "
+            f"{type(exc).__name__}: {exc}. "
+            "Fix LML connectivity (check --discogs-cache-dsn / DATABASE_URL_DISCOGS, "
+            "network, credentials) or pass --entity-source=local to skip LML."
+        ) from exc
+    finally:
+        pg_source.close()
+    log.info("LML PG reachable.")
+
+
 def run(args: argparse.Namespace) -> None:
     dump_path = args.dump_path
     output_dir = Path(args.output_dir)
@@ -287,6 +343,10 @@ def run(args: argparse.Namespace) -> None:
     if not Path(dump_path).exists():
         log.error("Dump file not found: %s", dump_path)
         sys.exit(1)
+
+    # Fail fast on LML connectivity before any expensive work.
+    if args.entity_source == "lml":
+        _validate_lml_entity_source(args)
 
     t0 = time.time()
 
@@ -477,9 +537,19 @@ def run(args: argparse.Namespace) -> None:
         pipeline_db.bulk_upsert_artists(all_canonical)
 
         # 5d. Import identities from LML entity store (PG)
-        if args.discogs_cache_dsn:
+        #
+        # Gated by --entity-source=lml. With the default (--entity-source=local),
+        # we skip LML entirely and rely on local reconciliation. With
+        # --entity-source=lml we already validated PG reachability above (in
+        # _validate_lml_entity_source); a failure here would be unexpected, but
+        # we still surface it as LmlEntitySourceError for consistency.
+        if args.entity_source == "lml":
             log.info("Importing identities from LML entity store (entity.identity)...")
-            from semantic_index.lml_identity import PgSource, import_lml_identities
+            from semantic_index.lml_identity import (
+                LmlEntitySourceError,
+                PgSource,
+                import_lml_identities,
+            )
 
             pg_source = PgSource(args.discogs_cache_dsn)
             try:
@@ -490,10 +560,29 @@ def run(args: argparse.Namespace) -> None:
                     lml_report.unmatched,
                     lml_report.entities_created,
                 )
+                if lml_report.matched == 0:
+                    log.warning(
+                        "LML returned zero matched identities — entity.identity "
+                        "appears empty for the local artist set. Pipeline will "
+                        "continue with no LML reconciliation applied."
+                    )
+            except LmlEntitySourceError:
+                raise
+            except Exception as exc:
+                raise LmlEntitySourceError(
+                    "LML identity import failed after initial connectivity probe "
+                    "succeeded. Underlying error: "
+                    f"{type(exc).__name__}: {exc}. "
+                    "Re-run with --entity-source=local to skip LML."
+                ) from exc
             finally:
                 pg_source.close()
         else:
-            log.warning("No --discogs-cache-dsn provided; skipping LML identity import")
+            log.info(
+                "Skipping LML identity import (--entity-source=%s); "
+                "using local reconciliation only.",
+                args.entity_source,
+            )
 
         # 5e2. Assign Wikidata QIDs from wikidata-cache via Discogs ID bridge
         if args.wikidata_cache_dsn:

--- a/semantic_index/lml_identity.py
+++ b/semantic_index/lml_identity.py
@@ -15,6 +15,19 @@ from typing import Any, Protocol, runtime_checkable
 
 logger = logging.getLogger(__name__)
 
+
+class LmlEntitySourceError(RuntimeError):
+    """Raised when the LML entity source is selected but cannot be reached.
+
+    This is a fail-loud signal: when ``--entity-source=lml`` is requested and
+    LML PG is unavailable (connection refused, auth failure, timeout, missing
+    DSN), we surface this exception with a clear actionable message instead
+    of silently falling back to local reconciliation. Silent fallback masks
+    real LML configuration errors (wrong DSN, expired credentials, etc.).
+    To skip LML entirely, the operator should pass ``--entity-source=local``.
+    """
+
+
 _FETCH_ALL_IDENTITIES_SQL = """\
 SELECT library_name, discogs_artist_id, wikidata_qid,
        musicbrainz_artist_id, spotify_artist_id,

--- a/tests/integration/test_entity_source_fallback.py
+++ b/tests/integration/test_entity_source_fallback.py
@@ -1,0 +1,296 @@
+"""Tests for `--entity-source=lml` fail-loud behavior when LML PG is unavailable.
+
+The historical audit asked the pipeline to "fall back to local reconciliation"
+when LML PG is unreachable. We deliberately rejected that design: silent
+fallback masks LML config errors (wrong DSN, expired credentials, network
+issues). Instead, the pipeline raises :class:`LmlEntitySourceError` with a
+clear message that points the operator at the explicit ``--entity-source=local``
+workaround. The file name is preserved for traceability with the audit (#183).
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+from pathlib import Path
+
+import pytest
+
+from semantic_index.lml_identity import LmlEntitySourceError
+
+pytestmark = pytest.mark.integration
+
+_RELATIVE = "tubafrenzy/scripts/dev/fixtures/wxycmusic-fixture.sql"
+
+
+def _find_fixture() -> Path:
+    override = os.environ.get("TUBAFRENZY_FIXTURE")
+    if override:
+        return Path(override)
+    d = Path(__file__).resolve().parent
+    while d != d.parent:
+        candidate = d / _RELATIVE
+        if candidate.exists():
+            return candidate
+        d = d.parent
+    return Path(_RELATIVE)
+
+
+FIXTURE_PATH = _find_fixture()
+
+
+@pytest.fixture
+def fixture_dump() -> str:
+    if not FIXTURE_PATH.exists():
+        pytest.skip(f"Fixture dump not found at {FIXTURE_PATH}")
+    return str(FIXTURE_PATH)
+
+
+def _make_args(**overrides) -> argparse.Namespace:
+    """Build a Namespace mimicking parse_args() output, with overrides."""
+    base = {
+        "dump_path": "dump.sql",
+        "entity_source": "lml",
+        "discogs_cache_dsn": "postgresql://example/discogs",
+        "verbose": False,
+    }
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+class _RaisingPgSource:
+    """Test double matching the PgSource interface but raising on fetchall.
+
+    Mirrors the real :class:`semantic_index.lml_identity.PgSource` constructor
+    signature so it can be substituted via monkeypatch.
+    """
+
+    instances: list[_RaisingPgSource] = []
+
+    def __init__(self, dsn: str) -> None:
+        self.dsn = dsn
+        self.closed = False
+        _RaisingPgSource.instances.append(self)
+
+    def fetchall(self, query: str):  # noqa: ARG002 — interface compat
+        raise ConnectionRefusedError("Connection refused: localhost:5433")
+
+    def close(self) -> None:
+        self.closed = True
+
+
+@pytest.fixture(autouse=True)
+def _reset_raising_instances():
+    _RaisingPgSource.instances.clear()
+    yield
+    _RaisingPgSource.instances.clear()
+
+
+def _patch_pg_source_to_raise(monkeypatch) -> None:
+    """Replace the PgSource class so any LML PG connection attempt fails."""
+    monkeypatch.setattr("semantic_index.lml_identity.PgSource", _RaisingPgSource)
+
+
+class TestValidateLmlEntitySource:
+    """Direct tests of the early-fail probe (`_validate_lml_entity_source`)."""
+
+    def test_lml_unavailable_raises_clear_error(self, monkeypatch):
+        """When LML PG cannot be reached, raise LmlEntitySourceError with guidance.
+
+        The exception message must mention LML *and* the --entity-source=local
+        workaround so the operator can immediately self-recover.
+        """
+        from run_pipeline import _validate_lml_entity_source
+
+        _patch_pg_source_to_raise(monkeypatch)
+        args = _make_args()
+
+        with pytest.raises(LmlEntitySourceError) as excinfo:
+            _validate_lml_entity_source(args)
+
+        msg = str(excinfo.value)
+        assert "LML" in msg
+        assert "--entity-source=local" in msg
+        # The original error type/text should be chained for debuggability.
+        assert isinstance(excinfo.value.__cause__, ConnectionRefusedError)
+        assert "ConnectionRefusedError" in msg
+        # And the resource we were probing should be hinted in the chained message.
+        assert "Connection refused" in msg
+
+    def test_lml_unavailable_logs_clearly(self, monkeypatch, caplog):
+        """An ERROR-level log should describe both the failure and the workaround."""
+        from run_pipeline import _validate_lml_entity_source
+
+        _patch_pg_source_to_raise(monkeypatch)
+        args = _make_args()
+
+        with caplog.at_level(logging.ERROR, logger="run_pipeline"):
+            with pytest.raises(LmlEntitySourceError):
+                _validate_lml_entity_source(args)
+
+        assert any(
+            "LML entity source unavailable" in rec.message
+            and "--entity-source=local" in rec.message
+            for rec in caplog.records
+        ), f"Expected ERROR mentioning fallback, got: {[r.message for r in caplog.records]}"
+
+    def test_missing_dsn_raises_with_actionable_message(self, monkeypatch):
+        """--entity-source=lml without a DSN should fail fast with a clear message."""
+        from run_pipeline import _validate_lml_entity_source
+
+        # No PgSource patch needed: we never get that far.
+        args = _make_args(discogs_cache_dsn=None)
+
+        with pytest.raises(LmlEntitySourceError) as excinfo:
+            _validate_lml_entity_source(args)
+
+        msg = str(excinfo.value)
+        assert "--discogs-cache-dsn" in msg
+        assert "--entity-source=local" in msg
+
+    def test_pg_source_is_closed_even_on_failure(self, monkeypatch):
+        """The PgSource connection is closed in the failure path (no leaks)."""
+        from run_pipeline import _validate_lml_entity_source
+
+        _patch_pg_source_to_raise(monkeypatch)
+        args = _make_args()
+
+        with pytest.raises(LmlEntitySourceError):
+            _validate_lml_entity_source(args)
+
+        assert len(_RaisingPgSource.instances) == 1
+        assert _RaisingPgSource.instances[0].closed is True
+
+
+class TestPipelineRunWithEntitySource:
+    """End-to-end checks running the pipeline against the fixture dump."""
+
+    def test_local_entity_source_works_when_lml_down(self, monkeypatch, fixture_dump, tmp_path):
+        """`--entity-source=local` succeeds even when LML PG would fail.
+
+        This verifies the user-facing workaround actually works: an operator
+        seeing the LmlEntitySourceError message can re-run with =local and
+        get a graph DB.
+        """
+        from run_pipeline import main
+
+        # Even if some code path tried to reach LML, the patched PgSource
+        # would raise. With --entity-source=local we should never instantiate
+        # it, and the pipeline must complete.
+        _patch_pg_source_to_raise(monkeypatch)
+
+        out_dir = tmp_path / "out"
+        main(
+            [
+                fixture_dump,
+                "--output-dir",
+                str(out_dir),
+                "--min-count",
+                "1",
+                "--entity-source",
+                "local",
+                # Provide a DSN to prove that "local" ignores it entirely.
+                "--discogs-cache-dsn",
+                "postgresql://wont-be-used/discogs",
+                "--skip-enrichment",
+                "--no-graph-metrics",
+            ]
+        )
+
+        sqlite_path = out_dir / "wxyc_artist_graph.db"
+        assert sqlite_path.exists()
+        # And no LML PG connection was ever attempted.
+        assert _RaisingPgSource.instances == []
+
+    def test_lml_unavailable_pipeline_fails_fast(self, monkeypatch, fixture_dump, tmp_path):
+        """`--entity-source=lml` fails before any expensive parsing work.
+
+        We assert the failure surfaces as :class:`LmlEntitySourceError` (not a
+        bare exception) and that no SQLite DB was produced.
+        """
+        from run_pipeline import main
+
+        _patch_pg_source_to_raise(monkeypatch)
+        out_dir = tmp_path / "out"
+
+        with pytest.raises(LmlEntitySourceError):
+            main(
+                [
+                    fixture_dump,
+                    "--output-dir",
+                    str(out_dir),
+                    "--min-count",
+                    "1",
+                    "--entity-source",
+                    "lml",
+                    "--discogs-cache-dsn",
+                    "postgresql://example/discogs",
+                ]
+            )
+
+        sqlite_path = out_dir / "wxyc_artist_graph.db"
+        assert not sqlite_path.exists(), "Pipeline wrote output despite LML failure"
+
+    def test_lml_success_path_still_works(self, monkeypatch, fixture_dump, tmp_path):
+        """Sanity check: with a working (mocked) LML PG, the pipeline runs.
+
+        Uses a stub PgSource that returns one identity row matching an artist
+        likely to appear in the fixture dump. We don't assert on identity
+        rows specifically (the fixture is small) — only that the pipeline
+        completes and writes a non-empty `artist` table.
+        """
+        import sqlite3
+
+        from run_pipeline import main
+
+        class _StubPgSource:
+            def __init__(self, dsn: str) -> None:
+                self.dsn = dsn
+
+            def fetchall(self, query: str):  # noqa: ARG002
+                return [
+                    {
+                        "library_name": "Aphex Twin",
+                        "discogs_artist_id": 45,
+                        "wikidata_qid": "Q1397",
+                        "musicbrainz_artist_id": ("f22942a1-6f70-4f48-866e-238cb2308fbd"),
+                        "spotify_artist_id": "6kBDZFXuLrZgHnvmPu9NsG",
+                        "apple_music_artist_id": "3024009",
+                        "bandcamp_id": None,
+                        "reconciliation_status": "reconciled",
+                    },
+                ]
+
+            def close(self) -> None:
+                pass
+
+        monkeypatch.setattr("semantic_index.lml_identity.PgSource", _StubPgSource)
+
+        out_dir = tmp_path / "out"
+        db_path = out_dir / "wxyc_artist_graph.db"
+        # `--db-path` triggers the pipeline-DB path that exercises LML import.
+        out_dir.mkdir()
+
+        main(
+            [
+                fixture_dump,
+                "--output-dir",
+                str(out_dir),
+                "--min-count",
+                "1",
+                "--entity-source",
+                "lml",
+                "--discogs-cache-dsn",
+                "postgresql://example/discogs",
+                "--db-path",
+                str(db_path),
+                "--skip-enrichment",
+                "--no-graph-metrics",
+            ]
+        )
+
+        assert db_path.exists()
+        with sqlite3.connect(str(db_path)) as conn:
+            count = conn.execute("SELECT COUNT(*) FROM artist").fetchone()[0]
+        assert count > 0, "Pipeline produced an empty artist table"

--- a/tests/integration/test_entity_source_lml.py
+++ b/tests/integration/test_entity_source_lml.py
@@ -245,13 +245,11 @@ class TestLmlEntitySourcePipeline:
 class TestLmlEntitySourceCLI:
     """Verify --entity-source CLI flag parsing."""
 
-    def test_entity_source_lml_requires_discogs_dsn(self):
-        """--entity-source=lml without --discogs-cache-dsn should parse but not have a DSN."""
+    def test_entity_source_lml_parses_without_dsn(self):
+        """--entity-source=lml parses; DSN absence is enforced at pipeline run time."""
         from run_pipeline import parse_args
 
-        args = parse_args(
-            ["dump.sql", "--entity-source", "lml", "--entity-store-path", "/tmp/test.db"]
-        )
+        args = parse_args(["dump.sql", "--entity-source", "lml"])
         assert args.entity_source == "lml"
         assert args.discogs_cache_dsn is None
 

--- a/tests/unit/test_run_pipeline.py
+++ b/tests/unit/test_run_pipeline.py
@@ -78,8 +78,21 @@ class TestParseArgs:
             parse_args(["dump.sql", "--skip-reconciliation"])
         with pytest.raises(SystemExit):
             parse_args(["dump.sql", "--fetch-streaming-ids"])
+
+    def test_entity_source_default_is_local(self):
+        """Default entity source is 'local' (skips LML)."""
+        args = parse_args(["dump.sql"])
+        assert args.entity_source == "local"
+
+    def test_entity_source_lml_accepted(self):
+        """--entity-source=lml is accepted as a valid choice."""
+        args = parse_args(["dump.sql", "--entity-source", "lml"])
+        assert args.entity_source == "lml"
+
+    def test_entity_source_invalid_rejected(self):
+        """Invalid --entity-source values are rejected by argparse."""
         with pytest.raises(SystemExit):
-            parse_args(["dump.sql", "--entity-source", "local"])
+            parse_args(["dump.sql", "--entity-source", "remote"])
 
 
 def _make_resolved_entry(


### PR DESCRIPTION
## Summary

- Adds a `--entity-source {local,lml}` flag to `run_pipeline.py` (default: `local`).
- With `--entity-source=lml`, the pipeline probes LML PG (`entity.identity`) before any expensive work and raises `LmlEntitySourceError` if it cannot reach LML — instead of silently falling back to local reconciliation. The error message points the operator at the explicit `--entity-source=local` workaround so a single re-run unblocks them.
- Gates the existing 5d LML import block on `--entity-source=lml` rather than the mere presence of `--discogs-cache-dsn`, so operators who only set the DSN for Discogs enrichment no longer pull from `entity.identity` by accident. Empty LML results (matched=0) are surfaced as a WARNING but do not fail the run.

## Design note

The issue body proposed silent LML-to-local fallback. We deliberately rejected that: a silent fallback masks LML config errors (wrong DSN, expired credentials, network outages) and can hide weeks of degraded reconciliation. Failing loudly with an actionable message preserves the operator's choice and keeps misconfiguration visible.

## Test plan

- [x] `pytest tests/integration/test_entity_source_fallback.py -v -m integration` (7 new tests)
- [x] `pytest tests/unit/ -q` (656 passing, no regressions)
- [x] Stale `TestLmlEntitySourceCLI` tests in `test_entity_source_lml.py` updated and now passing under `-m integration`
- [x] `ruff check .` and `ruff format --check .` clean
- [x] mypy clean (pre-commit hook)

Closes #183