### PR TITLE
Apply minimum AA-score threshold to narrative generation

### DIFF
--- a/semantic_index/api/narrative.py
+++ b/semantic_index/api/narrative.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import math
+import os
 import sqlite3
 from datetime import UTC, datetime
 
@@ -20,9 +21,37 @@ narrative_router = APIRouter(prefix="/graph", tags=["graph"])
 
 # Bump whenever the prompt's structure or content changes so the sidecar cache
 # evicts stale entries instead of serving them indefinitely.
-_PROMPT_VERSION = 2
+_PROMPT_VERSION = 3
 
 _SHARED_NEIGHBORS_TOP_K = 5
+
+# Minimum total Adamic-Adar contribution across surfaced shared neighbors for a
+# pair to be worth narrating. Pairs below this floor share only generic hubs
+# (Frank Sinatra, The Beatles), and even AA reranking can't manufacture a real
+# story. Empirical sweet spot from compare_neighbor_weighting.py was 0.8 —
+# overrideable via NARRATIVE_MIN_AA_SCORE for tuning without a redeploy.
+_DEFAULT_MIN_AA_SCORE = 0.8
+
+_INSUFFICIENT_SIGNAL_NARRATIVE = (
+    "WXYC DJs occasionally play these artists together, but they don't share "
+    "enough specific musical context — same labels, similar styles, common "
+    "collaborators — to characterize a meaningful connection."
+)
+
+
+def _min_aa_score() -> float:
+    """Read the AA-score threshold from the environment, falling back to default."""
+    raw = os.environ.get("NARRATIVE_MIN_AA_SCORE")
+    if raw is None:
+        return _DEFAULT_MIN_AA_SCORE
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning(
+            "Invalid NARRATIVE_MIN_AA_SCORE=%r; using default %.2f", raw, _DEFAULT_MIN_AA_SCORE
+        )
+        return _DEFAULT_MIN_AA_SCORE
+
 
 MONTH_NAMES = [
     "",
@@ -48,6 +77,8 @@ _SYSTEM_PROMPT = (
     "from the data. Do not add information not present in the data."
 )
 
+_REQUIRED_CACHE_COLUMNS = {"edge_type", "prompt_version", "insufficient_signal"}
+
 _CACHE_SCHEMA = """
 CREATE TABLE IF NOT EXISTS narrative_cache (
     source_id INTEGER NOT NULL,
@@ -56,6 +87,7 @@ CREATE TABLE IF NOT EXISTS narrative_cache (
     dj_id INTEGER NOT NULL DEFAULT 0,
     edge_type TEXT NOT NULL DEFAULT '',
     prompt_version INTEGER NOT NULL DEFAULT 1,
+    insufficient_signal INTEGER NOT NULL DEFAULT 0,
     narrative TEXT NOT NULL,
     created_at TEXT NOT NULL,
     PRIMARY KEY (source_id, target_id, month, dj_id, edge_type, prompt_version)
@@ -69,19 +101,51 @@ def _get_cache_db(db_path: str) -> sqlite3.Connection:
     Cache eviction is by exclusion: ``prompt_version`` is part of the row's
     primary key and reads filter on the current ``_PROMPT_VERSION``, so rows
     written under prior versions stay on disk but are never returned. The
-    initial schema-mismatch drop here only fires for caches built before
-    ``prompt_version`` (or ``edge_type``) was added — once the column exists,
-    subsequent version bumps don't change the schema.
+    schema-mismatch drop fires for caches missing any required column — once
+    a release adds a column (e.g. ``insufficient_signal``) the next connect
+    drops and rebuilds. Subsequent version bumps that don't change the schema
+    rely on read-side filtering instead.
     """
     cache_path = db_path + ".narrative-cache.db"
     conn = sqlite3.connect(cache_path, check_same_thread=False)
     conn.row_factory = sqlite3.Row
     conn.execute("PRAGMA journal_mode=WAL")
     cols = {r[1] for r in conn.execute("PRAGMA table_info(narrative_cache)")}
-    if cols and ("edge_type" not in cols or "prompt_version" not in cols):
+    if cols and not _REQUIRED_CACHE_COLUMNS.issubset(cols):
         conn.execute("DROP TABLE narrative_cache")
     conn.executescript(_CACHE_SCHEMA)
     return conn
+
+
+def _write_cache_entry(
+    cache_db: sqlite3.Connection,
+    lo: int,
+    hi: int,
+    cache_month: int,
+    cache_dj: int,
+    cache_edge_type: str,
+    narrative: str,
+    insufficient_signal: bool,
+) -> None:
+    """Insert (or replace) a cache row at the current ``_PROMPT_VERSION``."""
+    cache_db.execute(
+        "INSERT OR REPLACE INTO narrative_cache "
+        "(source_id, target_id, month, dj_id, edge_type, prompt_version, "
+        "insufficient_signal, narrative, created_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            lo,
+            hi,
+            cache_month,
+            cache_dj,
+            cache_edge_type,
+            _PROMPT_VERSION,
+            int(insufficient_signal),
+            narrative,
+            datetime.now(UTC).isoformat(),
+        ),
+    )
+    cache_db.commit()
 
 
 def _rank_shared_neighbors_by_aa(
@@ -357,17 +421,41 @@ def get_narrative(
     cache_db = _get_cache_db(request.app.state.db_path)
     try:
         cached_row = cache_db.execute(
-            "SELECT narrative FROM narrative_cache "
+            "SELECT narrative, insufficient_signal FROM narrative_cache "
             "WHERE source_id = ? AND target_id = ? AND month = ? AND dj_id = ? "
             "AND edge_type = ? AND prompt_version = ?",
             (lo, hi, cache_month, cache_dj, cache_edge_type, _PROMPT_VERSION),
         ).fetchone()
         if cached_row:
             return NarrativeResponse(
-                source=source, target=target, narrative=cached_row["narrative"], cached=True
+                source=source,
+                target=target,
+                narrative=cached_row["narrative"],
+                cached=True,
+                insufficient_signal=bool(cached_row["insufficient_signal"]),
             )
     finally:
         pass  # keep cache_db open for potential write below
+
+    # AA-ranked shared neighbors are computed up-front because the threshold
+    # check below can short-circuit the LLM call entirely.
+    shared_neighbors = _rank_shared_neighbors_by_aa(db, source_id, target_id)
+    total_aa = sum(n["aa_score"] for n in shared_neighbors)
+    if total_aa < _min_aa_score():
+        # No real connection — skip the LLM, cache a deterministic placeholder
+        # so subsequent identical requests stay cheap.
+        narrative = _INSUFFICIENT_SIGNAL_NARRATIVE
+        _write_cache_entry(
+            cache_db, lo, hi, cache_month, cache_dj, cache_edge_type, narrative, True
+        )
+        cache_db.close()
+        return NarrativeResponse(
+            source=source,
+            target=target,
+            narrative=narrative,
+            cached=False,
+            insufficient_signal=True,
+        )
 
     # Check for Anthropic client
     client = _get_anthropic_client(request)
@@ -406,10 +494,6 @@ def get_narrative(
     dj_name = _lookup_dj_name(db, dj_id) if dj_id else None
     faceted_count = _compute_faceted_pair_count(db, source_id, target_id, month, dj_id)
 
-    # AA-ranked shared neighbors — surfaces specific mid-degree connections
-    # instead of generic high-degree hubs in the prompt.
-    shared_neighbors = _rank_shared_neighbors_by_aa(db, source_id, target_id)
-
     user_message = _build_prompt(
         source_meta=source_meta,
         target_meta=target_meta,
@@ -436,23 +520,9 @@ def get_narrative(
 
     # Write to cache
     try:
-        cache_db.execute(
-            "INSERT OR REPLACE INTO narrative_cache "
-            "(source_id, target_id, month, dj_id, edge_type, prompt_version, "
-            "narrative, created_at) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-            (
-                lo,
-                hi,
-                cache_month,
-                cache_dj,
-                cache_edge_type,
-                _PROMPT_VERSION,
-                narrative,
-                datetime.now(UTC).isoformat(),
-            ),
+        _write_cache_entry(
+            cache_db, lo, hi, cache_month, cache_dj, cache_edge_type, narrative, False
         )
-        cache_db.commit()
     finally:
         cache_db.close()
 

--- a/semantic_index/api/narrative.py
+++ b/semantic_index/api/narrative.py
@@ -152,20 +152,18 @@ def _rank_shared_neighbors_by_aa(
     db: sqlite3.Connection,
     source_id: int,
     target_id: int,
-    top_k: int = _SHARED_NEIGHBORS_TOP_K,
 ) -> list[dict]:
-    """Rank the shared ``dj_transition`` neighbors of two artists by AA contribution.
+    """Rank ALL shared ``dj_transition`` neighbors of two artists by AA contribution.
 
     Each returned neighbor's score is its Adamic-Adar *contribution* —
     ``1 / log(degree)``, where ``degree`` is its number of distinct
     ``dj_transition`` partners. Note this is the per-neighbor term, not the
     full Adamic-Adar similarity of the source/target *pair* (which would be
-    the sum of these terms over all shared neighbors). Sorting neighbors by
-    their AA contribution surfaces informative mid-degree connections over
-    generic high-degree hubs, which is what the prompt wants.
+    the sum of these terms over all shared neighbors).
 
-    Returns a list of ``{name, degree, aa_score}`` dicts sorted descending by
-    ``aa_score``, capped at ``top_k``.
+    Returns the full ranked list — *no* top-K cap applied here. Callers slice
+    for the prompt; the AA-score threshold (#220) sums the full list so it
+    matches the true pair AA, not a top-K underestimate.
     """
     rows = db.execute(
         """
@@ -205,7 +203,7 @@ def _rank_shared_neighbors_by_aa(
             }
         )
     scored.sort(key=lambda x: x["aa_score"], reverse=True)
-    return scored[:top_k]
+    return scored
 
 
 def _get_anthropic_client(request: Request):
@@ -438,9 +436,11 @@ def get_narrative(
         pass  # keep cache_db open for potential write below
 
     # AA-ranked shared neighbors are computed up-front because the threshold
-    # check below can short-circuit the LLM call entirely.
-    shared_neighbors = _rank_shared_neighbors_by_aa(db, source_id, target_id)
-    total_aa = sum(n["aa_score"] for n in shared_neighbors)
+    # check below can short-circuit the LLM call entirely. The full ranked
+    # list is summed for the threshold (so it matches true pair AA), then
+    # sliced to top-K for the prompt to keep the LLM input bounded.
+    all_shared_neighbors = _rank_shared_neighbors_by_aa(db, source_id, target_id)
+    total_aa = sum(n["aa_score"] for n in all_shared_neighbors)
     if total_aa < _min_aa_score():
         # No real connection — skip the LLM, cache a deterministic placeholder
         # so subsequent identical requests stay cheap.
@@ -493,6 +493,9 @@ def get_narrative(
     # Facet context
     dj_name = _lookup_dj_name(db, dj_id) if dj_id else None
     faceted_count = _compute_faceted_pair_count(db, source_id, target_id, month, dj_id)
+
+    # Cap to top-K only for the prompt; threshold check above used the full sum.
+    shared_neighbors = all_shared_neighbors[:_SHARED_NEIGHBORS_TOP_K]
 
     user_message = _build_prompt(
         source_meta=source_meta,

--- a/semantic_index/api/schemas.py
+++ b/semantic_index/api/schemas.py
@@ -103,12 +103,21 @@ class EntityArtists(BaseModel):
 
 
 class NarrativeResponse(BaseModel):
-    """Response for GET /graph/artists/{id}/explain/{target_id}/narrative."""
+    """Response for GET /graph/artists/{id}/explain/{target_id}/narrative.
+
+    ``insufficient_signal`` is ``True`` when the pair's total Adamic-Adar
+    contribution from shared neighbors falls below ``NARRATIVE_MIN_AA_SCORE``
+    (default 0.8). The endpoint short-circuits the LLM call and returns a
+    deterministic placeholder ``narrative`` for these pairs — DJs do play
+    them together, but with no consistent neighborhood context to narrate.
+    Clients can render these differently (muted card, hint, etc.).
+    """
 
     source: ArtistSummary
     target: ArtistSummary
     narrative: str
     cached: bool
+    insufficient_signal: bool = False
 
 
 class BioResponse(BaseModel):

--- a/tests/unit/test_narrative.py
+++ b/tests/unit/test_narrative.py
@@ -13,7 +13,11 @@ import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 
 from semantic_index.api.app import create_app
-from semantic_index.api.narrative import _rank_shared_neighbors_by_aa
+from semantic_index.api.narrative import (
+    _INSUFFICIENT_SIGNAL_NARRATIVE,
+    _SHARED_NEIGHBORS_TOP_K,
+    _rank_shared_neighbors_by_aa,
+)
 from semantic_index.facet_export import export_facet_tables
 from semantic_index.models import ArtistStats, PmiEdge, SharedPersonnelEdge, SharedStyleEdge
 from semantic_index.sqlite_export import export_sqlite
@@ -623,8 +627,13 @@ class TestAdamicAdarReranking:
         assert joe["aa_score"] == round(1.0 / math.log(2), 3)
         assert ylt["aa_score"] == round(1.0 / math.log(50), 3)
 
-    def test_top_k_caps_result(self) -> None:
-        """top_k=1 returns only the highest-scoring shared neighbor."""
+    def test_returns_full_list_uncapped(self) -> None:
+        """The function returns ALL shared neighbors — top-K capping is the caller's job.
+
+        Locks the contract: the threshold check needs the full sum to match true
+        pair AA, not a top-K underestimate. If a future refactor pushes capping
+        back inside this function, this test fails first.
+        """
         path = _build_aa_fixture_db()
         conn = sqlite3.connect(path)
         conn.row_factory = sqlite3.Row
@@ -633,13 +642,11 @@ class TestAdamicAdarReranking:
             for r in conn.execute("SELECT id, canonical_name FROM artist")
         }
 
-        result = _rank_shared_neighbors_by_aa(
-            conn, ids["Father John Misty"], ids["Caetano Veloso"], top_k=1
-        )
+        result = _rank_shared_neighbors_by_aa(conn, ids["Father John Misty"], ids["Caetano Veloso"])
         conn.close()
 
-        assert len(result) == 1
-        assert result[0]["name"] == "Joe McPhee"
+        # Fixture has exactly 2 shared neighbors (Joe McPhee, Yo La Tengo).
+        assert [r["name"] for r in result] == ["Joe McPhee", "Yo La Tengo"]
 
     def test_no_shared_neighbors_returns_empty(self) -> None:
         """Artists with no shared neighbors return an empty list."""
@@ -839,10 +846,7 @@ class TestAaThreshold:
         body = resp.json()
         assert body["insufficient_signal"] is True
         assert body["cached"] is False
-        assert (
-            "no consistent" in body["narrative"].lower()
-            or "occasionally" in body["narrative"].lower()
-        )
+        assert body["narrative"] == _INSUFFICIENT_SIGNAL_NARRATIVE
         assert mock_client.messages.create.call_count == 0, (
             "LLM should not be called below threshold"
         )
@@ -927,6 +931,83 @@ class TestAaThreshold:
         assert second.json()["cached"] is True
         assert second.json()["insufficient_signal"] is True
         assert mock_client.messages.create.call_count == 0
+
+    @pytest.mark.asyncio
+    async def test_threshold_uses_full_pair_aa_not_top_k_sum(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The threshold sums the full ranked list, not just the top-K surfaced.
+
+        Constructs a graph with 6 shared neighbors (one more than top-K=5),
+        each at degree 50 (AA contribution ~0.256). The top-K sum is ~1.28;
+        the full sum is ~1.535. With NARRATIVE_MIN_AA_SCORE=1.4, a buggy
+        implementation that summed only the surfaced top-K would short-circuit;
+        the correct implementation reaches the LLM.
+        """
+        # Sanity: top-K is 5, so we need >5 shared neighbors to exercise the gap.
+        assert _SHARED_NEIGHBORS_TOP_K == 5, "test designed around top-K = 5"
+
+        path = tempfile.mktemp(suffix=".db")
+        conn = sqlite3.connect(path)
+        conn.executescript(
+            """
+            CREATE TABLE artist (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                canonical_name TEXT NOT NULL UNIQUE,
+                genre TEXT,
+                total_plays INTEGER NOT NULL DEFAULT 0
+            );
+            CREATE TABLE dj_transition (
+                source_id INTEGER NOT NULL,
+                target_id INTEGER NOT NULL,
+                raw_count INTEGER NOT NULL,
+                pmi REAL NOT NULL,
+                PRIMARY KEY (source_id, target_id)
+            );
+            """
+        )
+        shared = [f"Shared {i}" for i in range(6)]
+        fillers = [f"Filler {i:02d}" for i in range(48)]
+        names = ["A", "B", *shared, *fillers]
+        conn.executemany("INSERT INTO artist (canonical_name) VALUES (?)", [(n,) for n in names])
+        ids = {r[0]: r[1] for r in conn.execute("SELECT canonical_name, id FROM artist").fetchall()}
+        edges: list[tuple[int, int]] = []
+        # Each shared neighbor connects to A, B, and all 48 fillers → degree 50.
+        for s in shared:
+            edges.append((ids["A"], ids[s]))
+            edges.append((ids["B"], ids[s]))
+            for f in fillers:
+                edges.append((ids[s], ids[f]))
+        conn.executemany(
+            "INSERT INTO dj_transition (source_id, target_id, raw_count, pmi) "
+            "VALUES (?, ?, 1, 1.0)",
+            edges,
+        )
+        conn.commit()
+        conn.close()
+
+        # Threshold is between top-5 (~1.28) and full-6 (~1.54).
+        monkeypatch.setenv("NARRATIVE_MIN_AA_SCORE", "1.4")
+        _clear_narrative_cache(path)
+        mock_client = _mock_anthropic_client()
+        app = create_app(path, anthropic_api_key="test-key")
+        app.state.anthropic_client = mock_client
+        transport = ASGITransport(app=app)
+
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get(f"/graph/artists/{ids['A']}/explain/{ids['B']}/narrative")
+
+        body = resp.json()
+        assert body["insufficient_signal"] is False, (
+            "threshold should sum all 6 shared neighbors, not just top-5"
+        )
+        assert mock_client.messages.create.call_count == 1
+        # Sanity: prompt was capped to top-K so the LLM input stays bounded.
+        last_call = mock_client.messages.create.call_args
+        messages = last_call.kwargs.get("messages") or last_call[1].get("messages", [])
+        prompt_data = json.loads(messages[0]["content"])
+        assert len(prompt_data["shared_neighbors"]) == _SHARED_NEIGHBORS_TOP_K
 
     @pytest.mark.asyncio
     async def test_invalid_threshold_falls_back_to_default(

--- a/tests/unit/test_narrative.py
+++ b/tests/unit/test_narrative.py
@@ -172,6 +172,18 @@ def _clear_narrative_cache(db_path: str) -> None:
             pass
 
 
+@pytest.fixture(autouse=True)
+def _disable_aa_threshold(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Disable the AA-score threshold for default narrative tests.
+
+    The shared fixture only has two adjacency pairs and no shared neighbors,
+    so every pair would otherwise short-circuit on ``insufficient_signal`` and
+    skip the mock LLM. Tests in ``TestAaThreshold`` re-set the env var to
+    exercise the threshold logic explicitly.
+    """
+    monkeypatch.setenv("NARRATIVE_MIN_AA_SCORE", "0")
+
+
 @pytest_asyncio.fixture
 async def client(narrative_db_path: str) -> AsyncClient:
     _clear_narrative_cache(narrative_db_path)
@@ -711,3 +723,232 @@ class TestPromptVersionEviction:
             # And the new version becomes the warm cache.
             resp_warm = await ac.get(f"/graph/artists/{ae_id}/explain/{sl_id}/narrative")
             assert resp_warm.json()["cached"] is True
+
+
+def _build_aa_threshold_fixture_db() -> str:
+    """Build a graph with one above-threshold pair and one below-threshold pair.
+
+    - Above: ``A_above`` and ``B_above`` share two degree-2 neighbors
+      (``Niche 1``, ``Niche 2``). Each contributes ~1.44 → total ~2.88, above
+      the 0.8 default.
+    - Below: ``A_below`` and ``B_below`` share one degree-50 neighbor
+      (``Mega Hub``) plus 49 disjoint fillers. Total ~0.26, below the floor.
+    """
+    path = tempfile.mktemp(suffix=".db")
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        """
+        CREATE TABLE artist (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            canonical_name TEXT NOT NULL UNIQUE,
+            genre TEXT,
+            total_plays INTEGER NOT NULL DEFAULT 0
+        );
+        CREATE TABLE dj_transition (
+            source_id INTEGER NOT NULL,
+            target_id INTEGER NOT NULL,
+            raw_count INTEGER NOT NULL,
+            pmi REAL NOT NULL,
+            PRIMARY KEY (source_id, target_id)
+        );
+        """
+    )
+
+    fillers = [f"Mega Filler {i:02d}" for i in range(49)]
+    names = [
+        "Aldous Harding",  # A_above
+        "Cate Le Bon",  # B_above
+        "Beverly Glenn-Copeland",  # niche 1 (deg 2)
+        "Hermanos Gutiérrez",  # niche 2 (deg 2)
+        "Frank Sinatra",  # A_below
+        "Sun Ra",  # B_below
+        "Mega Hub",  # deg 50 shared neighbor
+        *fillers,
+    ]
+    conn.executemany(
+        "INSERT INTO artist (canonical_name) VALUES (?)",
+        [(n,) for n in names],
+    )
+
+    name_to_id = {
+        r[1]: r[0] for r in conn.execute("SELECT id, canonical_name FROM artist").fetchall()
+    }
+
+    edges = [
+        # Above-threshold pair shares two niche neighbors.
+        (name_to_id["Aldous Harding"], name_to_id["Beverly Glenn-Copeland"]),
+        (name_to_id["Cate Le Bon"], name_to_id["Beverly Glenn-Copeland"]),
+        (name_to_id["Aldous Harding"], name_to_id["Hermanos Gutiérrez"]),
+        (name_to_id["Cate Le Bon"], name_to_id["Hermanos Gutiérrez"]),
+        # Below-threshold pair shares only a high-degree hub.
+        (name_to_id["Frank Sinatra"], name_to_id["Mega Hub"]),
+        (name_to_id["Sun Ra"], name_to_id["Mega Hub"]),
+    ]
+    # Pump Mega Hub up to degree 50 with 49 disjoint fillers.
+    for filler in fillers:
+        edges.append((name_to_id["Mega Hub"], name_to_id[filler]))
+    conn.executemany(
+        "INSERT INTO dj_transition (source_id, target_id, raw_count, pmi) VALUES (?, ?, 1, 1.0)",
+        edges,
+    )
+    conn.commit()
+    conn.close()
+    return path
+
+
+@pytest.fixture(scope="module")
+def threshold_db_path() -> str:
+    return _build_aa_threshold_fixture_db()
+
+
+@pytest.fixture(scope="module")
+def threshold_artist_ids(threshold_db_path: str) -> dict[str, int]:
+    conn = sqlite3.connect(threshold_db_path)
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute("SELECT id, canonical_name FROM artist").fetchall()
+    conn.close()
+    return {r["canonical_name"]: r["id"] for r in rows}
+
+
+class TestAaThreshold:
+    @pytest.mark.asyncio
+    async def test_below_threshold_short_circuits_llm(
+        self,
+        threshold_db_path: str,
+        threshold_artist_ids: dict[str, int],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A pair whose total AA falls below the floor returns the canned narrative.
+
+        The LLM client is set on the app but should never be called.
+        """
+        monkeypatch.setenv("NARRATIVE_MIN_AA_SCORE", "0.8")
+        _clear_narrative_cache(threshold_db_path)
+        mock_client = _mock_anthropic_client()
+        app = create_app(threshold_db_path, anthropic_api_key="test-key")
+        app.state.anthropic_client = mock_client
+        transport = ASGITransport(app=app)
+
+        sinatra = threshold_artist_ids["Frank Sinatra"]
+        sun_ra = threshold_artist_ids["Sun Ra"]
+
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get(f"/graph/artists/{sinatra}/explain/{sun_ra}/narrative")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["insufficient_signal"] is True
+        assert body["cached"] is False
+        assert (
+            "no consistent" in body["narrative"].lower()
+            or "occasionally" in body["narrative"].lower()
+        )
+        assert mock_client.messages.create.call_count == 0, (
+            "LLM should not be called below threshold"
+        )
+
+    @pytest.mark.asyncio
+    async def test_above_threshold_calls_llm(
+        self,
+        threshold_db_path: str,
+        threshold_artist_ids: dict[str, int],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A pair whose total AA clears the floor reaches the LLM normally."""
+        monkeypatch.setenv("NARRATIVE_MIN_AA_SCORE", "0.8")
+        _clear_narrative_cache(threshold_db_path)
+        mock_client = _mock_anthropic_client()
+        app = create_app(threshold_db_path, anthropic_api_key="test-key")
+        app.state.anthropic_client = mock_client
+        transport = ASGITransport(app=app)
+
+        aldous = threshold_artist_ids["Aldous Harding"]
+        cate = threshold_artist_ids["Cate Le Bon"]
+
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get(f"/graph/artists/{aldous}/explain/{cate}/narrative")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["insufficient_signal"] is False
+        assert body["narrative"] == MOCK_NARRATIVE
+        assert mock_client.messages.create.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_threshold_env_var_overrides_default(
+        self,
+        threshold_db_path: str,
+        threshold_artist_ids: dict[str, int],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Lowering ``NARRATIVE_MIN_AA_SCORE`` lifts the below-default pair above the floor."""
+        # Drop the threshold so the previously-below pair clears it.
+        monkeypatch.setenv("NARRATIVE_MIN_AA_SCORE", "0.1")
+        _clear_narrative_cache(threshold_db_path)
+        mock_client = _mock_anthropic_client()
+        app = create_app(threshold_db_path, anthropic_api_key="test-key")
+        app.state.anthropic_client = mock_client
+        transport = ASGITransport(app=app)
+
+        sinatra = threshold_artist_ids["Frank Sinatra"]
+        sun_ra = threshold_artist_ids["Sun Ra"]
+
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get(f"/graph/artists/{sinatra}/explain/{sun_ra}/narrative")
+
+        body = resp.json()
+        assert body["insufficient_signal"] is False
+        assert mock_client.messages.create.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_below_threshold_response_is_cached(
+        self,
+        threshold_db_path: str,
+        threshold_artist_ids: dict[str, int],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A below-threshold response is cached so repeat requests stay cheap."""
+        monkeypatch.setenv("NARRATIVE_MIN_AA_SCORE", "0.8")
+        _clear_narrative_cache(threshold_db_path)
+        mock_client = _mock_anthropic_client()
+        app = create_app(threshold_db_path, anthropic_api_key="test-key")
+        app.state.anthropic_client = mock_client
+        transport = ASGITransport(app=app)
+
+        sinatra = threshold_artist_ids["Frank Sinatra"]
+        sun_ra = threshold_artist_ids["Sun Ra"]
+
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            first = await ac.get(f"/graph/artists/{sinatra}/explain/{sun_ra}/narrative")
+            second = await ac.get(f"/graph/artists/{sinatra}/explain/{sun_ra}/narrative")
+
+        assert first.json()["cached"] is False
+        assert first.json()["insufficient_signal"] is True
+        assert second.json()["cached"] is True
+        assert second.json()["insufficient_signal"] is True
+        assert mock_client.messages.create.call_count == 0
+
+    @pytest.mark.asyncio
+    async def test_invalid_threshold_falls_back_to_default(
+        self,
+        threshold_db_path: str,
+        threshold_artist_ids: dict[str, int],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A garbage ``NARRATIVE_MIN_AA_SCORE`` reverts to the 0.8 default."""
+        monkeypatch.setenv("NARRATIVE_MIN_AA_SCORE", "not-a-float")
+        _clear_narrative_cache(threshold_db_path)
+        mock_client = _mock_anthropic_client()
+        app = create_app(threshold_db_path, anthropic_api_key="test-key")
+        app.state.anthropic_client = mock_client
+        transport = ASGITransport(app=app)
+
+        sinatra = threshold_artist_ids["Frank Sinatra"]
+        sun_ra = threshold_artist_ids["Sun Ra"]
+
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get(f"/graph/artists/{sinatra}/explain/{sun_ra}/narrative")
+
+        # Default 0.8 should have applied; below-threshold pair short-circuits.
+        assert resp.json()["insufficient_signal"] is True
+        assert mock_client.messages.create.call_count == 0


### PR DESCRIPTION
## Summary

Adds the 0.8 minimum-total-AA threshold from #220. Pairs whose surfaced shared neighbors sum below the floor short-circuit the Haiku call and return a deterministic placeholder narrative with a new \`insufficient_signal: bool\` field on \`NarrativeResponse\`.

The Bob Marley / Les Rallizes Dénudés case from the plan doc is the exemplar — five shared neighbors (Björk, Velvet Underground, Tim Hecker, Frank Sinatra, Hiatus Kaiyote) with AA scores all under 0.25; total ~0.8 isn't enough to produce a real story, and feeding it to Haiku just yields hallucinated context. The threshold catches these without an LLM call (saves cost + latency).

## Decision on response shape (open question from the issue)

Picked **HTTP 200 + new \`insufficient_signal\` flag** rather than 404 or a separate status code:

- The pair *exists* on the graph; 404 is semantically wrong.
- Clients (the explorer card UI) can render below-threshold responses differently — muted card, "no story available" hint — based on the flag.
- The placeholder \`narrative\` is human-readable so even non-flag-aware clients show something reasonable.

## Configuration

\`NARRATIVE_MIN_AA_SCORE\` env var overrides the 0.8 default. Invalid values log a warning and fall back. Tunable in production via \`.env.semantic-index\` without a redeploy.

## Cache

\`_PROMPT_VERSION\` bumps 2 → 3; cache schema gains \`insufficient_signal INTEGER\` column. The schema-mismatch drop fires once on first connect to evict pre-column rows. Subsequent prompt-only edits (no schema change) continue to rely on read-side filtering by \`prompt_version\`.

## Tests

Adds \`TestAaThreshold\` (5 tests) on a dedicated synthetic fixture with one above-threshold pair (Aldous Harding / Cate Le Bon, two niche shared neighbors → ~2.88) and one below-threshold pair (Frank Sinatra / Sun Ra, one degree-50 hub → ~0.26):

- Below-threshold short-circuits the LLM, returns placeholder + \`insufficient_signal: true\`
- Above-threshold reaches the LLM normally
- Env-var override (lowering to 0.1) lifts a previously-below pair above the floor
- Below-threshold response is cached
- Invalid env value falls back to default

Existing 21 tests use an autouse fixture to disable the threshold (set to 0) so the synthetic 2-pair fixture continues to exercise the LLM path.

## Test plan

- [x] \`ruff check .\` passes
- [x] \`ruff format --check .\` passes
- [x] \`mypy semantic_index/\` passes
- [x] \`pytest tests/unit/test_narrative.py\` — 26 passed
- [ ] CI green
- [ ] Deploy: cache evicts on first request via column-mismatch drop

Closes #220.