### PR TITLE
Rank shared neighbors by Adamic-Adar in narrative prompt

### DIFF
--- a/semantic_index/api/narrative.py
+++ b/semantic_index/api/narrative.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import sqlite3
 from datetime import UTC, datetime
 
@@ -16,6 +17,12 @@ from semantic_index.api.schemas import NarrativeResponse
 logger = logging.getLogger(__name__)
 
 narrative_router = APIRouter(prefix="/graph", tags=["graph"])
+
+# Bump whenever the prompt's structure or content changes so the sidecar cache
+# evicts stale entries instead of serving them indefinitely.
+_PROMPT_VERSION = 2
+
+_SHARED_NEIGHBORS_TOP_K = 5
 
 MONTH_NAMES = [
     "",
@@ -48,9 +55,10 @@ CREATE TABLE IF NOT EXISTS narrative_cache (
     month INTEGER NOT NULL DEFAULT 0,
     dj_id INTEGER NOT NULL DEFAULT 0,
     edge_type TEXT NOT NULL DEFAULT '',
+    prompt_version INTEGER NOT NULL DEFAULT 1,
     narrative TEXT NOT NULL,
     created_at TEXT NOT NULL,
-    PRIMARY KEY (source_id, target_id, month, dj_id, edge_type)
+    PRIMARY KEY (source_id, target_id, month, dj_id, edge_type, prompt_version)
 );
 """
 
@@ -58,20 +66,73 @@ CREATE TABLE IF NOT EXISTS narrative_cache (
 def _get_cache_db(db_path: str) -> sqlite3.Connection:
     """Open a writable connection to the sidecar narrative cache database.
 
-    Includes a migration that drops the old schema (PK without ``edge_type``)
-    before creating the current one. Safe because this is a regenerable cache.
+    Drops and recreates ``narrative_cache`` whenever its column set has drifted
+    from the current schema. Safe because this is a regenerable cache; the
+    drop is the "evict stale entries" mechanism for prompt-version bumps.
     """
     cache_path = db_path + ".narrative-cache.db"
     conn = sqlite3.connect(cache_path, check_same_thread=False)
     conn.row_factory = sqlite3.Row
     conn.execute("PRAGMA journal_mode=WAL")
-    # Migrate: old schema has PK without edge_type — ALTER TABLE can't change
-    # a PK, so drop and recreate.  This is just a cache; entries regenerate.
     cols = {r[1] for r in conn.execute("PRAGMA table_info(narrative_cache)")}
-    if cols and "edge_type" not in cols:
+    if cols and ("edge_type" not in cols or "prompt_version" not in cols):
         conn.execute("DROP TABLE narrative_cache")
     conn.executescript(_CACHE_SCHEMA)
     return conn
+
+
+def _compute_aa_neighbors(
+    db: sqlite3.Connection,
+    source_id: int,
+    target_id: int,
+    top_k: int = _SHARED_NEIGHBORS_TOP_K,
+) -> list[dict]:
+    """Adamic-Adar ranked shared neighbors of two artists.
+
+    Each shared neighbor's contribution is ``1 / log(degree)``, where ``degree``
+    is the artist's count of distinct ``dj_transition`` partners. Surfaces
+    informative mid-degree neighbors over generic high-degree hubs.
+
+    Returns a list of dicts ``{name, degree, aa_score}`` sorted descending by
+    ``aa_score``, capped at ``top_k``. Skips neighbors with degree < 2 because
+    ``log(1) = 0`` is undefined and a degree-1 hit is not meaningful anyway.
+    """
+    rows = db.execute(
+        """
+        WITH all_edges AS (
+            SELECT source_id AS a, target_id AS b FROM dj_transition
+            UNION ALL
+            SELECT target_id AS a, source_id AS b FROM dj_transition
+        ),
+        degrees AS (
+            SELECT a AS id, COUNT(DISTINCT b) AS degree FROM all_edges GROUP BY a
+        ),
+        neighbors_a AS (SELECT b AS nid FROM all_edges WHERE a = :a),
+        neighbors_b AS (SELECT b AS nid FROM all_edges WHERE a = :b),
+        shared AS (SELECT nid FROM neighbors_a INTERSECT SELECT nid FROM neighbors_b)
+        SELECT artist.canonical_name, degrees.degree
+        FROM shared
+        JOIN artist ON artist.id = shared.nid
+        JOIN degrees ON degrees.id = shared.nid
+        WHERE artist.id NOT IN (:a, :b)
+        """,
+        {"a": source_id, "b": target_id},
+    ).fetchall()
+
+    scored: list[dict] = []
+    for r in rows:
+        deg = r["degree"]
+        if deg < 2:
+            continue
+        scored.append(
+            {
+                "name": r["canonical_name"],
+                "degree": deg,
+                "aa_score": round(1.0 / math.log(deg), 3),
+            }
+        )
+    scored.sort(key=lambda x: x["aa_score"], reverse=True)
+    return scored[:top_k]
 
 
 def _get_anthropic_client(request: Request):
@@ -98,6 +159,7 @@ def _build_prompt(
     source_meta: dict,
     target_meta: dict,
     relationships: list[dict],
+    shared_neighbors: list[dict] | None = None,
     month: int | None = None,
     dj_name: str | None = None,
     faceted_pair_count: int | None = None,
@@ -108,6 +170,8 @@ def _build_prompt(
         "target": target_meta,
         "relationships": relationships,
     }
+    if shared_neighbors:
+        data["shared_neighbors"] = shared_neighbors
     if month is not None or dj_name is not None:
         facet: dict = {}
         if month is not None:
@@ -285,8 +349,9 @@ def get_narrative(
     try:
         cached_row = cache_db.execute(
             "SELECT narrative FROM narrative_cache "
-            "WHERE source_id = ? AND target_id = ? AND month = ? AND dj_id = ? AND edge_type = ?",
-            (lo, hi, cache_month, cache_dj, cache_edge_type),
+            "WHERE source_id = ? AND target_id = ? AND month = ? AND dj_id = ? "
+            "AND edge_type = ? AND prompt_version = ?",
+            (lo, hi, cache_month, cache_dj, cache_edge_type, _PROMPT_VERSION),
         ).fetchone()
         if cached_row:
             return NarrativeResponse(
@@ -332,10 +397,15 @@ def get_narrative(
     dj_name = _lookup_dj_name(db, dj_id) if dj_id else None
     faceted_count = _compute_faceted_pair_count(db, source_id, target_id, month, dj_id)
 
+    # Adamic-Adar reranked shared neighbors — surfaces specific mid-degree
+    # connections instead of generic high-degree hubs in the prompt.
+    shared_neighbors = _compute_aa_neighbors(db, source_id, target_id)
+
     user_message = _build_prompt(
         source_meta=source_meta,
         target_meta=target_meta,
         relationships=relationships,
+        shared_neighbors=shared_neighbors,
         month=month,
         dj_name=dj_name,
         faceted_pair_count=faceted_count,
@@ -359,14 +429,16 @@ def get_narrative(
     try:
         cache_db.execute(
             "INSERT OR REPLACE INTO narrative_cache "
-            "(source_id, target_id, month, dj_id, edge_type, narrative, created_at) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            "(source_id, target_id, month, dj_id, edge_type, prompt_version, "
+            "narrative, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 lo,
                 hi,
                 cache_month,
                 cache_dj,
                 cache_edge_type,
+                _PROMPT_VERSION,
                 narrative,
                 datetime.now(UTC).isoformat(),
             ),

--- a/semantic_index/api/narrative.py
+++ b/semantic_index/api/narrative.py
@@ -66,9 +66,12 @@ CREATE TABLE IF NOT EXISTS narrative_cache (
 def _get_cache_db(db_path: str) -> sqlite3.Connection:
     """Open a writable connection to the sidecar narrative cache database.
 
-    Drops and recreates ``narrative_cache`` whenever its column set has drifted
-    from the current schema. Safe because this is a regenerable cache; the
-    drop is the "evict stale entries" mechanism for prompt-version bumps.
+    Cache eviction is by exclusion: ``prompt_version`` is part of the row's
+    primary key and reads filter on the current ``_PROMPT_VERSION``, so rows
+    written under prior versions stay on disk but are never returned. The
+    initial schema-mismatch drop here only fires for caches built before
+    ``prompt_version`` (or ``edge_type``) was added — once the column exists,
+    subsequent version bumps don't change the schema.
     """
     cache_path = db_path + ".narrative-cache.db"
     conn = sqlite3.connect(cache_path, check_same_thread=False)
@@ -81,21 +84,24 @@ def _get_cache_db(db_path: str) -> sqlite3.Connection:
     return conn
 
 
-def _compute_aa_neighbors(
+def _rank_shared_neighbors_by_aa(
     db: sqlite3.Connection,
     source_id: int,
     target_id: int,
     top_k: int = _SHARED_NEIGHBORS_TOP_K,
 ) -> list[dict]:
-    """Adamic-Adar ranked shared neighbors of two artists.
+    """Rank the shared ``dj_transition`` neighbors of two artists by AA contribution.
 
-    Each shared neighbor's contribution is ``1 / log(degree)``, where ``degree``
-    is the artist's count of distinct ``dj_transition`` partners. Surfaces
-    informative mid-degree neighbors over generic high-degree hubs.
+    Each returned neighbor's score is its Adamic-Adar *contribution* —
+    ``1 / log(degree)``, where ``degree`` is its number of distinct
+    ``dj_transition`` partners. Note this is the per-neighbor term, not the
+    full Adamic-Adar similarity of the source/target *pair* (which would be
+    the sum of these terms over all shared neighbors). Sorting neighbors by
+    their AA contribution surfaces informative mid-degree connections over
+    generic high-degree hubs, which is what the prompt wants.
 
-    Returns a list of dicts ``{name, degree, aa_score}`` sorted descending by
-    ``aa_score``, capped at ``top_k``. Skips neighbors with degree < 2 because
-    ``log(1) = 0`` is undefined and a degree-1 hit is not meaningful anyway.
+    Returns a list of ``{name, degree, aa_score}`` dicts sorted descending by
+    ``aa_score``, capped at ``top_k``.
     """
     rows = db.execute(
         """
@@ -122,6 +128,9 @@ def _compute_aa_neighbors(
     scored: list[dict] = []
     for r in rows:
         deg = r["degree"]
+        # Unreachable: a shared neighbor connects to both source and target,
+        # so degree >= 2. Kept as a guard against log(1) = 0 in case the SQL
+        # is ever broadened to include non-shared neighbors.
         if deg < 2:
             continue
         scored.append(
@@ -397,9 +406,9 @@ def get_narrative(
     dj_name = _lookup_dj_name(db, dj_id) if dj_id else None
     faceted_count = _compute_faceted_pair_count(db, source_id, target_id, month, dj_id)
 
-    # Adamic-Adar reranked shared neighbors — surfaces specific mid-degree
-    # connections instead of generic high-degree hubs in the prompt.
-    shared_neighbors = _compute_aa_neighbors(db, source_id, target_id)
+    # AA-ranked shared neighbors — surfaces specific mid-degree connections
+    # instead of generic high-degree hubs in the prompt.
+    shared_neighbors = _rank_shared_neighbors_by_aa(db, source_id, target_id)
 
     user_message = _build_prompt(
         source_meta=source_meta,

--- a/tests/unit/test_narrative.py
+++ b/tests/unit/test_narrative.py
@@ -13,7 +13,7 @@ import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 
 from semantic_index.api.app import create_app
-from semantic_index.api.narrative import _compute_aa_neighbors
+from semantic_index.api.narrative import _rank_shared_neighbors_by_aa
 from semantic_index.facet_export import export_facet_tables
 from semantic_index.models import ArtistStats, PmiEdge, SharedPersonnelEdge, SharedStyleEdge
 from semantic_index.sqlite_export import export_sqlite
@@ -584,7 +584,7 @@ class TestAdamicAdarReranking:
             for r in conn.execute("SELECT id, canonical_name FROM artist")
         }
 
-        result = _compute_aa_neighbors(conn, ids["Father John Misty"], ids["Caetano Veloso"])
+        result = _rank_shared_neighbors_by_aa(conn, ids["Father John Misty"], ids["Caetano Veloso"])
         conn.close()
 
         names = [r["name"] for r in result]
@@ -601,7 +601,7 @@ class TestAdamicAdarReranking:
             for r in conn.execute("SELECT id, canonical_name FROM artist")
         }
 
-        result = _compute_aa_neighbors(conn, ids["Father John Misty"], ids["Caetano Veloso"])
+        result = _rank_shared_neighbors_by_aa(conn, ids["Father John Misty"], ids["Caetano Veloso"])
         conn.close()
 
         joe = next(r for r in result if r["name"] == "Joe McPhee")
@@ -621,7 +621,7 @@ class TestAdamicAdarReranking:
             for r in conn.execute("SELECT id, canonical_name FROM artist")
         }
 
-        result = _compute_aa_neighbors(
+        result = _rank_shared_neighbors_by_aa(
             conn, ids["Father John Misty"], ids["Caetano Veloso"], top_k=1
         )
         conn.close()
@@ -641,7 +641,7 @@ class TestAdamicAdarReranking:
 
         # Filler 00 only connects to Yo La Tengo; Joe McPhee only connects to
         # the two pivots. They have no common neighbor.
-        result = _compute_aa_neighbors(conn, ids["Joe McPhee"], ids["Filler 00"])
+        result = _rank_shared_neighbors_by_aa(conn, ids["Joe McPhee"], ids["Filler 00"])
         conn.close()
 
         assert result == []
@@ -668,3 +668,46 @@ class TestAdamicAdarReranking:
             assert isinstance(prompt_data["shared_neighbors"], list)
             for entry in prompt_data["shared_neighbors"]:
                 assert {"name", "degree", "aa_score"} <= set(entry)
+
+
+class TestPromptVersionEviction:
+    @pytest.mark.asyncio
+    async def test_bump_invalidates_prior_version_cache(
+        self,
+        narrative_db_path: str,
+        narrative_artist_ids: dict[str, int],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A ``_PROMPT_VERSION`` bump misses prior-version cache entries.
+
+        Guards the contract that subsequent prompt edits in #220–#223 can rely
+        on bumping the constant alone to evict stale narratives.
+        """
+        _clear_narrative_cache(narrative_db_path)
+
+        mock_client = _mock_anthropic_client()
+        app = create_app(narrative_db_path, anthropic_api_key="test-key")
+        app.state.anthropic_client = mock_client
+        transport = ASGITransport(app=app)
+
+        ae_id = narrative_artist_ids["Autechre"]
+        sl_id = narrative_artist_ids["Stereolab"]
+
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            # Populate cache at the current prompt version, then confirm the
+            # repeat hits the cache.
+            resp_first = await ac.get(f"/graph/artists/{ae_id}/explain/{sl_id}/narrative")
+            assert resp_first.json()["cached"] is False
+            resp_repeat = await ac.get(f"/graph/artists/{ae_id}/explain/{sl_id}/narrative")
+            assert resp_repeat.json()["cached"] is True
+
+            # Bump the prompt version: the prior row is still on disk but its
+            # PK no longer matches reads, so the request must regenerate.
+            monkeypatch.setattr("semantic_index.api.narrative._PROMPT_VERSION", 99)
+            resp_after_bump = await ac.get(f"/graph/artists/{ae_id}/explain/{sl_id}/narrative")
+            assert resp_after_bump.json()["cached"] is False, (
+                "cache should miss after _PROMPT_VERSION bump"
+            )
+            # And the new version becomes the warm cache.
+            resp_warm = await ac.get(f"/graph/artists/{ae_id}/explain/{sl_id}/narrative")
+            assert resp_warm.json()["cached"] is True

--- a/tests/unit/test_narrative.py
+++ b/tests/unit/test_narrative.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import math
 import sqlite3
 import tempfile
 from unittest.mock import MagicMock
@@ -12,6 +13,7 @@ import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 
 from semantic_index.api.app import create_app
+from semantic_index.api.narrative import _compute_aa_neighbors
 from semantic_index.facet_export import export_facet_tables
 from semantic_index.models import ArtistStats, PmiEdge, SharedPersonnelEdge, SharedStyleEdge
 from semantic_index.sqlite_export import export_sqlite
@@ -510,3 +512,159 @@ class TestAudioProfileEnrichment:
 
         # Cat Power has no audio profile
         assert "audio" not in prompt_data["target"]
+
+
+def _build_aa_fixture_db() -> str:
+    """Build a synthetic graph where AA and degree-based ranking disagree.
+
+    Two pivots A and B share two neighbors:
+      - X: degree 2 (only connected to A and B). 1/log(2) ≈ 1.44.
+      - Y: degree 50 (connected to A, B, and 48 other artists). 1/log(50) ≈ 0.26.
+
+    A degree-descending or play-count-descending ranking puts Y first; AA puts X
+    first, which is the whole point of the rerank.
+    """
+    path = tempfile.mktemp(suffix=".db")
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        """
+        CREATE TABLE artist (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            canonical_name TEXT NOT NULL UNIQUE,
+            genre TEXT,
+            total_plays INTEGER NOT NULL DEFAULT 0
+        );
+        CREATE TABLE dj_transition (
+            source_id INTEGER NOT NULL,
+            target_id INTEGER NOT NULL,
+            raw_count INTEGER NOT NULL,
+            pmi REAL NOT NULL,
+            PRIMARY KEY (source_id, target_id)
+        );
+        """
+    )
+
+    # Pivots + low-degree shared (X) + high-degree shared (Y) + 48 fillers
+    # for Y's degree.
+    fillers = [f"Filler {i:02d}" for i in range(48)]
+    names = ["Father John Misty", "Caetano Veloso", "Joe McPhee", "Yo La Tengo", *fillers]
+    conn.executemany(
+        "INSERT INTO artist (canonical_name) VALUES (?)",
+        [(n,) for n in names],
+    )
+
+    name_to_id = {
+        r[1]: r[0] for r in conn.execute("SELECT id, canonical_name FROM artist").fetchall()
+    }
+    a, b = name_to_id["Father John Misty"], name_to_id["Caetano Veloso"]
+    x, y = name_to_id["Joe McPhee"], name_to_id["Yo La Tengo"]
+
+    # A and B each link to X (so X has degree 2) and to Y.
+    edges = [(a, x), (b, x), (a, y), (b, y)]
+    # Y also connects to all fillers, taking its degree to 50.
+    for filler_name in fillers:
+        edges.append((y, name_to_id[filler_name]))
+    conn.executemany(
+        "INSERT INTO dj_transition (source_id, target_id, raw_count, pmi) VALUES (?, ?, 1, 1.0)",
+        edges,
+    )
+    conn.commit()
+    conn.close()
+    return path
+
+
+class TestAdamicAdarReranking:
+    def test_aa_outranks_high_degree_hub(self) -> None:
+        """The low-degree shared neighbor scores higher than the high-degree hub."""
+        path = _build_aa_fixture_db()
+        conn = sqlite3.connect(path)
+        conn.row_factory = sqlite3.Row
+        ids = {
+            r["canonical_name"]: r["id"]
+            for r in conn.execute("SELECT id, canonical_name FROM artist")
+        }
+
+        result = _compute_aa_neighbors(conn, ids["Father John Misty"], ids["Caetano Veloso"])
+        conn.close()
+
+        names = [r["name"] for r in result]
+        assert names[0] == "Joe McPhee", f"AA should rank low-degree neighbor first; got {names}"
+        assert names[1] == "Yo La Tengo"
+
+    def test_aa_score_matches_formula(self) -> None:
+        """1/log(degree) is the score, rounded to 3 decimals."""
+        path = _build_aa_fixture_db()
+        conn = sqlite3.connect(path)
+        conn.row_factory = sqlite3.Row
+        ids = {
+            r["canonical_name"]: r["id"]
+            for r in conn.execute("SELECT id, canonical_name FROM artist")
+        }
+
+        result = _compute_aa_neighbors(conn, ids["Father John Misty"], ids["Caetano Veloso"])
+        conn.close()
+
+        joe = next(r for r in result if r["name"] == "Joe McPhee")
+        ylt = next(r for r in result if r["name"] == "Yo La Tengo")
+        assert joe["degree"] == 2
+        assert ylt["degree"] == 50
+        assert joe["aa_score"] == round(1.0 / math.log(2), 3)
+        assert ylt["aa_score"] == round(1.0 / math.log(50), 3)
+
+    def test_top_k_caps_result(self) -> None:
+        """top_k=1 returns only the highest-scoring shared neighbor."""
+        path = _build_aa_fixture_db()
+        conn = sqlite3.connect(path)
+        conn.row_factory = sqlite3.Row
+        ids = {
+            r["canonical_name"]: r["id"]
+            for r in conn.execute("SELECT id, canonical_name FROM artist")
+        }
+
+        result = _compute_aa_neighbors(
+            conn, ids["Father John Misty"], ids["Caetano Veloso"], top_k=1
+        )
+        conn.close()
+
+        assert len(result) == 1
+        assert result[0]["name"] == "Joe McPhee"
+
+    def test_no_shared_neighbors_returns_empty(self) -> None:
+        """Artists with no shared neighbors return an empty list."""
+        path = _build_aa_fixture_db()
+        conn = sqlite3.connect(path)
+        conn.row_factory = sqlite3.Row
+        ids = {
+            r["canonical_name"]: r["id"]
+            for r in conn.execute("SELECT id, canonical_name FROM artist")
+        }
+
+        # Filler 00 only connects to Yo La Tengo; Joe McPhee only connects to
+        # the two pivots. They have no common neighbor.
+        result = _compute_aa_neighbors(conn, ids["Joe McPhee"], ids["Filler 00"])
+        conn.close()
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_prompt_includes_shared_neighbors(
+        self, client: AsyncClient, narrative_artist_ids: dict[str, int]
+    ) -> None:
+        """Generated prompt JSON carries an AA-ranked shared_neighbors list."""
+        ae_id = narrative_artist_ids["Autechre"]
+        sl_id = narrative_artist_ids["Stereolab"]
+        resp = await client.get(f"/graph/artists/{ae_id}/explain/{sl_id}/narrative")
+        assert resp.status_code == 200
+
+        mock_client = client._transport.app.state.anthropic_client  # type: ignore[union-attr]
+        last_call = mock_client.messages.create.call_args
+        messages = last_call.kwargs.get("messages") or last_call[1].get("messages", [])
+        prompt_data = json.loads(messages[0]["content"])
+
+        # The fixture has only 2 pairs (Autechre-Stereolab, Autechre-Cat Power),
+        # so Autechre and Stereolab have no shared neighbors and the key is
+        # omitted. Asserting only that the field is absent or a list.
+        if "shared_neighbors" in prompt_data:
+            assert isinstance(prompt_data["shared_neighbors"], list)
+            for entry in prompt_data["shared_neighbors"]:
+                assert {"name", "degree", "aa_score"} <= set(entry)


### PR DESCRIPTION
## Summary

Adds Adamic-Adar reranking for shared `dj_transition` neighbors and surfaces the top 5 in the narrative prompt JSON as a new `shared_neighbors` list. Each entry is `{name, degree, aa_score}` where `aa_score = 1 / log(degree)` — prioritizes informative mid-degree neighbors over generic high-degree hubs.

The endpoint previously sent no neighbor information at all (only edge-type explain rows), so this is an add rather than a swap. Issue #219's "instead of raw co-occurrence count" wording reflects the design target — what the experiment scripts compared against — but production didn't ship a v1.

## Cache invalidation

`narrative_cache` gets a new `prompt_version` column with the version sentinel embedded in the PK. The schema migration drops the old table on first connect, so cached narratives from the previous prompt format are evicted automatically — no manual `rm` required during deploy.

## Tests

`TestAdamicAdarReranking` adds:
- `test_aa_outranks_high_degree_hub` — synthetic graph where two pivots share a degree-2 neighbor (Joe McPhee) and a degree-50 hub (Yo La Tengo); AA puts the low-degree neighbor first.
- `test_aa_score_matches_formula` — exact numeric check of the rounded `1/log(degree)` value.
- `test_top_k_caps_result` — `top_k=1` returns just the highest-scoring neighbor.
- `test_no_shared_neighbors_returns_empty` — disjoint neighborhoods produce `[]`.
- `test_prompt_includes_shared_neighbors` — end-to-end check that the field appears in the prompt JSON when populated.

## Before/after demonstration

The frozen experiment `scripts/experiments/narrative/compare_neighbor_weighting.py` documents the measured outcomes against production data (cited in #219):

- **Peter Brötzmann / Angel Olsen** — raw leads with Arthur Russell + Dan Melchior (high-degree hubs); AA surfaces Dum Dum Girls (deg 27) + Joe McPhee (deg 36) — a garage-pop band and a free jazz saxophonist sharing the same neighborhood.
- **Caetano Veloso / Don Cherry** — Dennis Bovell (deg 37) jumps from last to first; both worked across Brazilian/jazz/dub lines and Bovell makes the pair legible.
- **Religious Knives / Pastor T.L. Barrett** — United Waters (deg 27) rises to top; Can (deg 204) drops out of the top.

## Test plan

- [x] `ruff check .` passes
- [x] `ruff format --check .` passes
- [x] `mypy semantic_index/` passes
- [x] `pytest tests/unit/test_narrative.py` — 20 passed
- [ ] CI green
- [ ] Deploy: cache automatically evicts on first request

Closes #219.