### PR TITLE
ci: run integration and e2e tiers; guard with marker-sync workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,3 +56,82 @@ jobs:
       - run: pip install _wxyc-etl/target/wheels/*.whl
       - run: pip install -e ".[api,dev]"
       - run: pytest tests/unit/ -v --cov=semantic_index --cov-report=term-missing
+
+  integration:
+    # Runs the integration-marked tests that don't need external service data.
+    # The discogs-edges SQL tests require a populated discogs-cache PG (out of
+    # reach in CI — the cache is built from a multi-GB Discogs XML dump), so
+    # they self-skip when `DATABASE_URL_DISCOGS` is unreachable.
+    #
+    # Three integration files (test_entity_migration, test_entity_source_lml,
+    # test_entity_store_pipeline) import the deleted ``semantic_index.entity_store``
+    # module and will fail at import. They are owned by issue #184 and explicitly
+    # ignored here so this guardrail can land green; #184 will resurrect or
+    # delete them as part of the entity-source rework.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          repository: WXYC/wxyc-etl
+          path: _wxyc-etl
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v4
+        with:
+          repository: WXYC/tubafrenzy
+          path: tubafrenzy
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: dtolnay/rust-toolchain@stable
+      - run: pip install maturin
+      - run: cd _wxyc-etl/wxyc-etl-python && maturin build --release
+      - run: pip install _wxyc-etl/target/wheels/*.whl
+      - run: pip install -e ".[api,dev]"
+      - name: Run integration tests
+        env:
+          TUBAFRENZY_FIXTURE: ${{ github.workspace }}/tubafrenzy/scripts/dev/fixtures/wxycmusic-fixture.sql
+        run: >-
+          pytest tests/integration/ -v
+          -m "integration"
+          --ignore=tests/integration/test_entity_migration.py
+          --ignore=tests/integration/test_entity_source_lml.py
+          --ignore=tests/integration/test_entity_store_pipeline.py
+
+  e2e:
+    # Runs the end-to-end pipeline tests against the tubafrenzy fixture dump.
+    # Cloning tubafrenzy is cheap (the fixture is committed); no external DB
+    # is needed because the pipeline parses the SQL dump directly.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          repository: WXYC/wxyc-etl
+          path: _wxyc-etl
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v4
+        with:
+          repository: WXYC/tubafrenzy
+          path: tubafrenzy
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: dtolnay/rust-toolchain@stable
+      - run: pip install maturin
+      - run: cd _wxyc-etl/wxyc-etl-python && maturin build --release
+      - run: pip install _wxyc-etl/target/wheels/*.whl
+      - run: pip install -e ".[api,dev]"
+      - name: Run e2e tests
+        env:
+          TUBAFRENZY_FIXTURE: ${{ github.workspace }}/tubafrenzy/scripts/dev/fixtures/wxycmusic-fixture.sql
+        run: pytest tests/e2e/ -v -m "e2e"
+
+  marker-sync:
+    uses: WXYC/wxyc-etl/.github/workflows/check-ci-marker-sync.yml@main
+    with:
+      repo-path: "."
+      workflows-dir: ".github/workflows"
+      tests-dir: "tests"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,10 +76,15 @@ jobs:
     #
     # Three integration files (`test_entity_migration`,
     # `test_entity_source_lml`, `test_entity_store_pipeline`) import the
-    # deleted `semantic_index.entity_store` module and would fail at
-    # collection. They are owned by the parallel entity-source rework and
-    # explicitly ignored here so this guardrail can land green; that effort
-    # will resurrect or delete them as part of its own PR.
+    # deleted `semantic_index.entity_store` module (removed in commit
+    # e8226d3, "Delete dead entity resolution code"; the deletion is
+    # asserted by `tests/unit/test_deletion_audit.py`) and would fail at
+    # collection. The successor module is `semantic_index.pipeline_db`.
+    # They are owned by the parallel entity-source rework and explicitly
+    # ignored here so this guardrail can land green; that effort will
+    # port them to PipelineDB or delete them as part of its own PR.
+    # TODO: remove these `--ignore` lines once the entity-source rework
+    # ports or deletes the three files; grep for `entity_store` here.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -108,11 +113,13 @@ jobs:
     # Runs the end-to-end pipeline tests. These require the tubafrenzy
     # fixture dump (`tubafrenzy/scripts/dev/fixtures/wxycmusic-fixture.sql`),
     # which lives in a private sibling repo. See the comment on the
-    # `integration` job above for why we don't clone it. Tests self-skip
-    # via `_find_fixture` when `TUBAFRENZY_FIXTURE` is unset; the job still
-    # exists so `pytest -m e2e` is exercised and cannot regress to silent
-    # deselection by addopts. Local developers with WXYC sibling checkouts
-    # get the real assertions.
+    # `integration` job above for why we don't clone it. Without the
+    # fixture, every e2e test self-skips via the class-scoped
+    # `_run_pipeline` fixture in `tests/e2e/test_full_pipeline.py`, so
+    # in CI this job currently reports `24 skipped, 0 passed` — it is a
+    # marker-reachability guardrail (preventing silent addopts
+    # deselection of `-m e2e`), NOT a source of real coverage. Real
+    # assertions only run for developers with WXYC sibling checkouts.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,16 +58,28 @@ jobs:
       - run: pytest tests/unit/ -v --cov=semantic_index --cov-report=term-missing
 
   integration:
-    # Runs the integration-marked tests that don't need external service data.
-    # The discogs-edges SQL tests require a populated discogs-cache PG (out of
-    # reach in CI — the cache is built from a multi-GB Discogs XML dump), so
-    # they self-skip when `DATABASE_URL_DISCOGS` is unreachable.
+    # Runs the integration-marked tests. Most of these need the tubafrenzy
+    # fixture dump (`tubafrenzy/scripts/dev/fixtures/wxycmusic-fixture.sql`),
+    # which lives in a private sibling repo and so cannot be cloned with the
+    # default `GITHUB_TOKEN`. We deliberately do NOT add a cross-org PAT just
+    # to clone a fixture (per repo policy); instead, the tests self-skip
+    # cleanly via the `_find_fixture` walker when `TUBAFRENZY_FIXTURE` is
+    # unset. The job still exists so that:
+    #   1. `pytest -m integration` is exercised in CI (no more silent
+    #      addopts deselection of integration-marked tests, which is the
+    #      regression #186 was opened to prevent), and
+    #   2. integration tests that DON'T need the fixture (e.g. the
+    #      discogs-edges SQL tests, which only need `DATABASE_URL_DISCOGS`)
+    #      run for real when their preconditions are met locally.
+    # Local developers with the WXYC org checked out side-by-side get full
+    # coverage automatically.
     #
-    # Three integration files (test_entity_migration, test_entity_source_lml,
-    # test_entity_store_pipeline) import the deleted ``semantic_index.entity_store``
-    # module and will fail at import. They are owned by issue #184 and explicitly
-    # ignored here so this guardrail can land green; #184 will resurrect or
-    # delete them as part of the entity-source rework.
+    # Three integration files (`test_entity_migration`,
+    # `test_entity_source_lml`, `test_entity_store_pipeline`) import the
+    # deleted `semantic_index.entity_store` module and would fail at
+    # collection. They are owned by the parallel entity-source rework and
+    # explicitly ignored here so this guardrail can land green; that effort
+    # will resurrect or delete them as part of its own PR.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -75,11 +87,6 @@ jobs:
         with:
           repository: WXYC/wxyc-etl
           path: _wxyc-etl
-          token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/checkout@v4
-        with:
-          repository: WXYC/tubafrenzy
-          path: tubafrenzy
           token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-python@v5
         with:
@@ -90,8 +97,6 @@ jobs:
       - run: pip install _wxyc-etl/target/wheels/*.whl
       - run: pip install -e ".[api,dev]"
       - name: Run integration tests
-        env:
-          TUBAFRENZY_FIXTURE: ${{ github.workspace }}/tubafrenzy/scripts/dev/fixtures/wxycmusic-fixture.sql
         run: >-
           pytest tests/integration/ -v
           -m "integration"
@@ -100,9 +105,14 @@ jobs:
           --ignore=tests/integration/test_entity_store_pipeline.py
 
   e2e:
-    # Runs the end-to-end pipeline tests against the tubafrenzy fixture dump.
-    # Cloning tubafrenzy is cheap (the fixture is committed); no external DB
-    # is needed because the pipeline parses the SQL dump directly.
+    # Runs the end-to-end pipeline tests. These require the tubafrenzy
+    # fixture dump (`tubafrenzy/scripts/dev/fixtures/wxycmusic-fixture.sql`),
+    # which lives in a private sibling repo. See the comment on the
+    # `integration` job above for why we don't clone it. Tests self-skip
+    # via `_find_fixture` when `TUBAFRENZY_FIXTURE` is unset; the job still
+    # exists so `pytest -m e2e` is exercised and cannot regress to silent
+    # deselection by addopts. Local developers with WXYC sibling checkouts
+    # get the real assertions.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -110,11 +120,6 @@ jobs:
         with:
           repository: WXYC/wxyc-etl
           path: _wxyc-etl
-          token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/checkout@v4
-        with:
-          repository: WXYC/tubafrenzy
-          path: tubafrenzy
           token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-python@v5
         with:
@@ -125,8 +130,6 @@ jobs:
       - run: pip install _wxyc-etl/target/wheels/*.whl
       - run: pip install -e ".[api,dev]"
       - name: Run e2e tests
-        env:
-          TUBAFRENZY_FIXTURE: ${{ github.workspace }}/tubafrenzy/scripts/dev/fixtures/wxycmusic-fixture.sql
         run: pytest tests/e2e/ -v -m "e2e"
 
   marker-sync:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,15 +87,15 @@ module = ["boto3", "botocore.*", "essentia", "essentia.*"]
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]
+# ci-sync-skip: slow reason: perf benchmarks (test_artist_resolver_rust); manual-only
 markers = [
     "unit: pure logic tests, no external dependencies",
     "postgres: needs PostgreSQL (gated by DATABASE_URL_TEST)",
     "integration: needs external service or fixture data",
     "e2e: full pipeline end-to-end test",
-    "parity: old vs new implementation comparison",
     "slow: marks tests as slow",
 ]
-addopts = "-m 'not integration and not postgres and not e2e and not parity and not slow'"
+addopts = "-m 'not integration and not postgres and not e2e and not slow'"
 console_output_style = "progress"
 testpaths = ["tests"]
 pythonpath = ["."]

--- a/tests/integration/test_discogs_edges_sql.py
+++ b/tests/integration/test_discogs_edges_sql.py
@@ -1,4 +1,13 @@
-"""Tests for SQL-based Discogs edge computation via DiscogsClient."""
+"""Integration tests for SQL-based Discogs edge computation via DiscogsClient.
+
+These tests query the materialized summary tables in a populated discogs-cache
+PostgreSQL (port 5433 by default). They are skipped when the DB is unreachable
+or when the expected tables/data are absent. The DSN comes from the
+``DATABASE_URL_DISCOGS`` env var, falling back to ``postgresql://jake@localhost/discogs``
+for the original developer's local layout.
+"""
+
+import os
 
 import psycopg
 import pytest
@@ -14,8 +23,12 @@ from semantic_index.models import (
 
 @pytest.fixture
 def discogs_dsn():
-    """DSN for the local discogs-cache PostgreSQL."""
-    return "postgresql://jake@localhost/discogs"
+    """DSN for the discogs-cache PostgreSQL.
+
+    Honours ``DATABASE_URL_DISCOGS`` for CI / non-default layouts. Falls back to
+    the historical local-developer DSN.
+    """
+    return os.environ.get("DATABASE_URL_DISCOGS", "postgresql://jake@localhost/discogs")
 
 
 @pytest.fixture


### PR DESCRIPTION
Closes #186.

## Background

`pyproject.toml` declares `addopts = "-m 'not integration and not postgres and not e2e and not parity and not slow'"`, which deselects every non-unit marker by default. The CI `test` job invoked `pytest tests/unit/` without `-m`, so it inherited those exclusions. Two consequences fell out:

1. Four `@pytest.mark.integration` tests living inside `tests/unit/test_discogs_edges_sql.py` were silently deselected (they appeared in pytest's `deselected` counter, not as failures).
2. `tests/integration/` and `tests/e2e/` had no CI job at all — they ran only when developers invoked `pytest -m integration` locally.

This is the same structural failure mode as WXYC/discogs-etl#103.

## Coverage caveat (read this before assuming the new jobs catch real bugs)

The new `integration` and `e2e` jobs are primarily **marker-reachability guardrails**, not full coverage. Most tests in those tiers need the `tubafrenzy/scripts/dev/fixtures/wxycmusic-fixture.sql` dump from the private `WXYC/tubafrenzy` repo, which we do not clone in CI (per repo policy: no cross-org PAT just for a fixture). When the fixture is absent, the tests self-skip. Concretely, on the green CI run for this PR:

- `e2e` job: **24 skipped, 0 passed**. Pure guardrail — exists so `-m e2e` cannot regress to silent addopts deselection.
- `integration` job: **4 passed, 18 skipped**. The 4 passing tests are mock-based LML error-path checks in `test_entity_source_fallback.py`; everything else (including the moved discogs-edges SQL tests, which need a populated discogs-cache PG) skips.

Real assertions for both tiers run only when developers have WXYC sibling checkouts. This is intentional and acceptable — the guardrails close the silent-deselection gap that #186 was opened for — but it means a green `e2e` job in CI does NOT mean the full pipeline ran end-to-end. If/when we want real CI coverage, we will need either a tubafrenzy PAT or a committed minimal fixture.

## Changes per marker tier

**`unit` (existing job)** — unchanged. Still `pytest tests/unit/ -v --cov=semantic_index --cov-report=term-missing`. The four misplaced `@pytest.mark.integration` tests have been moved out (see below) so the `unit` job no longer silently drops them.

**`integration` (new job)** — runs `pytest tests/integration/ -v -m "integration"`. Most integration tests need the tubafrenzy fixture dump and self-skip via the existing `_find_fixture` walker when `TUBAFRENZY_FIXTURE` is unset. Three integration files (`test_entity_migration.py`, `test_entity_source_lml.py`, `test_entity_store_pipeline.py`) import the deleted `semantic_index.entity_store` module (removed in commit `e8226d3` and asserted gone by `tests/unit/test_deletion_audit.py`; successor is `semantic_index.pipeline_db`). They are explicitly `--ignore`d here because they are owned by a parallel entity-source rework, with an inline `TODO` and grep anchor in `ci.yml` so they cannot quietly become permanent ignores.

**`e2e` (new job)** — runs `pytest tests/e2e/ -v -m "e2e"`. See the coverage caveat above; this currently runs `24 skipped, 0 passed` in CI.

**`marker-sync` (new job)** — uses the reusable workflow from `WXYC/wxyc-etl/.github/workflows/check-ci-marker-sync.yml@main` (introduced in WXYC/wxyc-etl#43) so this regression class can't recur silently.

**`postgres` (declared, unused)** — left in place; intentionally future-proofed. The marker-sync script flags it as a warning (`declared but never used`), not a gap.

**`slow` (manual-only)** — gates a single perf benchmark in `tests/unit/test_artist_resolver_rust.py` (`TestFuzzyResolvePerformance`, a Rust-vs-Python timing comparison). Documented as an intentional opt-out via the `# ci-sync-skip: slow reason: …` convention the marker-sync script recognises.

**`parity`** — removed from `pyproject.toml`. No test references it.

## Misplaced-test relocation

`tests/unit/test_discogs_edges_sql.py` -> `tests/integration/test_discogs_edges_sql.py` (via `git mv` to preserve history; `git log --follow` confirms continuity). These tests query the materialized summary tables (`artist_style_summary`, `artist_personnel_summary`, etc.) of a populated discogs-cache PostgreSQL and assert on real Warp Records data — they are correctly tagged as integration. The fixture now reads `DATABASE_URL_DISCOGS` (falling back to the historical `postgresql://jake@localhost/discogs` for the original developer's local layout) so CI can target the cache when one is available; otherwise the existing `_verify_discogs_db` fixture skips cleanly.

## Verification

- Local marker-sync check (`scripts/check_marker_ci_sync.py` from `WXYC/wxyc-etl`) -> `PASS: every used marker is reachable from CI`
- `pytest tests/unit/` -> 656 passed, 1 deselected (the slow benchmark)
- `pytest tests/integration/ -m integration --ignore=…entity_store-importing files` -> 22 passed (locally, with sibling tubafrenzy checkout)
- `pytest tests/e2e/ -m e2e` -> 24 passed (locally)
- `ruff check .` and `ruff format --check .` -> clean
- CI: all 6 jobs green (with the skip-counts called out above)

## Test plan

- [x] Lint job green
- [x] Typecheck job green
- [x] Unit `test` job green
- [x] New `integration` job green (4 passed, 18 skipped — see coverage caveat)
- [x] New `e2e` job green (24 skipped — pure guardrail in CI; see coverage caveat)
- [x] New `marker-sync` job green