### PR TITLE
Un-skip cross-reference E2E test now that fixture exposes the path

### DIFF
--- a/tests/e2e/test_full_pipeline.py
+++ b/tests/e2e/test_full_pipeline.py
@@ -202,27 +202,16 @@ class TestFullPipeline:
     # -- Cross-references --
 
     def test_cross_reference_edges_extracted(self) -> None:
-        """Cross-reference edges populated when the fixture exposes the path.
+        """Cross-reference edges are extracted from the fixture.
 
-        The tubafrenzy dev fixture has 119 LIBRARY_CODE_CROSS_REFERENCE rows
-        and 35 RELEASE_CROSS_REFERENCE rows, but every CROSS_REFERENCING_ARTIST_ID
-        in those rows points at a LIBRARY_CODE.ID outside the truncated 1000-row
-        LIBRARY_CODE table that ships in the fixture. cross_reference.py logs a
-        warning and skips each unresolvable row, so extraction returns zero edges
-        and the cross_reference table comes out empty. Skip in that case so the
-        assertion fires automatically the moment the fixture's LIBRARY_CODE table
-        is widened to cover those IDs; until then, cross_reference extraction is
-        exercised directly by the unit tests.
+        The tubafrenzy dev fixture appends a small set of synthetic
+        LIBRARY_CODE_CROSS_REFERENCE and RELEASE_CROSS_REFERENCE rows that
+        reference LIBRARY_CODE / LIBRARY_RELEASE IDs already present in the
+        truncated fixture. The historical cross-ref rows reference much older
+        IDs that fall outside the top-1000-by-ID truncation window and are
+        silently skipped at extraction time. See WXYC/semantic-index#185.
         """
         count = self.conn.execute("SELECT count(*) FROM cross_reference").fetchone()[0]
-        if count == 0:
-            pytest.skip(
-                "cross_reference table is empty: every cross-ref row in "
-                "wxycmusic-fixture.sql references a LIBRARY_CODE.ID outside "
-                "the fixture's truncated LIBRARY_CODE table, so all rows are "
-                "skipped during extraction. Widen the fixture's LIBRARY_CODE "
-                "rows to cover the referenced IDs to exercise this path."
-            )
         assert count > 0, "cross_reference table is empty"
 
     # -- Facet tables --

--- a/tests/e2e/test_full_pipeline.py
+++ b/tests/e2e/test_full_pipeline.py
@@ -204,15 +204,36 @@ class TestFullPipeline:
     def test_cross_reference_edges_extracted(self) -> None:
         """Cross-reference edges are extracted from the fixture.
 
-        The tubafrenzy dev fixture appends a small set of synthetic
-        LIBRARY_CODE_CROSS_REFERENCE and RELEASE_CROSS_REFERENCE rows that
-        reference LIBRARY_CODE / LIBRARY_RELEASE IDs already present in the
-        truncated fixture. The historical cross-ref rows reference much older
-        IDs that fall outside the top-1000-by-ID truncation window and are
-        silently skipped at extraction time. See WXYC/semantic-index#185.
+        Both extraction paths (LIBRARY_CODE_CROSS_REFERENCE and
+        RELEASE_CROSS_REFERENCE) must produce at least one edge. The fixture's
+        historical cross-ref rows reference LIBRARY_CODE / LIBRARY_RELEASE IDs
+        that fall outside the top-1000-by-ID truncation window and are silently
+        skipped at extraction time; the fixture compensates by either (a)
+        appending synthetic rows whose FKs land inside the truncation window
+        or (b) pulling in the extra referenced rows via the supplemental
+        ``--no-create-info`` mysqldump invocations in
+        ``scripts/dev/generate-fixture-dump.sh``. Either mechanism keeps both
+        ``source`` flavours populated; if you regenerate the fixture and this
+        test starts failing, that's the contract that broke. See
+        WXYC/semantic-index#185 and WXYC/tubafrenzy#486.
+
+        Source of truth for the cross-ref IDs:
+        ``tubafrenzy/scripts/dev/fixtures/wxycmusic-fixture.sql``.
         """
-        count = self.conn.execute("SELECT count(*) FROM cross_reference").fetchone()[0]
-        assert count > 0, "cross_reference table is empty"
+        rows = self.conn.execute(
+            "SELECT source, count(*) FROM cross_reference GROUP BY source"
+        ).fetchall()
+        by_source = {row["source"]: row[1] for row in rows}
+        total = sum(by_source.values())
+        assert total > 0, "cross_reference table is empty"
+        assert by_source.get("library_code", 0) > 0, (
+            "no library_code cross-ref edges -- LIBRARY_CODE_CROSS_REFERENCE "
+            "extraction path is not exercised by the fixture"
+        )
+        assert by_source.get("release", 0) > 0, (
+            "no release cross-ref edges -- RELEASE_CROSS_REFERENCE extraction "
+            "path is not exercised by the fixture"
+        )
 
     # -- Facet tables --
 


### PR DESCRIPTION
Closes #185.

Removes the `pytest.skip`-when-empty guard from `test_cross_reference_edges_extracted`. The tubafrenzy fixture has been widened to include synthetic LIBRARY_CODE_CROSS_REFERENCE / RELEASE_CROSS_REFERENCE rows whose FKs resolve against the truncated LIBRARY_CODE / LIBRARY_RELEASE tables, so the cross_reference extraction path produces non-zero rows and the assertion can fire unconditionally.

## Sequencing

Depends on WXYC/tubafrenzy#486 — that fixture PR must merge first; CI here pulls the fixture from the sibling tubafrenzy checkout.

## Test plan

- [x] Local run of `tests/e2e/test_full_pipeline.py::TestFullPipeline` against the updated fixture: all 19 tests pass with `cross_reference` populated (20 edges).
- [ ] CI passes after the tubafrenzy PR is merged and the fresh fixture is loaded.