### PR TITLE
M0.2: audit SI graph for mojibake duplicate-artist nodes

### DIFF
--- a/audit/si_audit_summary.md
+++ b/audit/si_audit_summary.md
@@ -1,0 +1,17 @@
+# M0.2 — semantic-index mojibake duplicate-artist audit
+
+Total pairs: 0
+Total edges affected: 0
+Total plays affected: 0
+
+## Scan diagnostics
+
+- Total artists scanned: 136702
+- Round-trippable mojibake names (latin1->utf8 reversible): 0
+- Lossy-mojibake names (contain `?` + latin1-supplement chars, unrecoverable here): 73
+
+A pair is reported only when **both** the corrupted form and its round-trippable fixed form exist as separate artist rows. Lossy-mojibake names cannot be auto-recovered and require V013's human-reviewed lossy mappings to detect any corresponding duplicates. M2.2 will need to re-scan after V012 propagates and V013 lands.
+
+## Top 0 pairs by combined edge count
+
+_No round-trippable duplicate pairs found._

--- a/audit/si_duplicate_artists.csv
+++ b/audit/si_duplicate_artists.csv
@@ -1,0 +1,1 @@
+corrupted_id,corrupted_name,fixed_id,fixed_name,corrupted_edge_count,fixed_edge_count,corrupted_play_count,fixed_play_count

