### PR TITLE
Revert PR #256 — column name was correct as style_tag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,8 +164,8 @@ CREATE TABLE entity (
 
 CREATE TABLE artist_style (
     artist_id INTEGER NOT NULL REFERENCES artist(id),
-    style TEXT NOT NULL,
-    PRIMARY KEY (artist_id, style)
+    style_tag TEXT NOT NULL,
+    PRIMARY KEY (artist_id, style_tag)
 );
 
 CREATE TABLE reconciliation_log (

--- a/scripts/experiments/narrative/experiment_narrative_variants.py
+++ b/scripts/experiments/narrative/experiment_narrative_variants.py
@@ -152,10 +152,10 @@ def get_artist_meta(db: sqlite3.Connection, artist_id: int, max_styles: int = 5)
 
     try:
         styles = db.execute(
-            "SELECT style FROM artist_style WHERE artist_id = ? ORDER BY style",
+            "SELECT style_tag FROM artist_style WHERE artist_id = ? ORDER BY style_tag",
             (artist_id,),
         ).fetchall()
-        style_list = [r["style"] for r in styles]
+        style_list = [r["style_tag"] for r in styles]
         if style_list:
             meta["styles"] = style_list[:max_styles]
     except sqlite3.OperationalError:


### PR DESCRIPTION
## Summary

Reverts the column rename from #256. The \`artist_style\` table's column is \`style_tag\`, not \`style\` — confirmed in:

- \`semantic_index/sqlite_export.py:63–66\` (CREATE TABLE)
- \`semantic_index/pipeline_db.py:81–84\`
- The production database (\`sqlite3 data/wxyc_artist_graph.db \".schema artist_style\"\`)

## What happened

PR #256 changed correct code based on a misread of \`CLAUDE.md\`, which described the schema with the wrong column name. The pre-PR review hook trusted CLAUDE.md and flagged the original \`style_tag\` query as a typo against \`style\`; the rename was pushed on that basis. Net effect: a frozen-artifact experiment script that worked correctly was edited to silently fail (and a public PR description claimed §1.4 results were suspect when they weren't).

## Changes

- Restores \`experiment_narrative_variants.py\` to its original frozen state (column name \`style_tag\`).
- Fixes the \`CREATE TABLE artist_style\` block in \`CLAUDE.md\` so future readers — or hooks — don't fall into the same trap.

## What's NOT changed

- Production \`semantic_index/api/narrative.py\` was already querying \`style_tag\` correctly; it was never affected.
- The plan doc's §1.4 styles-on/off comparison is correct as-published — no rerun needed.

## Test plan

- [x] \`ruff check .\` passes
- [x] \`ruff format --check .\` passes
- [x] \`mypy semantic_index/\` passes
- [ ] CI green