### PR TITLE
Fix style column typo in experiment_narrative_variants.py

### DIFF
--- a/scripts/experiments/narrative/experiment_narrative_variants.py
+++ b/scripts/experiments/narrative/experiment_narrative_variants.py
@@ -6,14 +6,6 @@ Tests three prompt variants on the same set of pairs:
 3. ANTI-HALLUCINATION + VARIED LANGUAGE — also address verb monotony
 
 Uses Adamic-Adar weighted neighbors and filters out weak pairs.
-
-KNOWN BUG (preserved, fixed in a follow-up PR):
-    get_artist_meta() queries `SELECT style_tag FROM artist_style` but the
-    schema column is `style`. The resulting sqlite3.OperationalError is
-    swallowed by a broad except, so meta["styles"] is always [] in this
-    script's runs. Any plan-doc result derived from a styles-on/off
-    comparison in this experiment should be treated as suspect until
-    rerun. Landing the file as the historical artifact; fix follows.
 """
 
 import json
@@ -160,10 +152,10 @@ def get_artist_meta(db: sqlite3.Connection, artist_id: int, max_styles: int = 5)
 
     try:
         styles = db.execute(
-            "SELECT style_tag FROM artist_style WHERE artist_id = ? ORDER BY style_tag",
+            "SELECT style FROM artist_style WHERE artist_id = ? ORDER BY style",
             (artist_id,),
         ).fetchall()
-        style_list = [r["style_tag"] for r in styles]
+        style_list = [r["style"] for r in styles]
         if style_list:
             meta["styles"] = style_list[:max_styles]
     except sqlite3.OperationalError:


### PR DESCRIPTION
## Summary

`get_artist_meta()` in the experiment runner queried `SELECT style_tag FROM artist_style`, but the column is `style` (per the `artist_style` schema in `pipeline_db.py`). The resulting `sqlite3.OperationalError` was caught and discarded, so `meta["styles"]` was silently empty in every run.

Fixes the column name and removes the `KNOWN BUG` warning that #255 added to the module docstring.

## Caveat

The §1.4 styles-on/off comparison in `docs/narrative-enrichment-plan.md` was produced from runs of this script *with* the bug. Those numbers should be re-run before being cited in further work — flagging that here for follow-up rather than blocking on it.

Stacked on #255.

## Test plan

- [x] `ruff check .` passes
- [x] `ruff format --check .` passes
- [x] `mypy semantic_index/` unaffected