### PR TITLE
[narrative artifacts 1/6] Plan §1 data-selection scripts

### DIFF
--- a/scripts/experiments/narrative/compare_neighbor_weighting.py
+++ b/scripts/experiments/narrative/compare_neighbor_weighting.py
@@ -1,0 +1,134 @@
+"""Compare neighbor weighting methods across the 8 no-edge-shared-context pairs.
+
+For each pair, computes shared neighbors ranked by:
+1. Raw (unweighted, sorted by play count — current behavior)
+2. Adamic-Adar: weight = sum(1/log(degree(n)) for shared neighbor n)
+3. Resource Allocation: weight = sum(1/degree(n))
+4. Degree ceiling: exclude neighbors above 95th percentile degree
+
+Outputs a comparison table showing how each method reranks or filters the neighbors.
+"""
+
+import math
+import sqlite3
+
+DB_PATH = "data/wxyc_artist_graph.db"
+
+PAIRS = [
+    (87013, 780, "Hiatus Kaiyote", "Muddy Waters"),
+    (57122, 113128, "Bill Orcutt", "Durand Jones"),
+    (32948, 65513, "Religious Knives", "Pastor T.L. Barrett"),
+    (1576, 2832, "Bob Marley and the Wailers", "Les Rallizes Dénudés"),
+    (2800, 67435, "Peter Brötzmann", "Angel Olsen"),
+    (329, 7717, "Caetano Veloso", "Don Cherry"),
+    (59053, 301, "Tame Impala", "Smog"),
+    (22302, 386, "Wooden Shjips", "Guided by Voices"),
+]
+
+
+def main():
+    db = sqlite3.connect(DB_PATH)
+    db.row_factory = sqlite3.Row
+
+    # Compute degree for all artists
+    degree = {}
+    for row in db.execute(
+        """
+        SELECT a.id,
+               COUNT(DISTINCT CASE WHEN dt.source_id = a.id THEN dt.target_id
+                                   ELSE dt.source_id END) AS deg
+        FROM artist a
+        JOIN dj_transition dt ON (dt.source_id = a.id OR dt.target_id = a.id)
+            AND dt.source_id != dt.target_id
+        GROUP BY a.id
+        """
+    ):
+        degree[row["id"]] = row["deg"]
+
+    # 95th percentile degree for ceiling method
+    all_degrees = sorted(degree.values())
+    p95 = all_degrees[int(len(all_degrees) * 0.95)] if all_degrees else 100
+    print(f"95th percentile degree: {p95}")
+    print(f"Total artists with edges: {len(all_degrees)}")
+    print()
+
+    for id_a, id_b, name_a, name_b in PAIRS:
+        # Get shared neighbors
+        rows = db.execute(
+            """
+            WITH a_neighbors AS (
+                SELECT CASE WHEN source_id = :a THEN target_id ELSE source_id END AS nid
+                FROM dj_transition
+                WHERE (source_id = :a OR target_id = :a) AND source_id != target_id
+            ),
+            b_neighbors AS (
+                SELECT CASE WHEN source_id = :b THEN target_id ELSE source_id END AS nid
+                FROM dj_transition
+                WHERE (source_id = :b OR target_id = :b) AND source_id != target_id
+            )
+            SELECT DISTINCT a.id, a.canonical_name, a.total_plays
+            FROM a_neighbors an
+            JOIN b_neighbors bn ON an.nid = bn.nid
+            JOIN artist a ON a.id = an.nid
+            WHERE a.canonical_name NOT LIKE 'Various%'
+              AND a.canonical_name NOT LIKE 'V/A%'
+              AND a.canonical_name != 'various'
+              AND a.canonical_name != 'Unknown'
+            """,
+            {"a": id_a, "b": id_b},
+        ).fetchall()
+
+        neighbors = []
+        for r in rows:
+            nid = r["id"]
+            deg = degree.get(nid, 1)
+            aa_weight = 1.0 / math.log(deg) if deg > 1 else 1.0
+            ra_weight = 1.0 / deg
+            neighbors.append({
+                "name": r["canonical_name"],
+                "plays": r["total_plays"],
+                "degree": deg,
+                "adamic_adar": aa_weight,
+                "resource_alloc": ra_weight,
+            })
+
+        print(f"{'=' * 80}")
+        print(f"  {name_a} / {name_b}")
+        print(f"  ({len(neighbors)} shared neighbors)")
+        print(f"{'=' * 80}")
+
+        # Raw (play count)
+        by_plays = sorted(neighbors, key=lambda x: x["plays"], reverse=True)[:8]
+        print(f"\n  RAW (by play count):")
+        for n in by_plays:
+            print(f"    {n['name']:35s}  plays={n['plays']:5d}  degree={n['degree']}")
+
+        # Adamic-Adar
+        by_aa = sorted(neighbors, key=lambda x: x["adamic_adar"], reverse=True)[:8]
+        print(f"\n  ADAMIC-ADAR (1/log(degree)):")
+        for n in by_aa:
+            print(f"    {n['name']:35s}  aa={n['adamic_adar']:.4f}  degree={n['degree']}")
+
+        # Resource Allocation
+        by_ra = sorted(neighbors, key=lambda x: x["resource_alloc"], reverse=True)[:8]
+        print(f"\n  RESOURCE ALLOCATION (1/degree):")
+        for n in by_ra:
+            print(f"    {n['name']:35s}  ra={n['resource_alloc']:.6f}  degree={n['degree']}")
+
+        # Degree ceiling
+        by_ceil = [n for n in neighbors if n["degree"] <= p95]
+        by_ceil = sorted(by_ceil, key=lambda x: x["plays"], reverse=True)[:8]
+        print(f"\n  DEGREE CEILING (exclude degree > {p95}):")
+        if by_ceil:
+            for n in by_ceil:
+                print(f"    {n['name']:35s}  plays={n['plays']:5d}  degree={n['degree']}")
+        else:
+            print(f"    (all shared neighbors exceed ceiling)")
+
+        print()
+
+    db.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/experiments/narrative/coverage_with_normalization.py
+++ b/scripts/experiments/narrative/coverage_with_normalization.py
@@ -1,0 +1,161 @@
+"""Improved review-to-artist matching with name normalization.
+
+Fixes:
+- Split canonical names on " / ", " & ", " and " to match components
+- Strip leading "The " for matching
+- Normalize unicode (NFKD + strip diacritics)
+- Skip "Various Artists" entries entirely
+- Case-insensitive matching against review titles
+"""
+
+import json
+import re
+import sqlite3
+import unicodedata
+from collections import defaultdict
+from pathlib import Path
+
+DB_PATH = "data/wxyc_artist_graph.db"
+REVIEW_DIR = Path("data/reviews")
+
+
+def normalize(name: str) -> str:
+    """NFKD decomposition + strip diacritics + lowercase + trim."""
+    nfkd = unicodedata.normalize("NFKD", name)
+    stripped = "".join(c for c in nfkd if not unicodedata.combining(c))
+    return stripped.lower().strip()
+
+
+def generate_variants(canonical: str) -> set[str]:
+    """Generate matchable name variants from a canonical name."""
+    variants = set()
+    norm = normalize(canonical)
+
+    # Skip too-short names
+    if len(norm) < 4:
+        return variants
+
+    variants.add(norm)
+
+    # Strip leading "the "
+    if norm.startswith("the "):
+        variants.add(norm[4:])
+
+    # Split on separators and add components
+    for sep in [" / ", " & ", " and ", " + ", " with ", " vs. ", " vs "]:
+        if sep in norm:
+            for part in norm.split(sep):
+                part = part.strip()
+                if len(part) >= 4:
+                    variants.add(part)
+                    if part.startswith("the "):
+                        variants.add(part[4:])
+
+    # Handle "Jay Dee" from "J Dilla / Jay Dee"
+    # Handle "Mikal Cronin" from "Ty Segall & Mikal Cronin"
+    # (covered by the split above)
+
+    # Strip common suffixes
+    for suffix in [", Jr.", ", III", ", II"]:
+        cleaned = norm.replace(suffix.lower(), "").strip()
+        if len(cleaned) >= 4 and cleaned != norm:
+            variants.add(cleaned)
+
+    return variants
+
+
+def main():
+    db = sqlite3.connect(DB_PATH)
+    db.row_factory = sqlite3.Row
+
+    # Load artists with 100+ plays, skip VA entries
+    artists = {}
+    for r in db.execute(
+        "SELECT id, canonical_name, genre, total_plays FROM artist WHERE total_plays >= 100"
+    ):
+        name = r["canonical_name"]
+        if name.startswith("Various Artists") or name in ("V/A", "various", "Unknown"):
+            continue
+        artists[r["id"]] = {
+            "name": name,
+            "genre": r["genre"],
+            "plays": r["total_plays"],
+        }
+
+    print(f"Artists with 100+ plays (excl. VA): {len(artists)}")
+
+    # Build variant -> artist ID mapping
+    variant_to_ids: dict[str, set[int]] = defaultdict(set)
+    for aid, info in artists.items():
+        for v in generate_variants(info["name"]):
+            variant_to_ids[v].add(aid)
+
+    # Remove overly common variants that would cause false matches
+    # (variants matching 10+ artists are probably too generic)
+    variant_to_ids = {k: v for k, v in variant_to_ids.items() if len(v) <= 5}
+
+    print(f"Unique match variants: {len(variant_to_ids)}")
+
+    # Sort variants longest-first for greedy matching
+    sorted_variants = sorted(variant_to_ids.keys(), key=len, reverse=True)
+
+    # Scan reviews
+    source_matched: dict[str, set[int]] = defaultdict(set)
+    all_matched: set[int] = set()
+
+    sources = [d.name for d in REVIEW_DIR.iterdir() if d.is_dir() and (d / "reviews.jsonl").exists()]
+
+    for source in sorted(sources):
+        path = REVIEW_DIR / source / "reviews.jsonl"
+        with open(path) as f:
+            for line in f:
+                rec = json.loads(line)
+                title = normalize(rec.get("title", "") or "")
+                if not title:
+                    continue
+                for variant in sorted_variants:
+                    if variant in title:
+                        for aid in variant_to_ids[variant]:
+                            source_matched[source].add(aid)
+                            all_matched.add(aid)
+
+    print(f"\nMatched artists: {len(all_matched)} / {len(artists)} ({len(all_matched)/len(artists)*100:.0f}%)")
+    for source in sorted(source_matched):
+        print(f"  {source}: {len(source_matched[source])}")
+
+    # Before/after comparison for specific problem cases
+    print("\nSpot checks:")
+    problem_names = [
+        "J Dilla / Jay Dee", "Ty Segall & Mikal Cronin", "Lindstrom & Prins Thomas",
+        "Weyes Blood & Dark Juices", "Duke Ellington", "Ella Fitzgerald",
+        "Ali Farka Toure", "Konono No 1", "Omar S.",
+    ]
+    for name in problem_names:
+        for aid, info in artists.items():
+            if info["name"] == name:
+                status = "MATCHED" if aid in all_matched else "UNMATCHED"
+                variants = generate_variants(name)
+                print(f"  {name}: {status} (variants: {', '.join(sorted(variants)[:5])})")
+                break
+
+    # Genre breakdown of remaining unmatched
+    unmatched_by_genre = defaultdict(list)
+    for aid, info in artists.items():
+        if aid not in all_matched:
+            unmatched_by_genre[info["genre"] or "None"].append((info["name"], info["plays"]))
+
+    print(f"\nRemaining unmatched by genre:")
+    for genre, items in sorted(unmatched_by_genre.items(), key=lambda x: -len(x[1])):
+        print(f"  {genre}: {len(items)}")
+        top = sorted(items, key=lambda x: -x[1])[:3]
+        for name, plays in top:
+            print(f"    {name} ({plays} plays)")
+
+    total_unmatched = sum(len(v) for v in unmatched_by_genre.values())
+    print(f"\nTotal unmatched: {total_unmatched} / {len(artists)} ({total_unmatched/len(artists)*100:.0f}%)")
+
+    db.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/experiments/narrative/experiment_narrative_variants.py
+++ b/scripts/experiments/narrative/experiment_narrative_variants.py
@@ -1,0 +1,307 @@
+"""Experiment: compare narrative variants across prompt strategies.
+
+Tests three prompt variants on the same set of pairs:
+1. BASELINE — current prompt (from generate_narrative_samples.py)
+2. ANTI-HALLUCINATION — constrain model to only use provided data
+3. ANTI-HALLUCINATION + VARIED LANGUAGE — also address verb monotony
+
+Uses Adamic-Adar weighted neighbors and filters out weak pairs.
+
+KNOWN BUG (preserved, fixed in a follow-up PR):
+    get_artist_meta() queries `SELECT style_tag FROM artist_style` but the
+    schema column is `style`. The resulting sqlite3.OperationalError is
+    swallowed by a broad except, so meta["styles"] is always [] in this
+    script's runs. Any plan-doc result derived from a styles-on/off
+    comparison in this experiment should be treated as suspect until
+    rerun. Landing the file as the historical artifact; fix follows.
+"""
+
+import json
+import math
+import os
+import sqlite3
+import sys
+import time
+from collections import defaultdict
+
+import anthropic
+
+DB_PATH = "data/wxyc_artist_graph.db"
+
+PROMPT_BASELINE = (
+    "You are a music knowledge assistant for WXYC 89.3 FM, a freeform college radio station. "
+    "Given structured data about the relationship between two artists in the station's play "
+    "history, write 2-3 sentences (under 80 words) explaining their connection in plain "
+    "English. Be specific — mention shared genres, personnel names, labels, or play patterns "
+    "from the data. Do not add information not present in the data. "
+    "When sequential_context is present, use it to describe how DJs use these artists in "
+    "similar ways — which artists they tend to appear near, and what that suggests about their "
+    "shared role in a set. Use language like 'DJs reach for both at similar moments' or "
+    "'both tend to appear near [artists].' The shared_set_neighbors list shows artists that "
+    "both subjects tend to appear near — do not imply the neighbors are similar to each other. "
+    "Never reference adjacency or proximity in the playlist when describing sequential context — "
+    "the connection is about role, not position. "
+    "Never use technical terms like 'embedding,' 'vector,' or 'cosine similarity.' "
+    "Describe what an artist's music IS, not what it isn't — avoid 'low-danceability' or similar "
+    "negations. "
+    "Africa is a continent, not a genre. If the data includes country or region, use that. If it "
+    "only says 'Africa' or 'African,' describe the specific musical tradition from the styles "
+    "(e.g. 'Desert Blues,' 'Congolese likembe music') rather than generalizing across the continent."
+)
+
+PROMPT_ANTI_HALLUCINATION = (
+    "You are a music knowledge assistant for WXYC 89.3 FM, a freeform college radio station. "
+    "Given structured data about two artists, write 2-3 sentences (under 80 words) explaining "
+    "their connection. "
+    "CRITICAL: describe each artist ONLY using the styles, audio, and genre fields provided. "
+    "Do not draw on outside knowledge about these artists. If a field is missing, do not guess "
+    "what it might contain. If you lack data to describe an artist's sound, focus on the "
+    "sequential_context instead. "
+    "When sequential_context is present, describe how DJs use these artists in similar ways — "
+    "which artists they tend to appear near, and what that suggests about their role in a set. "
+    "The shared_set_neighbors list shows artists that both subjects tend to appear near — do not "
+    "imply the neighbors are similar to each other. Never reference adjacency or proximity in the "
+    "playlist — the connection is about role, not position. "
+    "Describe what an artist's music IS, not what it isn't. "
+    "Africa is a continent, not a genre. Use the specific tradition from the styles when possible."
+)
+
+PROMPT_ANTI_HALLUCINATION_VARIED = (
+    "You are a music knowledge assistant for WXYC 89.3 FM, a freeform college radio station. "
+    "Given structured data about two artists, write 2-3 sentences (under 80 words) explaining "
+    "their connection. "
+    "CRITICAL: describe each artist ONLY using the styles, audio, and genre fields provided. "
+    "Do not draw on outside knowledge about these artists. If a field is missing, do not guess "
+    "what it might contain. If you lack data to describe an artist's sound, focus on the "
+    "sequential_context instead. "
+    "When sequential_context is present, describe how DJs use these artists in similar ways — "
+    "which artists they tend to appear near, and what that suggests about their role in a set. "
+    "The shared_set_neighbors list shows artists that both subjects tend to appear near — do not "
+    "imply the neighbors are similar to each other. Never reference adjacency or proximity in the "
+    "playlist — the connection is about role, not position. "
+    "Describe what an artist's music IS, not what it isn't. "
+    "Africa is a continent, not a genre. Use the specific tradition from the styles when possible. "
+    "LANGUAGE: write in a natural, varied voice. Do not reuse the same verbs or phrases across "
+    "sentences. Avoid these overused words: occupy, reach, represent, suggest, anchor, bridge, "
+    "curate, sonic, territory, sensibility, touchstone. Find fresher ways to say things."
+)
+
+PROMPTS = {
+    "BASELINE": PROMPT_BASELINE,
+    "ANTI-HALLUCINATION": PROMPT_ANTI_HALLUCINATION,
+    "ANTI-HALLUC + VARIED": PROMPT_ANTI_HALLUCINATION_VARIED,
+}
+
+
+def get_db() -> sqlite3.Connection:
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def compute_degrees(db: sqlite3.Connection) -> dict[int, int]:
+    degree = {}
+    for row in db.execute(
+        "SELECT a.id, "
+        "COUNT(DISTINCT CASE WHEN dt.source_id = a.id THEN dt.target_id ELSE dt.source_id END) AS deg "
+        "FROM artist a "
+        "JOIN dj_transition dt ON (dt.source_id = a.id OR dt.target_id = a.id) AND dt.source_id != dt.target_id "
+        "GROUP BY a.id"
+    ):
+        degree[row["id"]] = row["deg"]
+    return degree
+
+
+def get_aa_weighted_neighbors(
+    db: sqlite3.Connection, id_a: int, id_b: int, degree: dict[int, int], top_k: int = 5
+) -> tuple[list[str], float]:
+    """Get Adamic-Adar weighted shared neighbors and total AA score."""
+    rows = db.execute(
+        """
+        WITH a_neighbors AS (
+            SELECT CASE WHEN source_id = :a THEN target_id ELSE source_id END AS nid
+            FROM dj_transition WHERE (source_id = :a OR target_id = :a) AND source_id != target_id
+        ),
+        b_neighbors AS (
+            SELECT CASE WHEN source_id = :b THEN target_id ELSE source_id END AS nid
+            FROM dj_transition WHERE (source_id = :b OR target_id = :b) AND source_id != target_id
+        )
+        SELECT DISTINCT a.id, a.canonical_name
+        FROM a_neighbors an JOIN b_neighbors bn ON an.nid = bn.nid
+        JOIN artist a ON a.id = an.nid
+        WHERE a.canonical_name NOT LIKE 'Various%'
+          AND a.canonical_name NOT LIKE 'V/A%'
+          AND a.canonical_name != 'various'
+          AND a.canonical_name != 'Unknown'
+        """,
+        {"a": id_a, "b": id_b},
+    ).fetchall()
+
+    scored = []
+    for r in rows:
+        deg = degree.get(r["id"], 1)
+        aa = 1.0 / math.log(deg) if deg > 1 else 1.0
+        scored.append((r["canonical_name"], aa))
+
+    scored.sort(key=lambda x: x[1], reverse=True)
+    total_aa = sum(s for _, s in scored)
+    top_names = [name for name, _ in scored[:top_k]]
+    return top_names, total_aa
+
+
+def get_artist_meta(db: sqlite3.Connection, artist_id: int, max_styles: int = 5) -> dict:
+    row = db.execute(
+        "SELECT canonical_name, genre, total_plays FROM artist WHERE id = ?", (artist_id,)
+    ).fetchone()
+    if not row:
+        return {}
+
+    meta: dict = {"name": row["canonical_name"], "genre": row["genre"], "total_plays": row["total_plays"]}
+
+    try:
+        styles = db.execute(
+            "SELECT style_tag FROM artist_style WHERE artist_id = ? ORDER BY style_tag",
+            (artist_id,),
+        ).fetchall()
+        style_list = [r["style_tag"] for r in styles]
+        if style_list:
+            meta["styles"] = style_list[:max_styles]
+    except sqlite3.OperationalError:
+        pass
+
+    try:
+        profile = db.execute(
+            "SELECT avg_danceability, voice_instrumental_ratio, recording_count "
+            "FROM audio_profile WHERE artist_id = ?",
+            (artist_id,),
+        ).fetchone()
+        if profile and profile["recording_count"] and profile["recording_count"] > 0:
+            meta["audio"] = {
+                "danceability": round(profile["avg_danceability"], 2),
+                "voice_instrumental": "vocal" if profile["voice_instrumental_ratio"] > 0.5 else "instrumental",
+            }
+    except sqlite3.OperationalError:
+        pass
+
+    return meta
+
+
+def find_test_pairs(db: sqlite3.Connection, degree: dict[int, int], count: int = 10) -> list[dict]:
+    """Find diverse pairs with strong AA scores."""
+    candidates = db.execute(
+        """
+        SELECT a.id, a.canonical_name, a.genre
+        FROM artist a
+        JOIN dj_transition dt ON (dt.source_id = a.id OR dt.target_id = a.id) AND dt.source_id != dt.target_id
+        WHERE a.total_plays >= 400
+          AND a.canonical_name NOT LIKE 'Various%'
+          AND a.canonical_name NOT LIKE 'V/A%'
+          AND a.canonical_name != 'various'
+        GROUP BY a.id
+        HAVING COUNT(DISTINCT CASE WHEN dt.source_id = a.id THEN dt.target_id ELSE dt.source_id END) >= 15
+        ORDER BY RANDOM()
+        LIMIT 80
+        """,
+    ).fetchall()
+
+    pairs = []
+    used_ids: set[int] = set()
+
+    for i, a in enumerate(candidates):
+        if len(pairs) >= count:
+            break
+        if a["id"] in used_ids:
+            continue
+        for b in candidates[i + 1 :]:
+            if len(pairs) >= count:
+                break
+            if b["id"] in used_ids:
+                continue
+
+            # No direct edge
+            edge = db.execute(
+                "SELECT 1 FROM dj_transition WHERE "
+                "(source_id = ? AND target_id = ?) OR (source_id = ? AND target_id = ?)",
+                (a["id"], b["id"], b["id"], a["id"]),
+            ).fetchone()
+            if edge:
+                continue
+
+            neighbors, aa_total = get_aa_weighted_neighbors(db, a["id"], b["id"], degree)
+            # Filter: require minimum AA sum of 0.8 and at least 3 neighbors
+            if aa_total < 0.8 or len(neighbors) < 3:
+                continue
+
+            pairs.append({
+                "id_a": a["id"],
+                "id_b": b["id"],
+                "neighbors": neighbors,
+                "aa_total": aa_total,
+            })
+            used_ids.add(a["id"])
+            used_ids.add(b["id"])
+            break
+
+    return pairs
+
+
+def main():
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    if not api_key:
+        print("Set ANTHROPIC_API_KEY to run this script.", file=sys.stderr)
+        sys.exit(1)
+
+    client = anthropic.Anthropic(api_key=api_key)
+    db = get_db()
+    degree = compute_degrees(db)
+
+    print("Finding test pairs (AA-filtered)...", file=sys.stderr)
+    pairs = find_test_pairs(db, degree, count=10)
+    print(f"Found {len(pairs)} pairs", file=sys.stderr)
+
+    for pair in pairs:
+        source_meta = get_artist_meta(db, pair["id_a"])
+        target_meta = get_artist_meta(db, pair["id_b"])
+
+        prompt_data = {
+            "source": source_meta,
+            "target": target_meta,
+            "relationships": [],
+            "sequential_context": {
+                "shared_set_neighbors": pair["neighbors"],
+            },
+        }
+
+        user_message = json.dumps(prompt_data, separators=(",", ":"))
+
+        print(f"{'=' * 70}")
+        print(f"{source_meta['name']} / {target_meta['name']}")
+        print(f"  genre: {source_meta.get('genre', '?')} / {target_meta.get('genre', '?')}")
+        print(f"  plays: {source_meta['total_plays']} / {target_meta['total_plays']}")
+        print(f"  AA score: {pair['aa_total']:.3f}")
+        print(f"  neighbors (AA-ranked): {', '.join(pair['neighbors'])}")
+        if source_meta.get('styles'):
+            print(f"  styles A: {', '.join(source_meta['styles'])}")
+        if target_meta.get('styles'):
+            print(f"  styles B: {', '.join(target_meta['styles'])}")
+        print()
+
+        for label, system_prompt in PROMPTS.items():
+            response = client.messages.create(
+                model="claude-haiku-4-5-20251001",
+                max_tokens=150,
+                system=system_prompt,
+                messages=[{"role": "user", "content": user_message}],
+            )
+            narrative = response.content[0].text
+            print(f"  [{label}]")
+            print(f"  {narrative}")
+            print()
+            time.sleep(0.3)
+
+    print(f"{'=' * 70}")
+    db.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/experiments/narrative/test_narrative_augmentation.py
+++ b/scripts/experiments/narrative/test_narrative_augmentation.py
@@ -1,0 +1,188 @@
+"""Test augmented narrative generation with hand-crafted sequential context.
+
+Sends three test cases to Claude Haiku to evaluate whether sequential context
+(the kind embeddings would provide) produces better narratives. No embeddings
+needed — the context is constructed from real database queries.
+"""
+
+import json
+import os
+import sys
+
+import anthropic
+
+SYSTEM_PROMPT = (
+    "You are a music knowledge assistant for WXYC 89.3 FM, a freeform college radio station. "
+    "Given structured data about the relationship between two artists in the station's play "
+    "history, write 2-3 sentences (under 80 words) explaining their connection in plain "
+    "English. Be specific — mention shared styles, personnel names, labels, or play patterns "
+    "from the data. Do not add information not present in the data. "
+    "When sequential_context is present, use it to describe how DJs use these artists in "
+    "similar ways — which artists they tend to appear near, and what that suggests about their "
+    "shared role in a set. Use language like 'DJs reach for both at similar moments' or "
+    "'both tend to appear near [artists].' The shared_set_neighbors list shows artists that "
+    "both subjects tend to appear near — do not imply the neighbors are similar to each other. "
+    "Never reference adjacency or proximity in the playlist when describing sequential context — "
+    "the connection is about role, not position. "
+    "Never use technical terms like 'embedding,' 'vector,' or 'cosine similarity.' "
+    "Describe what an artist's music IS, not what it isn't — avoid 'low-danceability' or similar "
+    "negations. "
+    "Africa is a continent, not a genre. If the data includes country or region, use that. If it "
+    "only says 'Africa' or 'African,' describe the specific musical tradition from the styles "
+    "(e.g. 'Desert Blues,' 'Congolese likembe music') rather than generalizing across the continent."
+)
+
+TEST_CASES = [
+    {
+        "label": "NO DIRECT EDGE, SHARED CONTEXT (Tinariwen / Konono No 1)",
+        "prompt": {
+            "source": {
+                "name": "Tinariwen",
+                "genre": "Africa",
+                "total_plays": 844,
+                "styles": [
+                    "African", "Blues Rock", "Desert Blues", "Electric Blues",
+                    "Experimental", "Folk", "Psychedelic Rock",
+                ],
+                "region": "Mali / Algeria (Saharan Tuareg)",
+            },
+            "target": {
+                "name": "Konono No 1",
+                "genre": "Africa",
+                "total_plays": 695,
+                "styles": [],
+                "region": "DR Congo (Kinshasa, likembe/thumb piano ensemble)",
+            },
+            "relationships": [],
+            "sequential_context": {
+                "shared_set_neighbors": [
+                    "Ali Farka Toure", "Mdou Moctar", "William Parker",
+                    "Duke Ellington", "LCD Soundsystem", "Gilberto Gil",
+                    "The Microphones", "People Like Us",
+                ],
+                "note": "These artists have never appeared back-to-back, but DJs place them near the same artists in their shows.",
+            },
+        },
+    },
+    {
+        "label": "CONTEXTUAL SIMILARITY DESPITE SURFACE DIFFERENCE (Outkast / Dam-Funk)",
+        "prompt": {
+            "source": {
+                "name": "Outkast",
+                "genre": "Hiphop",
+                "total_plays": 1780,
+                "styles": [
+                    "Boom Bap", "Conscious", "Funk", "G-Funk", "Hip Hop",
+                    "Neo Soul", "P.Funk", "Soul",
+                ],
+                "audio": {
+                    "danceability": 0.58,
+                    "voice_instrumental": "vocal",
+                    "top_moods": ["happy", "party"],
+                },
+            },
+            "target": {
+                "name": "Dam-Funk",
+                "genre": "Electronic",
+                "total_plays": 834,
+                "styles": [
+                    "Boogie", "Deep House", "Electro", "Free Funk", "Funk",
+                    "G-Funk", "Neo Soul", "P.Funk", "Synth-pop",
+                ],
+                "audio": {
+                    "danceability": 0.74,
+                    "voice_instrumental": "vocal",
+                    "top_moods": ["electronic", "happy"],
+                },
+            },
+            "relationships": [],
+            "sequential_context": {
+                "shared_set_neighbors": [
+                    "Miles Davis", "Nina Simone", "A Tribe Called Quest",
+                    "Gil Scott-Heron", "Madlib", "Omar S.", "Four Tet",
+                    "Octo Octa", "Animal Collective", "Pharoah Sanders",
+                    "Marvin Gaye", "Stevie Wonder",
+                ],
+                "note": "These artists have never appeared back-to-back, but DJs place them near the same artists in their shows.",
+            },
+        },
+    },
+    {
+        "label": "SPARSE NEIGHBORHOOD ENRICHMENT (Michael Nyman)",
+        "prompt": {
+            "source": {
+                "name": "Michael Nyman",
+                "genre": "OCS",
+                "total_plays": 214,
+                "styles": [
+                    "Ambient", "Avantgarde", "Chamber Music", "Classical",
+                    "Minimal", "Minimalism", "Modern Classical",
+                    "Neo-Classical", "Opera", "Score", "Soundtrack",
+                ],
+                "audio": {
+                    "danceability": 0.14,
+                    "voice_instrumental": "instrumental",
+                    "top_moods": ["relaxed", "acoustic", "sad"],
+                },
+            },
+            "target": {
+                "name": "Philip Glass",
+                "genre": "OCS",
+                "total_plays": 595,
+                "styles": [],
+            },
+            "relationships": [],
+            "sequential_context": {
+                "source_direct_neighbors": ["Bitchin' Bajas"],
+                "target_direct_neighbors": [
+                    "Steve Reich", "Nils Frahm", "Ennio Morricone",
+                    "Laurie Anderson", "Loscil", "Actress",
+                ],
+                "shared_set_neighbors": [],
+                "same_show_count": 2,
+                "note": "Michael Nyman has only 1 non-compilation edge (Bitchin' Bajas) despite 214 plays. Philip Glass connects to Steve Reich, Nils Frahm, and Ennio Morricone. Both are minimalist composers shelved under OCS. They appeared in the same show twice but never back-to-back.",
+            },
+        },
+    },
+]
+
+
+def main():
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    if not api_key:
+        print("Set ANTHROPIC_API_KEY to run this script.", file=sys.stderr)
+        sys.exit(1)
+
+    client = anthropic.Anthropic(api_key=api_key)
+
+    for case in TEST_CASES:
+        print(f"\n{'=' * 70}")
+        print(f"  {case['label']}")
+        print(f"{'=' * 70}\n")
+
+        user_message = json.dumps(case["prompt"], separators=(",", ":"))
+
+        print(f"Prompt ({len(user_message)} chars):")
+        print(json.dumps(case["prompt"], indent=2))
+        print()
+
+        response = client.messages.create(
+            model="claude-haiku-4-5-20251001",
+            max_tokens=150,
+            system=SYSTEM_PROMPT,
+            messages=[{"role": "user", "content": user_message}],
+        )
+
+        narrative = response.content[0].text
+        usage = response.usage
+
+        print(f"Narrative ({len(narrative.split())} words):")
+        print(f"  {narrative}")
+        print(f"\n  tokens: {usage.input_tokens} in / {usage.output_tokens} out")
+
+    print(f"\n{'=' * 70}")
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Recreated after the parent branch was deleted on merge of #248, which auto-closed the original PR #249.

## Summary

Lands 4 frozen runners cited in Plan §1:

- `compare_neighbor_weighting.py` (134) — Adamic-Adar vs raw PMI
- `coverage_with_normalization.py` (161) — normalization-driven coverage lifts
- `test_narrative_augmentation.py` (188) — prompt-augmentation feasibility
- `experiment_narrative_variants.py` (299) — prompt variant matrix

## Known bug in `experiment_narrative_variants.py`

`get_artist_meta()` queries `SELECT style_tag FROM artist_style` but the schema column is `style`; the `sqlite3.OperationalError` is swallowed silently, so styles never load in this experiment's runs. Any plan-doc result that depended on a styles-on/off comparison in this script should be treated as suspect until rerun.

This PR lands the script as the historical artifact (with the bug, plus a docstring warning). The fix is in a stacked follow-up PR — preserves the historical record while making the fix reviewable on its own.

794 lines total. All under `scripts/experiments/narrative/`, which ruff already excludes. Part of #207.

## Test plan

- [x] `ruff check .` passes
- [x] `ruff format --check .` passes
- [x] `mypy semantic_index/` unaffected