--- a/scripts/audit/si_mojibake_scan.py
+++ b/scripts/audit/si_mojibake_scan.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""M0.2 audit: find duplicate-artist nodes that exist only because of mojibake.
+
+Scans the semantic-index SQLite graph for artist rows whose `canonical_name`
+is double-encoded UTF-8 (e.g. ``björk``) AND whose latin1->utf8 round-trip
+recovery (``björk``) also exists as a separate node. Each such pair is one
+duplicate that the M2.2 reconciliation step will need to merge.
+
+Read-only. Writes a CSV and a Markdown summary. Does not modify the DB.
+
+Usage:
+    python scripts/audit/si_mojibake_scan.py \\
+        --db data/wxyc_artist_graph.db \\
+        --csv audit/si_duplicate_artists.csv \\
+        --summary audit/si_audit_summary.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import logging
+import sqlite3
+import sys
+from dataclasses import dataclass, fields
+from pathlib import Path
+
+log = logging.getLogger("si_mojibake_scan")
+
+# Edge tables in the semantic-index SQLite graph and the column pair that
+# references artist.id. Tables not present in older databases are skipped.
+EDGE_TABLES: list[tuple[str, str, str]] = [
+    ("dj_transition", "source_id", "target_id"),
+    ("cross_reference", "artist_a_id", "artist_b_id"),
+    ("wikidata_influence", "source_id", "target_id"),
+    ("acoustic_similarity", "artist_a_id", "artist_b_id"),
+    ("shared_personnel", "artist_a_id", "artist_b_id"),
+    ("shared_style", "artist_a_id", "artist_b_id"),
+    ("label_family", "artist_a_id", "artist_b_id"),
+    ("compilation", "artist_a_id", "artist_b_id"),
+]
+
+
+def try_fix(s: str | None) -> str | None:
+    """Recover a string corrupted by latin1->utf8 double-encoding.
+
+    Returns the recovered string, or None if the input is clean, lossy, or
+    not a valid double-encoding.
+    """
+    if not s:
+        return None
+    try:
+        fixed = s.encode("latin1").decode("utf-8")
+    except (UnicodeEncodeError, UnicodeDecodeError):
+        return None
+    if fixed == s:
+        return None
+    if "\ufffd" in fixed:
+        return None
+    return fixed
+
+
+@dataclass(frozen=True)
+class DuplicatePair:
+    corrupted_id: int
+    corrupted_name: str
+    fixed_id: int
+    fixed_name: str
+    corrupted_edge_count: int
+    fixed_edge_count: int
+    corrupted_play_count: int
+    fixed_play_count: int
+
+    @property
+    def total_edges(self) -> int:
+        return self.corrupted_edge_count + self.fixed_edge_count
+
+
+def _existing_edge_tables(conn: sqlite3.Connection) -> list[tuple[str, str, str]]:
+    rows = conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
+    present = {r[0] for r in rows}
+    return [t for t in EDGE_TABLES if t[0] in present]
+
+
+def _edge_counts(conn: sqlite3.Connection, ids: set[int]) -> dict[int, int]:
+    """Count edges (incoming + outgoing) per artist id across all edge tables."""
+    counts: dict[int, int] = dict.fromkeys(ids, 0)
+    if not ids:
+        return counts
+    id_list = ",".join(str(i) for i in ids)
+    for table, col_a, col_b in _existing_edge_tables(conn):
+        for col in (col_a, col_b):
+            cur = conn.execute(
+                f"SELECT {col}, COUNT(*) FROM {table} "
+                f"WHERE {col} IN ({id_list}) GROUP BY {col}"
+            )
+            for artist_id, n in cur:
+                counts[artist_id] = counts.get(artist_id, 0) + n
+    return counts
+
+
+def has_latin1_supplement(s: str) -> bool:
+    return any(0x80 <= ord(c) <= 0xFF for c in s)
+
+
+def looks_lossy_mojibake(s: str) -> bool:
+    """Strong signal of double-encoded utf-8 corrupted by an intermediate '?' replacement."""
+    return "?" in s and has_latin1_supplement(s)
+
+
+@dataclass(frozen=True)
+class ScanCounts:
+    total_artists: int
+    fixable_names: int
+    lossy_mojibake_names: int
+
+
+def scan_counts(conn: sqlite3.Connection) -> ScanCounts:
+    total = 0
+    fixable = 0
+    lossy = 0
+    for (name,) in conn.execute("SELECT canonical_name FROM artist"):
+        total += 1
+        if try_fix(name) is not None:
+            fixable += 1
+        elif looks_lossy_mojibake(name):
+            lossy += 1
+    return ScanCounts(total_artists=total, fixable_names=fixable, lossy_mojibake_names=lossy)
+
+
+def find_mojibake_duplicates(conn: sqlite3.Connection) -> list[DuplicatePair]:
+    """Return all (corrupted, fixed) pairs that both exist as separate artist rows."""
+    name_to_row: dict[str, tuple[int, int]] = {}
+    for row in conn.execute("SELECT id, canonical_name, total_plays FROM artist"):
+        name_to_row[row[1]] = (row[0], row[2] or 0)
+
+    candidates: list[tuple[str, str]] = []
+    for name in name_to_row:
+        fixed = try_fix(name)
+        if fixed is not None and fixed in name_to_row:
+            candidates.append((name, fixed))
+
+    all_ids = {name_to_row[n][0] for pair in candidates for n in pair}
+    edge_counts = _edge_counts(conn, all_ids)
+
+    pairs: list[DuplicatePair] = []
+    for corrupted, fixed in candidates:
+        c_id, c_plays = name_to_row[corrupted]
+        f_id, f_plays = name_to_row[fixed]
+        pairs.append(
+            DuplicatePair(
+                corrupted_id=c_id,
+                corrupted_name=corrupted,
+                fixed_id=f_id,
+                fixed_name=fixed,
+                corrupted_edge_count=edge_counts.get(c_id, 0),
+                fixed_edge_count=edge_counts.get(f_id, 0),
+                corrupted_play_count=c_plays,
+                fixed_play_count=f_plays,
+            )
+        )
+    pairs.sort(key=lambda p: (-p.total_edges, p.fixed_name))
+    return pairs
+
+
+def write_csv(pairs: list[DuplicatePair], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    cols = [f.name for f in fields(DuplicatePair)]
+    with path.open("w", newline="", encoding="utf-8") as fh:
+        w = csv.writer(fh)
+        w.writerow(cols)
+        for p in pairs:
+            w.writerow([getattr(p, c) for c in cols])
+
+
+def write_summary(
+    pairs: list[DuplicatePair],
+    path: Path,
+    counts: ScanCounts | None = None,
+    top_n: int = 20,
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    total_edges = sum(p.total_edges for p in pairs)
+    total_plays = sum(p.corrupted_play_count + p.fixed_play_count for p in pairs)
+    lines: list[str] = []
+    lines.append("# M0.2 — semantic-index mojibake duplicate-artist audit")
+    lines.append("")
+    lines.append(f"Total pairs: {len(pairs)}")
+    lines.append(f"Total edges affected: {total_edges}")
+    lines.append(f"Total plays affected: {total_plays}")
+    if counts is not None:
+        lines.append("")
+        lines.append("## Scan diagnostics")
+        lines.append("")
+        lines.append(f"- Total artists scanned: {counts.total_artists}")
+        lines.append(
+            f"- Round-trippable mojibake names (latin1->utf8 reversible): "
+            f"{counts.fixable_names}"
+        )
+        lines.append(
+            f"- Lossy-mojibake names (contain `?` + latin1-supplement chars, "
+            f"unrecoverable here): {counts.lossy_mojibake_names}"
+        )
+        lines.append("")
+        lines.append(
+            "A pair is reported only when **both** the corrupted form and its "
+            "round-trippable fixed form exist as separate artist rows. Lossy-mojibake "
+            "names cannot be auto-recovered and require V013's human-reviewed lossy "
+            "mappings to detect any corresponding duplicates. M2.2 will need to "
+            "re-scan after V012 propagates and V013 lands."
+        )
+    lines.append("")
+    lines.append(f"## Top {min(top_n, len(pairs))} pairs by combined edge count")
+    lines.append("")
+    if pairs:
+        lines.append(
+            "| Fixed name | Corrupted name | Fixed plays | Corrupted plays | "
+            "Fixed edges | Corrupted edges |"
+        )
+        lines.append("|---|---|---:|---:|---:|---:|")
+        for p in pairs[:top_n]:
+            lines.append(
+                f"| `{p.fixed_name}` | `{p.corrupted_name}` | {p.fixed_play_count} | "
+                f"{p.corrupted_play_count} | {p.fixed_edge_count} | "
+                f"{p.corrupted_edge_count} |"
+            )
+    else:
+        lines.append("_No round-trippable duplicate pairs found._")
+    lines.append("")
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def _open_readonly(db_path: Path) -> sqlite3.Connection:
+    uri = f"file:{db_path}?mode=ro"
+    return sqlite3.connect(uri, uri=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("--db", type=Path, required=True, help="Path to wxyc_artist_graph.db")
+    parser.add_argument("--csv", type=Path, default=Path("audit/si_duplicate_artists.csv"))
+    parser.add_argument("--summary", type=Path, default=Path("audit/si_audit_summary.md"))
+    parser.add_argument("--verbose", action="store_true")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+        datefmt="%H:%M:%S",
+    )
+
+    if not args.db.exists():
+        log.error("DB not found: %s", args.db)
+        return 2
+
+    log.info("Scanning %s (read-only)...", args.db)
+    conn = _open_readonly(args.db)
+    try:
+        counts = scan_counts(conn)
+        pairs = find_mojibake_duplicates(conn)
+    finally:
+        conn.close()
+
+    write_csv(pairs, args.csv)
+    write_summary(pairs, args.summary, counts=counts)
+
+    total_edges = sum(p.total_edges for p in pairs)
+    log.info(
+        "Scanned %d artists: %d round-trippable mojibake, %d lossy-mojibake, "
+        "%d duplicate pairs covering %d edges. CSV: %s — summary: %s",
+        counts.total_artists,
+        counts.fixable_names,
+        counts.lossy_mojibake_names,
+        len(pairs),
+        total_edges,
+        args.csv,
+        args.summary,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_si_mojibake_scan.py
+++ b/tests/unit/test_si_mojibake_scan.py
@@ -1,0 +1,228 @@
+"""Tests for the M0.2 mojibake duplicate-artist audit."""
+
+from __future__ import annotations
+
+import importlib.util
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "audit" / "si_mojibake_scan.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("si_mojibake_scan", SCRIPT_PATH)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["si_mojibake_scan"] = mod  # required for dataclasses on 3.14
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def mod():
+    return _load_module()
+
+
+# Mojibake fixtures (kept as escape sequences so the file's UTF-8 encoding
+# can't ambiguate the byte sequence we're testing).
+BJORK_MOJIBAKE = "bj\u00c3\u00b6rk"  # "björk" as latin1-misread of utf-8 "björk"
+BJORK_FIXED = "bj\u00f6rk"  # "björk"
+MU_MOJIBAKE = "\u00ce\u00bc-ziq"  # "Î¼-ziq" — mojibake of "μ-ziq"
+MU_FIXED = "\u03bc-ziq"  # "μ-ziq"
+
+
+class TestTryFix:
+    def test_recovers_double_encoded_lowercase_diacritic(self, mod):
+        assert mod.try_fix(BJORK_MOJIBAKE) == BJORK_FIXED
+
+    def test_recovers_greek(self, mod):
+        assert mod.try_fix(MU_MOJIBAKE) == MU_FIXED
+
+    def test_returns_none_for_clean_string(self, mod):
+        assert mod.try_fix(BJORK_FIXED) is None
+
+    def test_returns_none_for_ascii(self, mod):
+        assert mod.try_fix("autechre") is None
+
+    def test_returns_none_for_unrecoverable_lossy(self, mod):
+        # '?' bytes cannot round-trip back into a valid utf-8 sequence
+        assert mod.try_fix("b\u00e3?rns") is None
+
+    def test_returns_none_for_empty(self, mod):
+        assert mod.try_fix("") is None
+        assert mod.try_fix(None) is None
+
+    def test_rejects_replacement_char(self, mod):
+        # If decoding produces U+FFFD, the recovery is unreliable.
+        assert mod.try_fix("\ufffd") is None
+
+
+def _make_db() -> sqlite3.Connection:
+    """In-memory schema that mirrors the audit's reads."""
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(
+        """
+        CREATE TABLE artist (
+            id INTEGER PRIMARY KEY,
+            canonical_name TEXT NOT NULL UNIQUE,
+            total_plays INTEGER NOT NULL DEFAULT 0
+        );
+        CREATE TABLE dj_transition (
+            source_id INTEGER NOT NULL,
+            target_id INTEGER NOT NULL,
+            raw_count INTEGER NOT NULL,
+            pmi REAL NOT NULL,
+            PRIMARY KEY (source_id, target_id)
+        );
+        CREATE TABLE cross_reference (
+            artist_a_id INTEGER NOT NULL,
+            artist_b_id INTEGER NOT NULL,
+            comment TEXT,
+            source TEXT NOT NULL,
+            PRIMARY KEY (artist_a_id, artist_b_id, source)
+        );
+        """
+    )
+    return conn
+
+
+class TestFindDuplicates:
+    def test_finds_pair_when_both_forms_exist(self, mod):
+        conn = _make_db()
+        conn.executemany(
+            "INSERT INTO artist (id, canonical_name, total_plays) VALUES (?, ?, ?)",
+            [
+                (1, BJORK_FIXED, 100),
+                (2, BJORK_MOJIBAKE, 5),
+                (3, "autechre", 200),
+            ],
+        )
+        conn.execute(
+            "INSERT INTO dj_transition VALUES (?, ?, ?, ?)", (2, 3, 4, 0.1)
+        )  # corrupted -> autechre
+        conn.execute(
+            "INSERT INTO dj_transition VALUES (?, ?, ?, ?)", (3, 1, 7, 0.2)
+        )  # autechre -> fixed
+        conn.execute("INSERT INTO cross_reference VALUES (?, ?, ?, ?)", (2, 3, "see", "lc"))
+
+        pairs = mod.find_mojibake_duplicates(conn)
+
+        assert len(pairs) == 1
+        p = pairs[0]
+        assert p.corrupted_id == 2
+        assert p.fixed_id == 1
+        assert p.corrupted_name == BJORK_MOJIBAKE
+        assert p.fixed_name == BJORK_FIXED
+        assert p.corrupted_play_count == 5
+        assert p.fixed_play_count == 100
+        assert p.corrupted_edge_count == 2  # one dj_transition + one xref
+        assert p.fixed_edge_count == 1  # one dj_transition
+
+    def test_no_pair_when_only_corrupted_exists(self, mod):
+        conn = _make_db()
+        conn.execute(
+            "INSERT INTO artist (id, canonical_name, total_plays) VALUES (?, ?, ?)",
+            (1, BJORK_MOJIBAKE, 5),
+        )
+        assert mod.find_mojibake_duplicates(conn) == []
+
+    def test_no_pair_for_clean_unicode(self, mod):
+        conn = _make_db()
+        conn.executemany(
+            "INSERT INTO artist (id, canonical_name, total_plays) VALUES (?, ?, ?)",
+            [(1, BJORK_FIXED, 100), (2, "jo\u00e3o gilberto", 50)],
+        )
+        assert mod.find_mojibake_duplicates(conn) == []
+
+    def test_handles_missing_optional_edge_tables(self, mod):
+        conn = sqlite3.connect(":memory:")
+        conn.executescript(
+            """
+            CREATE TABLE artist (
+                id INTEGER PRIMARY KEY,
+                canonical_name TEXT NOT NULL UNIQUE,
+                total_plays INTEGER NOT NULL DEFAULT 0
+            );
+            CREATE TABLE dj_transition (
+                source_id INTEGER NOT NULL,
+                target_id INTEGER NOT NULL,
+                raw_count INTEGER NOT NULL,
+                pmi REAL NOT NULL,
+                PRIMARY KEY (source_id, target_id)
+            );
+            """
+        )
+        conn.executemany(
+            "INSERT INTO artist (id, canonical_name, total_plays) VALUES (?, ?, ?)",
+            [(1, BJORK_FIXED, 100), (2, BJORK_MOJIBAKE, 5)],
+        )
+        # No cross_reference table — must not crash.
+        pairs = mod.find_mojibake_duplicates(conn)
+        assert len(pairs) == 1
+        assert pairs[0].corrupted_id == 2
+
+
+class TestRender:
+    def test_csv_round_trip(self, mod, tmp_path):
+        pair = mod.DuplicatePair(
+            corrupted_id=2,
+            corrupted_name=BJORK_MOJIBAKE,
+            fixed_id=1,
+            fixed_name=BJORK_FIXED,
+            corrupted_edge_count=3,
+            fixed_edge_count=10,
+            corrupted_play_count=5,
+            fixed_play_count=100,
+        )
+        csv_path = tmp_path / "out.csv"
+        mod.write_csv([pair], csv_path)
+        text = csv_path.read_text(encoding="utf-8")
+        assert BJORK_MOJIBAKE in text
+        assert BJORK_FIXED in text
+        assert text.splitlines()[0].startswith("corrupted_id")
+
+    def test_summary_includes_totals_and_top(self, mod, tmp_path):
+        pairs = [
+            mod.DuplicatePair(2, BJORK_MOJIBAKE, 1, BJORK_FIXED, 3, 10, 5, 100),
+            mod.DuplicatePair(4, MU_MOJIBAKE, 3, MU_FIXED, 1, 2, 1, 5),
+        ]
+        path = tmp_path / "summary.md"
+        mod.write_summary(pairs, path)
+        text = path.read_text(encoding="utf-8")
+        assert "Total pairs: 2" in text
+        assert "Total edges affected: 16" in text  # 3+10+1+2
+        assert BJORK_FIXED in text
+        assert MU_FIXED in text
+
+    def test_summary_reports_zero_pairs_with_diagnostics(self, mod, tmp_path):
+        path = tmp_path / "summary.md"
+        counts = mod.ScanCounts(total_artists=100, fixable_names=0, lossy_mojibake_names=42)
+        mod.write_summary([], path, counts=counts)
+        text = path.read_text(encoding="utf-8")
+        assert "Total pairs: 0" in text
+        assert "Total artists scanned: 100" in text
+        assert "Lossy-mojibake names" in text
+        assert "42" in text
+        assert "No round-trippable duplicate pairs" in text
+
+
+class TestScanCounts:
+    def test_counts_partition_artists(self, mod):
+        conn = _make_db()
+        conn.executemany(
+            "INSERT INTO artist (id, canonical_name, total_plays) VALUES (?, ?, ?)",
+            [
+                (1, BJORK_FIXED, 0),  # clean unicode
+                (2, BJORK_MOJIBAKE, 0),  # round-trippable
+                (3, "autechre", 0),  # ascii
+                (4, "b\u00e3?rns", 0),  # lossy
+                (5, "ã??ã?¯", 0),  # lossy
+            ],
+        )
+        c = mod.scan_counts(conn)
+        assert c.total_artists == 5
+        assert c.fixable_names == 1
+        assert c.lossy_mojibake_names == 2


### PR DESCRIPTION
## Summary

- Adds a read-only audit script (`scripts/audit/si_mojibake_scan.py`) that scans `data/wxyc_artist_graph.db` for artist rows where both the double-encoded mojibake form and its latin1->utf8 round-trippable recovery exist as separate node ids.
- Counts edges (incoming + outgoing) across all artist-keyed edge tables (`dj_transition`, `cross_reference`, `wikidata_influence`, `acoustic_similarity`, `shared_personnel`, `shared_style`, `label_family`, `compilation`) so M2.2 can scope reconciliation by impact.
- Emits `audit/si_duplicate_artists.csv` (one row per pair) and `audit/si_audit_summary.md` (totals + top-20 + scan diagnostics).
- Unit-tested via `tests/unit/test_si_mojibake_scan.py` (15 tests).

## First-run findings

On the committed graph (`data/wxyc_artist_graph.db`, 136,702 artists):

- **0** round-trippable mojibake duplicate pairs
- **0** round-trippable mojibake names overall
- **73** lossy-mojibake names (contain `?` + latin1-supplement chars)

Round-trip recovery does not work on these 73 names because they were already corrupted with intermediate `?` replacements before reaching the SI graph. They are V013 (lossy) territory and need the human-reviewed `mojibake_lossy_proposals.csv` mappings before any duplicate detection can be done. M2.2 should re-run this audit after V012 propagates and V013 lands; the scan diagnostics in the summary will surface the same lossy-name population once V013 supplies fixed forms.

## Test plan

- [x] `pytest tests/unit/test_si_mojibake_scan.py` — 15 / 15 pass.
- [x] `python scripts/audit/si_mojibake_scan.py --db data/wxyc_artist_graph.db ...` — runs in <1s, writes both output files.
- [x] Ruff check + format + mypy pass via pre-commit hook.

Refs WXYC/docs#6
Closes #188