### PR TITLE
Cap Discogs styles to top 5 in narrative prompt

### DIFF
--- a/semantic_index/api/narrative.py
+++ b/semantic_index/api/narrative.py
@@ -21,9 +21,18 @@ narrative_router = APIRouter(prefix="/graph", tags=["graph"])
 
 # Bump whenever the prompt's structure or content changes so the sidecar cache
 # evicts stale entries instead of serving them indefinitely.
-_PROMPT_VERSION = 3
+_PROMPT_VERSION = 4
 
 _SHARED_NEIGHBORS_TOP_K = 5
+
+# Long Discogs style lists invite hallucination — a model fed Outkast's 53
+# styles latches onto an outlier ("makina", "breakbeat") and describes a hip
+# hop group as channeling it. Cap to the most prominent N. Ordering is
+# alphabetical for now because the upstream ``artist_style`` table doesn't
+# persist a release_count column; proper "top N by release count" ranking is a
+# pipeline-side follow-up. Even alphabetical-top-N drops the bulk of garbage —
+# 53 entries → 5.
+_STYLES_TOP_N = 5
 
 # Minimum total Adamic-Adar contribution across surfaced shared neighbors for a
 # pair to be worth narrating. Pairs below this floor share only generic hubs
@@ -263,8 +272,8 @@ def _lookup_artist_metadata(
     styles: list[str] = []
     try:
         rows = db.execute(
-            "SELECT style_tag FROM artist_style WHERE artist_id = ? ORDER BY style_tag",
-            (artist_id,),
+            "SELECT style_tag FROM artist_style WHERE artist_id = ? ORDER BY style_tag LIMIT ?",
+            (artist_id, _STYLES_TOP_N),
         ).fetchall()
         styles = [r["style_tag"] for r in rows]
     except sqlite3.OperationalError:

--- a/tests/unit/test_narrative.py
+++ b/tests/unit/test_narrative.py
@@ -16,6 +16,7 @@ from semantic_index.api.app import create_app
 from semantic_index.api.narrative import (
     _INSUFFICIENT_SIGNAL_NARRATIVE,
     _SHARED_NEIGHBORS_TOP_K,
+    _STYLES_TOP_N,
     _rank_shared_neighbors_by_aa,
 )
 from semantic_index.facet_export import export_facet_tables
@@ -1033,3 +1034,105 @@ class TestAaThreshold:
         # Default 0.8 should have applied; below-threshold pair short-circuits.
         assert resp.json()["insufficient_signal"] is True
         assert mock_client.messages.create.call_count == 0
+
+
+class TestStylesCap:
+    def test_long_style_list_capped_in_metadata(self) -> None:
+        """An artist with 10 styles surfaces only ``_STYLES_TOP_N`` in the prompt metadata.
+
+        Prevents the Outkast/Destroyer hallucination mode where the model latches
+        onto a minor-release outlier ("makina", "breakbeat") and describes a hip
+        hop or indie-rock artist as channeling it.
+
+        Uses an isolated fixture and calls ``_lookup_artist_metadata`` directly
+        so the test doesn't mutate the shared module-scoped narrative fixture.
+        """
+        from semantic_index.api.narrative import _lookup_artist_metadata
+
+        path = tempfile.mktemp(suffix=".db")
+        conn = sqlite3.connect(path)
+        conn.row_factory = sqlite3.Row
+        conn.executescript(
+            """
+            CREATE TABLE artist (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                canonical_name TEXT NOT NULL UNIQUE,
+                genre TEXT,
+                total_plays INTEGER NOT NULL DEFAULT 0
+            );
+            CREATE TABLE artist_style (
+                artist_id INTEGER NOT NULL,
+                style_tag TEXT NOT NULL,
+                PRIMARY KEY (artist_id, style_tag)
+            );
+            """
+        )
+        conn.execute(
+            "INSERT INTO artist (canonical_name, genre, total_plays) VALUES (?, ?, ?)",
+            ("Outkast", "Hip Hop", 200),
+        )
+        artist_id = conn.execute("SELECT id FROM artist").fetchone()["id"]
+
+        # 10 styles, deliberately not in alphabetical order so the SQL ORDER BY
+        # is exercised. Alphabetical top-5 = ['Crunk', 'Dirty South', 'Funk',
+        # 'Hip Hop', 'P.Funk'].
+        ten_styles = [
+            "Hip Hop",
+            "Soul",
+            "P.Funk",
+            "Crunk",
+            "Funk",
+            "Trip Hop",
+            "Rap",
+            "RnB",
+            "Reggae",
+            "Dirty South",
+        ]
+        conn.executemany(
+            "INSERT INTO artist_style (artist_id, style_tag) VALUES (?, ?)",
+            [(artist_id, s) for s in ten_styles],
+        )
+        conn.commit()
+
+        meta = _lookup_artist_metadata(conn, artist_id, "Outkast", "Hip Hop", 200)
+        conn.close()
+
+        assert len(meta["styles"]) == _STYLES_TOP_N, (
+            f"10 styles should be capped at {_STYLES_TOP_N}; got {len(meta['styles'])}"
+        )
+        assert meta["styles"] == sorted(ten_styles)[:_STYLES_TOP_N]
+
+    def test_short_style_list_unaffected(self) -> None:
+        """An artist with fewer than ``_STYLES_TOP_N`` styles passes them all."""
+        from semantic_index.api.narrative import _lookup_artist_metadata
+
+        path = tempfile.mktemp(suffix=".db")
+        conn = sqlite3.connect(path)
+        conn.row_factory = sqlite3.Row
+        conn.executescript(
+            """
+            CREATE TABLE artist (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                canonical_name TEXT NOT NULL UNIQUE,
+                genre TEXT,
+                total_plays INTEGER NOT NULL DEFAULT 0
+            );
+            CREATE TABLE artist_style (
+                artist_id INTEGER NOT NULL,
+                style_tag TEXT NOT NULL,
+                PRIMARY KEY (artist_id, style_tag)
+            );
+            """
+        )
+        conn.execute("INSERT INTO artist (canonical_name) VALUES ('Stereolab')")
+        artist_id = conn.execute("SELECT id FROM artist").fetchone()["id"]
+        conn.executemany(
+            "INSERT INTO artist_style (artist_id, style_tag) VALUES (?, ?)",
+            [(artist_id, s) for s in ("Krautrock", "Post-Rock", "Indie")],
+        )
+        conn.commit()
+
+        meta = _lookup_artist_metadata(conn, artist_id, "Stereolab", None, 0)
+        conn.close()
+
+        assert meta["styles"] == ["Indie", "Krautrock", "Post-Rock"]


### PR DESCRIPTION
## Summary

Caps the styles surfaced in the narrative prompt at \`_STYLES_TOP_N\` = 5. Adds \`LIMIT ?\` to the \`artist_style\` query in \`_lookup_artist_metadata\`. Bumps \`_PROMPT_VERSION\` 3 → 4 so cached narratives from the prior format are evicted via read-side version filtering.

## Why

Long Discogs style lists invite hallucination. The plan doc cites three concrete failures:

- **Outkast** has 53 Discogs styles. The model latches onto outliers.
- **Destroyer's** top 5 includes "Breakbeat" and "Techno" from minor releases — got described as "channeling breakbeat and techno elements."
- **Alex G's** top 3 came back as "Dance-pop, Euro House, Makina" from minor compilation appearances; got described as "channeling dance-pop and Euro House into experimental rock territory."

The narrative was technically faithful to the input but the input was garbage. Capping to 5 trims the long tail that drives the hallucination.

## Ordering caveat

Ordering is alphabetical because the upstream \`artist_style\` table doesn't persist a \`release_count\` column. Doing \"top N by release count\" properly requires a pipeline-side change:

1. Maintain a Counter in \`discogs_enrichment._enrich_from_releases\` (currently dumps styles into a set, dropping count).
2. Add \`release_count INTEGER\` to the \`artist_style\` schema in \`pipeline_db.py\` and \`sqlite_export.py\`.
3. Update \`persist_artist_styles\` to take counts; backfill on next pipeline run.
4. Switch the narrative query to \`ORDER BY release_count DESC\`.

The issue note explicitly framed this PR as a \"quick top-5-cap in the narrative endpoint\" and a \"sufficient first defense\". Even alphabetical-top-5 drops the bulk of garbage (53 entries → 5). Filing the proper-ranking work as a follow-up rather than expanding scope here.

## Tests

\`TestStylesCap\`:
- \`test_long_style_list_capped_in_metadata\` — 10 styles inserted; asserts \`_STYLES_TOP_N\` returned and matches alphabetical top-5.
- \`test_short_style_list_unaffected\` — 3 styles; asserts all 3 returned, sorted.

Both call \`_lookup_artist_metadata\` directly against an isolated tmpfile DB to avoid mutating the shared module fixture.

## Before/after narrative

Manual verification on real artists (Outkast, Destroyer) requires production deploy + Haiku key. The unit tests confirm the cap (10 → 5); production validation lands when this is deployed and the narrative cache evicts to the new prompt version.

## Test plan

- [x] \`ruff check .\` passes
- [x] \`ruff format --check .\` passes
- [x] \`mypy semantic_index/\` passes
- [x] \`pytest tests/unit/test_narrative.py\` — 29 passed
- [ ] CI green
- [ ] Deploy: cache evicts on first request via read-side version filter

Closes #221.