### PR TITLE
Install wxyc-etl from PyPI instead of building from source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,18 +23,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/checkout@v4
-        with:
-          repository: WXYC/wxyc-etl
-          path: _wxyc-etl
-          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - uses: dtolnay/rust-toolchain@stable
-      - run: pip install maturin
-      - run: cd _wxyc-etl/wxyc-etl-python && maturin build --release
-      - run: pip install _wxyc-etl/target/wheels/*.whl
       - run: pip install -e ".[api,dev]"
       - run: mypy semantic_index/
 
@@ -46,18 +37,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/checkout@v4
-        with:
-          repository: WXYC/wxyc-etl
-          path: _wxyc-etl
-          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - uses: dtolnay/rust-toolchain@stable
-      - run: pip install maturin
-      - run: cd _wxyc-etl/wxyc-etl-python && maturin build --release
-      - run: pip install _wxyc-etl/target/wheels/*.whl
       - run: pip install -e ".[api,dev]"
       - name: Run default (no-marker) tests
         run: pytest tests/ -v --cov=semantic_index --cov-report=term-missing
@@ -73,18 +55,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/checkout@v4
-        with:
-          repository: WXYC/wxyc-etl
-          path: _wxyc-etl
-          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - uses: dtolnay/rust-toolchain@stable
-      - run: pip install maturin
-      - run: cd _wxyc-etl/wxyc-etl-python && maturin build --release
-      - run: pip install _wxyc-etl/target/wheels/*.whl
       - run: pip install -e ".[api,dev]"
       - name: Run pg-marked tests
         run: pytest tests/ -v -m "pg"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,8 @@
-FROM python:3.12-slim AS rust-builder
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl build-essential git && \
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal && \
-    rm -rf /var/lib/apt/lists/*
-
-ENV PATH="/root/.cargo/bin:${PATH}"
-
-RUN pip install --no-cache-dir maturin
-
-WORKDIR /build
-RUN git clone --depth 1 https://github.com/WXYC/wxyc-etl.git && \
-    cd wxyc-etl/wxyc-etl-python && \
-    maturin build --release && \
-    cp /build/wxyc-etl/target/wheels/*.whl /build/
-
 FROM python:3.12-slim
 
 WORKDIR /app
 
 ENV PYTHONUNBUFFERED=1
-
-COPY --from=rust-builder /build/*.whl /tmp/
-RUN pip install --no-cache-dir /tmp/*.whl && rm /tmp/*.whl
 
 COPY pyproject.toml .
 RUN pip install --no-cache-dir ".[api]"


### PR DESCRIPTION
## Summary

- Drops the `git clone WXYC/wxyc-etl + maturin build + pip install /tmp/.../wheels/*.whl` dance from `.github/workflows/ci.yml` (typecheck, test, pg jobs) and from the runtime `Dockerfile`.
- The `pyproject.toml` already pins `wxyc-etl>=0.1.0`; the standard `pip install -e ".[api,dev]"` (CI) and `pip install ".[api]"` (Dockerfile) now resolve the published wheel from PyPI.
- Removes `dtolnay/rust-toolchain@stable` and `WXYC/wxyc-etl` checkout steps from CI jobs that no longer need them. Also drops the multi-stage rust-builder layer from the Dockerfile.

Verified locally with a fresh venv:

```
python3 -m venv /tmp/si-test-pin
source /tmp/si-test-pin/bin/activate
pip install -e ".[api,dev]"
python -c "from wxyc_etl import text, fuzzy, parser, schema; print('imports ok')"
pytest tests/unit/   # 702 passed
ruff check . && ruff format --check . && mypy semantic_index/
```

Closes #200

## Test plan

- [ ] CI green (lint, typecheck, test, pg, marker-sync)
- [ ] Deploy workflow builds the slimmed Dockerfile successfully