### PR TITLE
deploy: copy generated/ into Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ COPY pyproject.toml .
 RUN pip install --no-cache-dir ".[api]"
 
 COPY semantic_index/ semantic_index/
+COPY generated/ generated/
 COPY scripts/ scripts/
 COPY explorer/ explorer/
 COPY data/ data/


### PR DESCRIPTION
Closes #195

## Summary

`explore.wxyc.org` is currently returning 502. The semantic-index container on EC2 is in a uvicorn import-error crash loop because `semantic_index/api/schemas.py` imports `from generated.api_models import ReconciledIdentity` (added in `e5d55b7`) but the Dockerfile never copied the `generated/` directory into the image.

This adds the missing `COPY generated/ generated/` line. Once merged and the deploy workflow finishes (~3-5 min), the container will start cleanly and `explore.wxyc.org` will recover.

## Test plan

- [x] Confirmed crash loop via `docker logs semantic-index` on EC2
- [x] Confirmed `generated/api_models.py` is git-tracked and not in `.dockerignore`
- [x] ruff check / ruff format / mypy all green via pre-commit
- [ ] After merge: watch `deploy.yml` workflow run, confirm `curl https://explore.wxyc.org/health` returns 200