### PR TITLE
Wire up Sentry + JSON logs in semantic-index

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -244,6 +244,17 @@ The pipeline uses `wxyc-etl` (a Rust/PyO3 package) for shared text normalization
 
 Summary tables (`artist_style_summary`, `artist_personnel_summary`, `artist_label_summary`, `artist_compilation_summary`) are materialized views created by discogs-cache and are not part of the wxyc-etl schema constants.
 
+### Observability (Sentry + JSON logs)
+
+Both pipeline entrypoints (`run_pipeline.py` and `scripts/nightly_sync.py`) initialize the shared `wxyc_etl.logger` at the top of `main()` so logs come out as one JSON object per line on stderr and unhandled exceptions land in Sentry. Every log line carries the four standard tags:
+
+- `repo` — `"semantic-index"`
+- `tool` — `"semantic-index run_pipeline"` or `"semantic-index nightly_sync"`
+- `step` — supplied per-call via `logger.info("...", extra={"step": "resolve"})`
+- `run_id` — UUIDv4 generated at `init_logger` time, shared across all log lines for a single invocation
+
+Sentry activates automatically when `SENTRY_DSN` is set in the environment; without it, JSON logging still initializes and Sentry stays inactive. TODO: provision `SENTRY_DSN` in the EC2 `.env.semantic-index` and the GitHub Actions deploy workflow (separate child task — see Phase A epic).
+
 ### Code Style
 
 - Python 3.12+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "psycopg[binary]>=3.1",
     "httpx>=0.25",
     "wxyc-etl>=0.1.0",
+    "sentry-sdk>=2.0",
 ]
 
 [project.optional-dependencies]

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -14,6 +14,8 @@ import sys
 import time
 from pathlib import Path
 
+from wxyc_etl.logger import init_logger
+
 from semantic_index.adjacency import extract_adjacency_pairs
 from semantic_index.artist_resolver import (
     ArtistResolver,
@@ -1251,10 +1253,10 @@ def run(args: argparse.Namespace) -> None:
 
 def main(argv: list[str] | None = None) -> None:
     args = parse_args(argv)
-    logging.basicConfig(
+    init_logger(
+        repo="semantic-index",
+        tool="semantic-index run_pipeline",
         level=logging.DEBUG if args.verbose else logging.INFO,
-        format="%(asctime)s %(levelname)s %(message)s",
-        datefmt="%H:%M:%S",
     )
     run(args)
 

--- a/semantic_index/nightly_sync.py
+++ b/semantic_index/nightly_sync.py
@@ -25,6 +25,8 @@ import sys
 import time
 from pathlib import Path
 
+from wxyc_etl.logger import init_logger
+
 logger = logging.getLogger(__name__)
 
 DEFAULT_DB_PATH = "data/wxyc_artist_graph.db"
@@ -396,10 +398,10 @@ def main(argv: list[str] | None = None) -> None:
     """Entry point for the nightly sync script."""
     args = parse_args(argv)
 
-    logging.basicConfig(
+    init_logger(
+        repo="semantic-index",
+        tool="semantic-index nightly_sync",
         level=logging.DEBUG if args.verbose else logging.INFO,
-        format="%(asctime)s %(levelname)s [nightly_sync] %(message)s",
-        datefmt="%Y-%m-%dT%H:%M:%S",
     )
 
     if not args.dsn:

--- a/tests/unit/test_logger_init.py
+++ b/tests/unit/test_logger_init.py
@@ -1,0 +1,71 @@
+"""Smoke tests for wxyc_etl.logger wireup in semantic-index entrypoints."""
+
+from __future__ import annotations
+
+import json
+import logging
+from unittest.mock import patch
+
+import pytest
+
+
+def test_logger_init_emits_json_with_repo_tag(monkeypatch, capsys):
+    """init_logger produces a JSON line tagged with repo='semantic-index'."""
+    monkeypatch.delenv("SENTRY_DSN", raising=False)
+
+    root = logging.getLogger()
+    for handler in list(root.handlers):
+        root.removeHandler(handler)
+
+    from wxyc_etl import logger as wxyc_logger
+
+    wxyc_logger._INITIALIZED = False
+    wxyc_logger.init_logger(repo="semantic-index", tool="semantic-index test")
+    logging.getLogger("semantic_index.test").info("smoke", extra={"step": "smoke"})
+
+    captured = capsys.readouterr()
+    line = next(line for line in captured.err.splitlines() if line.strip().startswith("{"))
+    payload = json.loads(line)
+    assert payload["repo"] == "semantic-index"
+    assert payload["tool"] == "semantic-index test"
+    assert payload["step"] == "smoke"
+    assert payload["message"] == "smoke"
+
+
+def test_run_pipeline_main_calls_init_logger():
+    """run_pipeline.main() invokes wxyc_etl.logger.init_logger with the
+    semantic-index repo tag before any pipeline work."""
+    import run_pipeline
+
+    with (
+        patch.object(run_pipeline, "init_logger") as mock_init,
+        patch.object(run_pipeline, "run") as mock_run,
+    ):
+        run_pipeline.main(["dump.sql"])
+
+    mock_init.assert_called_once()
+    kwargs = mock_init.call_args.kwargs or {}
+    args_pos = mock_init.call_args.args
+    repo = kwargs.get("repo") or (args_pos[0] if args_pos else None)
+    assert repo == "semantic-index"
+    mock_run.assert_called_once()
+
+
+def test_nightly_sync_main_calls_init_logger():
+    """nightly_sync.main() invokes wxyc_etl.logger.init_logger with the
+    semantic-index repo tag before running."""
+    from semantic_index import nightly_sync
+
+    with (
+        patch.object(nightly_sync, "init_logger") as mock_init,
+        patch.object(nightly_sync, "nightly_sync") as mock_run,
+    ):
+        with pytest.raises(SystemExit):
+            nightly_sync.main([])  # missing --dsn -> exit 1, after init_logger
+
+    mock_init.assert_called_once()
+    kwargs = mock_init.call_args.kwargs or {}
+    args_pos = mock_init.call_args.args
+    repo = kwargs.get("repo") or (args_pos[0] if args_pos else None)
+    assert repo == "semantic-index"
+    mock_run.assert_not_called()


### PR DESCRIPTION
## Summary

- Replace `logging.basicConfig()` in `run_pipeline.py` and `semantic_index/nightly_sync.py` with `wxyc_etl.logger.init_logger`, so logs emit JSON with the four standard tags (`repo`, `tool`, `step`, `run_id`) and unhandled exceptions land in Sentry when `SENTRY_DSN` is set. Without a DSN, JSON logging still initializes and Sentry stays inactive — no operational change for local dev.
- Add `sentry-sdk` as an explicit runtime dep (already transitive via `wxyc-etl`) and document the observability tags in `CLAUDE.md` under "Shared Dependencies".
- Cover the wireup with a unit test (`tests/unit/test_logger_init.py`): asserts JSON format with `repo: semantic-index`, and asserts both `main()` entrypoints invoke `init_logger` with the right repo tag before any pipeline work.

## TODO (separate child task on the Phase A epic)

Provision `SENTRY_DSN` in the EC2 `.env.semantic-index` and the GitHub Actions deploy workflow.

## Test plan

- [x] `pytest` — 716 passed, 13 deselected
- [x] `ruff check` / `ruff format --check` / `mypy` (pre-commit) — all clean
- [x] `python run_pipeline.py /tmp/no-such-file.sql` emits a JSON line with `repo: "semantic-index"`, `tool: "semantic-index run_pipeline"`, and a generated `run_id`

## Tracking

Closes #198. Parent epic: WXYC/wxyc-etl#44.