### PR TITLE
chore: migrate pytest markers to architecture A

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,15 @@ jobs:
       - run: pip install _wxyc-etl/target/wheels/*.whl
       - run: pip install -e ".[api,dev]"
       - name: Run pg-marked tests
-        run: pytest tests/ -v -m "pg"
+        # Same `--ignore` flags as the `test` and `integration` jobs: the
+        # three entity_store-importing files would fail at collection even
+        # though they don't bear the `pg` marker. See the `integration`
+        # job's comment for the full rationale.
+        run: >-
+          pytest tests/ -v -m "pg"
+          --ignore=tests/integration/test_entity_migration.py
+          --ignore=tests/integration/test_entity_source_lml.py
+          --ignore=tests/integration/test_entity_store_pipeline.py
 
   integration:
     # Transitional `integration` marker job. After the architecture-A migration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,10 @@ jobs:
       - run: mypy semantic_index/
 
   test:
+    # Default (no-marker) tests: everything in tests/ that isn't gated by an
+    # infra marker. Includes tests/unit/ plus the unmarked in-memory tests under
+    # tests/integration/ and tests/e2e/ (which self-skip when the tubafrenzy
+    # fixture is absent — see the integration job comment for why).
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -55,36 +59,56 @@ jobs:
       - run: cd _wxyc-etl/wxyc-etl-python && maturin build --release
       - run: pip install _wxyc-etl/target/wheels/*.whl
       - run: pip install -e ".[api,dev]"
-      - run: pytest tests/unit/ -v --cov=semantic_index --cov-report=term-missing
+      - name: Run default (no-marker) tests
+        run: >-
+          pytest tests/ -v --cov=semantic_index --cov-report=term-missing
+          --ignore=tests/integration/test_entity_migration.py
+          --ignore=tests/integration/test_entity_source_lml.py
+          --ignore=tests/integration/test_entity_store_pipeline.py
+
+  pg:
+    # PG-backed tests (architecture A `pg` marker). Currently the only `pg`
+    # tests are the discogs-edges SQL tests, which target the discogs-cache
+    # PostgreSQL via DATABASE_URL_DISCOGS. CI does not provision discogs-cache
+    # (it requires a multi-GB seed), so the tests self-skip cleanly when the
+    # DSN is unreachable. The job exists to exercise `pytest -m pg` so the
+    # marker can never be silently deselected by addopts (the WXYC/discogs-etl#103
+    # failure mode that the marker-sync workflow guards against).
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          repository: WXYC/wxyc-etl
+          path: _wxyc-etl
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: dtolnay/rust-toolchain@stable
+      - run: pip install maturin
+      - run: cd _wxyc-etl/wxyc-etl-python && maturin build --release
+      - run: pip install _wxyc-etl/target/wheels/*.whl
+      - run: pip install -e ".[api,dev]"
+      - name: Run pg-marked tests
+        run: pytest tests/ -v -m "pg"
 
   integration:
-    # Runs the integration-marked tests. Most of these need the tubafrenzy
-    # fixture dump (`tubafrenzy/scripts/dev/fixtures/wxycmusic-fixture.sql`),
-    # which lives in a private sibling repo and so cannot be cloned with the
-    # default `GITHUB_TOKEN`. We deliberately do NOT add a cross-org PAT just
-    # to clone a fixture (per repo policy); instead, the tests self-skip
-    # cleanly via the `_find_fixture` walker when `TUBAFRENZY_FIXTURE` is
-    # unset. The job still exists so that:
-    #   1. `pytest -m integration` is exercised in CI (no more silent
-    #      addopts deselection of integration-marked tests, which is the
-    #      regression #186 was opened to prevent), and
-    #   2. integration tests that DON'T need the fixture (e.g. the
-    #      discogs-edges SQL tests, which only need `DATABASE_URL_DISCOGS`)
-    #      run for real when their preconditions are met locally.
-    # Local developers with the WXYC org checked out side-by-side get full
-    # coverage automatically.
-    #
-    # Three integration files (`test_entity_migration`,
-    # `test_entity_source_lml`, `test_entity_store_pipeline`) import the
-    # deleted `semantic_index.entity_store` module (removed in commit
-    # e8226d3, "Delete dead entity resolution code"; the deletion is
-    # asserted by `tests/unit/test_deletion_audit.py`) and would fail at
-    # collection. The successor module is `semantic_index.pipeline_db`.
-    # They are owned by the parallel entity-source rework and explicitly
-    # ignored here so this guardrail can land green; that effort will
-    # port them to PipelineDB or delete them as part of its own PR.
-    # TODO: remove these `--ignore` lines once the entity-source rework
-    # ports or deletes the three files; grep for `entity_store` here.
+    # Transitional `integration` marker job. After the architecture-A migration
+    # (`plans/test-patterns.md` Section 3), only one file still wears
+    # `pytestmark = pytest.mark.integration`: `test_entity_source_fallback.py`,
+    # which is owned by the parallel entity-source rework (PR #192) and so is
+    # off-limits to this migration PR. Three other entity_store/entity_source
+    # files (`test_entity_migration`, `test_entity_source_lml`,
+    # `test_entity_store_pipeline`) also still bear the marker but import the
+    # deleted `semantic_index.entity_store` module (removed in commit e8226d3,
+    # asserted by `tests/unit/test_deletion_audit.py`); the successor is
+    # `semantic_index.pipeline_db`. They would fail at collection and are
+    # explicitly `--ignore`d here so this guardrail can land green; that effort
+    # will port them to PipelineDB or delete them as part of its own PR.
+    # TODO: remove this entire job (and the `integration` marker declaration in
+    # pyproject.toml) once PR #192 has landed and the three ignored files have
+    # been ported or deleted; grep for `entity_store` here.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -101,43 +125,13 @@ jobs:
       - run: cd _wxyc-etl/wxyc-etl-python && maturin build --release
       - run: pip install _wxyc-etl/target/wheels/*.whl
       - run: pip install -e ".[api,dev]"
-      - name: Run integration tests
+      - name: Run integration-marked tests (transitional)
         run: >-
           pytest tests/integration/ -v
           -m "integration"
           --ignore=tests/integration/test_entity_migration.py
           --ignore=tests/integration/test_entity_source_lml.py
           --ignore=tests/integration/test_entity_store_pipeline.py
-
-  e2e:
-    # Runs the end-to-end pipeline tests. These require the tubafrenzy
-    # fixture dump (`tubafrenzy/scripts/dev/fixtures/wxycmusic-fixture.sql`),
-    # which lives in a private sibling repo. See the comment on the
-    # `integration` job above for why we don't clone it. Without the
-    # fixture, every e2e test self-skips via the class-scoped
-    # `_run_pipeline` fixture in `tests/e2e/test_full_pipeline.py`, so
-    # in CI this job currently reports `24 skipped, 0 passed` — it is a
-    # marker-reachability guardrail (preventing silent addopts
-    # deselection of `-m e2e`), NOT a source of real coverage. Real
-    # assertions only run for developers with WXYC sibling checkouts.
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/checkout@v4
-        with:
-          repository: WXYC/wxyc-etl
-          path: _wxyc-etl
-          token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-      - uses: dtolnay/rust-toolchain@stable
-      - run: pip install maturin
-      - run: cd _wxyc-etl/wxyc-etl-python && maturin build --release
-      - run: pip install _wxyc-etl/target/wheels/*.whl
-      - run: pip install -e ".[api,dev]"
-      - name: Run e2e tests
-        run: pytest tests/e2e/ -v -m "e2e"
 
   marker-sync:
     uses: WXYC/wxyc-etl/.github/workflows/check-ci-marker-sync.yml@main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,9 +228,9 @@ CREATE TABLE dj_total (
 ```bash
 python -m venv .venv && source .venv/bin/activate
 pip install -e ".[dev]"
-pytest                          # unit tests only
-pytest -m integration           # needs fixture dump
-pytest -m slow                  # needs production dump
+pytest                          # default (no-marker) tests: unit + unmarked integration/e2e (which self-skip without fixtures)
+pytest -m pg                    # PG-backed tests (needs DATABASE_URL_DISCOGS / DATABASE_URL_TEST)
+pytest -m slow                  # slow tests, e.g. the artist-resolver-rust perf benchmark (manual-only)
 ```
 
 ### Shared Dependencies (wxyc-etl)
@@ -254,10 +254,14 @@ Summary tables (`artist_style_summary`, `artist_personnel_summary`, `artist_labe
 
 ### Testing
 
-- Unit tests in `tests/unit/` — hand-crafted data via factory functions, no SQL files
-- Integration tests in `tests/integration/` — run against fixture dump, marked `@pytest.mark.integration`
-- Slow tests marked `@pytest.mark.slow` — run against production dump, manual only
-- Use WXYC example artists (Autechre, Stereolab, Father John Misty, etc.) in test fixtures
+Markers follow architecture A from `plans/test-patterns.md` Section 3 — they route CI by infrastructure, not by tier. The directory layout (`tests/unit/`, `tests/integration/`, `tests/e2e/`) documents tier; markers describe operational requirements.
+
+- **Default (no marker)** — pure logic tests plus the in-memory pipeline tests in `tests/integration/test_pipeline.py` and `tests/e2e/test_full_pipeline.py`. The latter two self-skip when the tubafrenzy fixture (`tubafrenzy/scripts/dev/fixtures/wxycmusic-fixture.sql`) is not on disk.
+- **`pg`** — needs a PostgreSQL service. Currently the discogs-edges SQL tests in `tests/integration/test_discogs_edges_sql.py`, which query the discogs-cache PG via `DATABASE_URL_DISCOGS`. Self-skip when the DSN is unreachable.
+- **`slow`** — orthogonal cost dimension; takes longer than ~10s. Currently the Rust resolver perf benchmark in `tests/unit/test_artist_resolver_rust.py`. Manual-only via `# ci-sync-skip: slow` in `pyproject.toml`.
+- **`integration`** (transitional) — kept for `tests/integration/test_entity_source_fallback.py` (owned by PR #192) and three `entity_store`-importing files that are `--ignore`d in CI pending the entity-source rework. Will be removed when those files are ported or deleted; see the TODO in `pyproject.toml` and `.github/workflows/ci.yml`.
+
+Use WXYC example artists (Autechre, Stereolab, Father John Misty, etc.) in test fixtures.
 
 ## Usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,14 +88,22 @@ ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 # ci-sync-skip: slow reason: perf benchmarks (test_artist_resolver_rust); manual-only
+# Architecture A markers (see plans/test-patterns.md Section 3): markers route CI by
+# infrastructure; directories document tier. `integration` is a transitional declaration
+# kept so the four entity_store/entity_source files still using `pytestmark =
+# pytest.mark.integration` (`test_entity_migration`, `test_entity_source_lml`,
+# `test_entity_store_pipeline`, `test_entity_source_fallback`) still parse cleanly.
+# The first three are `--ignore`d in CI (deleted-module imports); the fourth is owned
+# by PR #192's entity-source rework, which is why this PR doesn't touch it. Drop the
+# `integration` marker (and its CI job) once PR #192 has landed and the three ignored
+# files have been ported or deleted by their owning workstream.
+# TODO: remove `integration` marker after PR #192 lands; grep for `entity_store`.
 markers = [
-    "unit: pure logic tests, no external dependencies",
-    "postgres: needs PostgreSQL (gated by DATABASE_URL_TEST)",
-    "integration: needs external service or fixture data",
-    "e2e: full pipeline end-to-end test",
-    "slow: marks tests as slow",
+    "pg: needs a PostgreSQL service (DATABASE_URL_TEST or DATABASE_URL_DISCOGS)",
+    "slow: takes longer than ~10s (orthogonal to infra)",
+    "integration: transitional marker for entity_store/entity_source files; see TODO above",
 ]
-addopts = "-m 'not integration and not postgres and not e2e and not slow'"
+addopts = "-m 'not pg and not slow and not integration'"
 console_output_style = "progress"
 testpaths = ["tests"]
 pythonpath = ["."]

--- a/tests/e2e/test_full_pipeline.py
+++ b/tests/e2e/test_full_pipeline.py
@@ -23,8 +23,6 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = pytest.mark.e2e
-
 # Walk up from this file to find the WXYC org directory containing sibling repos.
 _FIXTURE_RELATIVE = "tubafrenzy/scripts/dev/fixtures/wxycmusic-fixture.sql"
 

--- a/tests/integration/test_discogs_edges_sql.py
+++ b/tests/integration/test_discogs_edges_sql.py
@@ -48,7 +48,7 @@ def _verify_discogs_db(discogs_dsn):
         pytest.skip("discogs-cache PostgreSQL not available")
 
 
-@pytest.mark.integration
+@pytest.mark.pg
 @pytest.mark.usefixtures("_verify_discogs_db")
 class TestComputeSharedStylesSql:
     """Tests for SQL-based shared style edge computation."""
@@ -89,7 +89,7 @@ class TestComputeSharedStylesSql:
         assert edges == []
 
 
-@pytest.mark.integration
+@pytest.mark.pg
 @pytest.mark.usefixtures("_verify_discogs_db")
 class TestComputeSharedPersonnelSql:
     """Tests for SQL-based shared personnel edge computation."""
@@ -115,7 +115,7 @@ class TestComputeSharedPersonnelSql:
         assert edges == []
 
 
-@pytest.mark.integration
+@pytest.mark.pg
 @pytest.mark.usefixtures("_verify_discogs_db")
 class TestComputeLabelFamilySql:
     """Tests for SQL-based label family edge computation."""
@@ -146,7 +146,7 @@ class TestComputeLabelFamilySql:
         assert edges == []
 
 
-@pytest.mark.integration
+@pytest.mark.pg
 @pytest.mark.usefixtures("_verify_discogs_db")
 class TestComputeCompilationSql:
     """Tests for SQL-based compilation co-appearance edge computation."""

--- a/tests/integration/test_pipeline.py
+++ b/tests/integration/test_pipeline.py
@@ -10,8 +10,6 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = pytest.mark.integration
-
 # Default: walk up from this file to find the WXYC parent dir containing sibling repos.
 # Override with TUBAFRENZY_FIXTURE env var if the layout differs.
 _RELATIVE = "tubafrenzy/scripts/dev/fixtures/wxycmusic-fixture.sql"


### PR DESCRIPTION
## Summary

Migrates the legacy 6-marker scheme (`unit / postgres / integration / e2e / parity / slow`) to architecture A from [`plans/test-patterns.md` Section 3](https://github.com/WXYC/wxyc-etl/blob/main/plans/test-patterns.md). Markers route CI by infrastructure; directories document tier; lifecycle is a property of test names; cost is one independent marker (`slow`).

## Mapping applied

| Legacy | After | Files |
|---|---|---|
| `unit` | (default, no marker) | n/a -- no test file used `pytest.mark.unit` |
| `postgres` | `pg` | n/a -- no test file used `pytest.mark.postgres` |
| `integration` (4 sites in `test_discogs_edges_sql.py`) | `pg` | `tests/integration/test_discogs_edges_sql.py` (queries discogs-cache PG via `DATABASE_URL_DISCOGS`) |
| `integration` (1 site in `test_pipeline.py`) | (unmarked) | `tests/integration/test_pipeline.py` -- in-process `run_pipeline.main` against the on-disk tubafrenzy fixture; self-skips when fixture is missing |
| `e2e` (1 site in `test_full_pipeline.py`) | (unmarked) | `tests/e2e/test_full_pipeline.py` -- in-process `run_pipeline.main` + SQLite output, no PG; self-skips when fixture missing. Directory name `tests/e2e/` survives for taxonomy |
| `parity` | dropped | n/a -- no test file used `pytest.mark.parity`; existing parity tests (`test_migration_parity`, `test_artist_resolver_rust`, `test_sql_parser_rust`) are unmarked characterization tests with descriptive names per Section 7 |
| `slow` | `slow` (unchanged) | `tests/unit/test_artist_resolver_rust.py::TestFuzzyResolvePerformance` -- kept as `# ci-sync-skip: slow` opt-out for the perf benchmark |

## Counts before / after

(Excluding the three `--ignore`d `entity_store`-importing files; their markers are not touched.)

| Marker | Before | After |
|---|---|---|
| `integration` | 6 sites | 1 site (transitional, see below) |
| `e2e` | 1 site | 0 |
| `slow` | 1 site | 1 site |
| `pg` | 0 | 4 sites |
| `unit` / `postgres` / `parity` | 0 | 0 (dropped) |

## Judgment calls

**Transitional `integration` marker.** One file -- `tests/integration/test_entity_source_fallback.py` -- still wears `pytestmark = pytest.mark.integration` after this migration. It is owned by the parallel entity-source rework (#192) and so is off-limits to this PR. Rather than (a) touching the file (would conflict with #192) or (b) adding it to the `--ignore` list (loses real coverage), I kept the `integration` marker declared in `pyproject.toml` and a dedicated `integration` CI job that runs `pytest -m integration --ignore=<the three deleted-module-importers>`. Both `pyproject.toml` and `.github/workflows/ci.yml` carry TODO + `entity_store` grep anchors marking this for removal once #192 lands and the three `entity_store`-importing files have been ported to PipelineDB or deleted by their owning workstream.

**Unmarked e2e + integration tests need a CI host.** The new `test` job runs `pytest tests/` (with the same three `--ignore` flags from #193) instead of `pytest tests/unit/`, so it picks up the now-unmarked e2e + integration tests. They self-skip when the tubafrenzy fixture is absent (same guardrail-only behaviour as #193's `e2e` job). This avoids the failure mode where a renamed-marker test ends up uncollected by every CI invocation.

**`tests/e2e/test_full_pipeline.py` is unmarked, not `pg`.** The migration plan asks "`pg` if it actually uses PG when fixtures are available." This file calls `run_pipeline.main` in-process and writes only SQLite -- it never connects to PostgreSQL. So it is unmarked. The `tests/e2e/` directory survives for taxonomy per Section 3.

## Files NOT touched

Per the migration plan:

- `tests/integration/test_entity_migration.py` (`--ignore`d in CI per #193 -- imports deleted `semantic_index.entity_store`)
- `tests/integration/test_entity_source_lml.py` (`--ignore`d in CI per #193 -- imports deleted `semantic_index.entity_store`)
- `tests/integration/test_entity_store_pipeline.py` (`--ignore`d in CI per #193 -- imports deleted `semantic_index.entity_store`)
- `tests/integration/test_entity_source_fallback.py` (touched by #192)
- `run_pipeline.py` (touched by #192)
- `tests/unit/test_run_pipeline.py` (touched by #192)

The `--ignore` of the three `entity_store`-importing files (and the TODO/grep anchor from #193) is preserved in both the new `test` job and the transitional `integration` job.

## Test plan

- [x] `python3 scripts/check_marker_ci_sync.py --repo-path .` passes
- [x] `ruff format --check .` passes
- [x] `ruff check .` passes
- [x] `pytest tests/ --ignore=<3 entity_store files>` collects 718 tests, 698 pass, 20 deselected (the pg/slow/integration markers)
- [x] `pytest -m pg --collect-only` collects only the four `test_discogs_edges_sql.py` classes (12 tests)
- [x] `pytest -m integration --collect-only` collects only `test_entity_source_fallback.py` (after `--ignore`s, 7 tests)
- [ ] CI green on this branch