### PR TITLE
Convert audio profile to qualitative descriptors in narrative prompt

### DIFF
--- a/semantic_index/api/narrative.py
+++ b/semantic_index/api/narrative.py
@@ -54,8 +54,8 @@ _INSUFFICIENT_SIGNAL_NARRATIVE = (
 # model has no number to quote.
 _DANCEABILITY_LOW = 0.3
 _DANCEABILITY_HIGH = 0.6
-_VOICE_INSTRUMENTAL_INSTRUMENTAL = 0.2
-_VOICE_INSTRUMENTAL_VOCAL = 0.8
+_VOICE_INSTRUMENTAL_LOW = 0.2
+_VOICE_INSTRUMENTAL_HIGH = 0.8
 _GENRE_CONFIDENCE_THRESHOLD = 0.7
 _MOOD_THRESHOLD = 0.3
 _BPM_SLOW = 90
@@ -331,11 +331,15 @@ def _qualitative_audio_descriptors(profile: sqlite3.Row, bpm_row: sqlite3.Row | 
     Returns a dict containing only fields whose values are *remarkable* — high
     or low extremes get a label, unremarkable middles are omitted entirely so
     the prompt has no number to quote. ``primary_genre`` is included only when
-    classifier confidence clears ``_GENRE_CONFIDENCE_THRESHOLD``; otherwise
-    omitted because a low-confidence guess just teaches the model wrong.
+    classifier confidence clears the threshold; a low-confidence guess just
+    teaches the model wrong.
 
     ``recording_count`` is kept as an integer (not a perceptual decimal) — the
-    model uses it as a confidence signal but it has no leak-as-prose problem.
+    model uses it as a confidence signal — but the descriptor block is
+    suppressed entirely if no other remarkable field surfaces. A bare
+    ``{"recording_count": N}`` just tells the model there's audio data
+    without anchoring it to anything, which over-confidently primes phrases
+    like "based on audio analysis" with nothing real to back them.
     """
     desc: dict = {"recording_count": profile["recording_count"]}
 
@@ -354,9 +358,9 @@ def _qualitative_audio_descriptors(profile: sqlite3.Row, bpm_row: sqlite3.Row | 
 
     vi = profile["voice_instrumental_ratio"]
     if vi is not None:
-        if vi < _VOICE_INSTRUMENTAL_INSTRUMENTAL:
+        if vi < _VOICE_INSTRUMENTAL_LOW:
             desc["voice_instrumental"] = "instrumental"
-        elif vi > _VOICE_INSTRUMENTAL_VOCAL:
+        elif vi > _VOICE_INSTRUMENTAL_HIGH:
             desc["voice_instrumental"] = "vocal-forward"
         # else: ambiguous — omit.
 
@@ -384,6 +388,10 @@ def _qualitative_audio_descriptors(profile: sqlite3.Row, bpm_row: sqlite3.Row | 
         if key:
             desc["key"] = key
 
+    # Drop the whole audio block if only ``recording_count`` survived the
+    # filters — see the docstring for why a bare count misleads the model.
+    if len(desc) <= 1:
+        return {}
     return desc
 
 

--- a/semantic_index/api/narrative.py
+++ b/semantic_index/api/narrative.py
@@ -21,7 +21,7 @@ narrative_router = APIRouter(prefix="/graph", tags=["graph"])
 
 # Bump whenever the prompt's structure or content changes so the sidecar cache
 # evicts stale entries instead of serving them indefinitely.
-_PROMPT_VERSION = 4
+_PROMPT_VERSION = 5
 
 _SHARED_NEIGHBORS_TOP_K = 5
 
@@ -46,6 +46,20 @@ _INSUFFICIENT_SIGNAL_NARRATIVE = (
     "enough specific musical context — same labels, similar styles, common "
     "collaborators — to characterize a meaningful connection."
 )
+
+# Audio-profile decimals (danceability, voice/instrumental ratio, genre
+# confidence, BPM) leak into prose verbatim — past generations quoted
+# "(0.68 danceability)" and "(0.34 danceability)". Convert them to qualitative
+# descriptors at extremes only, omitting unremarkable middles entirely so the
+# model has no number to quote.
+_DANCEABILITY_LOW = 0.3
+_DANCEABILITY_HIGH = 0.6
+_VOICE_INSTRUMENTAL_INSTRUMENTAL = 0.2
+_VOICE_INSTRUMENTAL_VOCAL = 0.8
+_GENRE_CONFIDENCE_THRESHOLD = 0.7
+_MOOD_THRESHOLD = 0.3
+_BPM_SLOW = 90
+_BPM_FAST = 130
 
 
 def _min_aa_score() -> float:
@@ -286,7 +300,7 @@ def _lookup_artist_metadata(
         "styles": styles,
     }
 
-    # Audio profile: add descriptive features when available
+    # Audio profile: add qualitative descriptors when available
     try:
         profile = db.execute(
             "SELECT avg_danceability, primary_genre, primary_genre_probability, "
@@ -295,48 +309,82 @@ def _lookup_artist_metadata(
             (artist_id,),
         ).fetchone()
         if profile and profile["feature_centroid"]:
-            centroid = json.loads(profile["feature_centroid"])
-            # Extract narratively useful features from the 59-dim centroid
-            mood_labels = [
-                "acoustic",
-                "aggressive",
-                "electronic",
-                "happy",
-                "party",
-                "relaxed",
-                "sad",
-            ]
-            mood_vector = centroid[9:16]
-            top_moods = sorted(
-                zip(mood_labels, mood_vector, strict=True), key=lambda x: x[1], reverse=True
-            )
-            audio_meta: dict = {
-                "primary_genre": profile["primary_genre"],
-                "danceability": round(profile["avg_danceability"], 2),
-                "voice_instrumental": (
-                    "vocal" if profile["voice_instrumental_ratio"] > 0.5 else "instrumental"
-                ),
-                "top_moods": [m for m, v in top_moods[:3] if v > 0.3],
-                "recording_count": profile["recording_count"],
-            }
-            # Add BPM and key if available (columns may not exist on older DBs)
             try:
                 bpm_row = db.execute(
                     "SELECT avg_bpm, primary_key FROM audio_profile WHERE artist_id = ?",
                     (artist_id,),
                 ).fetchone()
-                if bpm_row:
-                    if bpm_row["avg_bpm"]:
-                        audio_meta["bpm"] = round(bpm_row["avg_bpm"])
-                    if bpm_row["primary_key"]:
-                        audio_meta["key"] = bpm_row["primary_key"]
             except sqlite3.OperationalError:
-                pass  # avg_bpm/primary_key columns may not exist
-            meta["audio"] = audio_meta
+                bpm_row = None  # avg_bpm/primary_key columns may not exist
+            audio_meta = _qualitative_audio_descriptors(profile, bpm_row)
+            if audio_meta:
+                meta["audio"] = audio_meta
     except sqlite3.OperationalError:
         pass  # audio_profile table may not exist
 
     return meta
+
+
+def _qualitative_audio_descriptors(profile: sqlite3.Row, bpm_row: sqlite3.Row | None) -> dict:
+    """Convert raw audio-profile decimals into qualitative descriptors.
+
+    Returns a dict containing only fields whose values are *remarkable* — high
+    or low extremes get a label, unremarkable middles are omitted entirely so
+    the prompt has no number to quote. ``primary_genre`` is included only when
+    classifier confidence clears ``_GENRE_CONFIDENCE_THRESHOLD``; otherwise
+    omitted because a low-confidence guess just teaches the model wrong.
+
+    ``recording_count`` is kept as an integer (not a perceptual decimal) — the
+    model uses it as a confidence signal but it has no leak-as-prose problem.
+    """
+    desc: dict = {"recording_count": profile["recording_count"]}
+
+    genre = profile["primary_genre"]
+    genre_prob = profile["primary_genre_probability"]
+    if genre and genre_prob is not None and genre_prob > _GENRE_CONFIDENCE_THRESHOLD:
+        desc["primary_genre"] = f"clearly {genre}"
+
+    dance = profile["avg_danceability"]
+    if dance is not None:
+        if dance < _DANCEABILITY_LOW:
+            desc["danceability"] = "minimal pulse"
+        elif dance > _DANCEABILITY_HIGH:
+            desc["danceability"] = "highly danceable"
+        # else: unremarkable middle — omit so the model has no number to quote.
+
+    vi = profile["voice_instrumental_ratio"]
+    if vi is not None:
+        if vi < _VOICE_INSTRUMENTAL_INSTRUMENTAL:
+            desc["voice_instrumental"] = "instrumental"
+        elif vi > _VOICE_INSTRUMENTAL_VOCAL:
+            desc["voice_instrumental"] = "vocal-forward"
+        # else: ambiguous — omit.
+
+    centroid_raw = profile["feature_centroid"]
+    if centroid_raw:
+        centroid = json.loads(centroid_raw)
+        mood_labels = ["acoustic", "aggressive", "electronic", "happy", "party", "relaxed", "sad"]
+        mood_vector = centroid[9:16]
+        top_moods = sorted(
+            zip(mood_labels, mood_vector, strict=True), key=lambda x: x[1], reverse=True
+        )
+        moods = [m for m, v in top_moods[:3] if v > _MOOD_THRESHOLD]
+        if moods:
+            desc["top_moods"] = moods
+
+    if bpm_row:
+        bpm = bpm_row["avg_bpm"]
+        if bpm is not None:
+            if bpm < _BPM_SLOW:
+                desc["tempo"] = "slow"
+            elif bpm > _BPM_FAST:
+                desc["tempo"] = "fast"
+            # else: unremarkable — omit.
+        key = bpm_row["primary_key"]
+        if key:
+            desc["key"] = key
+
+    return desc
 
 
 def _lookup_dj_name(db: sqlite3.Connection, dj_id: int) -> str | None:

--- a/tests/unit/test_narrative.py
+++ b/tests/unit/test_narrative.py
@@ -451,10 +451,15 @@ class TestAudioProfileEnrichment:
     async def test_prompt_includes_audio_profile(
         self, narrative_db_path: str, narrative_artist_ids: dict[str, int]
     ) -> None:
-        """When an audio profile exists, the prompt includes audio features."""
+        """When an audio profile exists, the prompt carries qualitative descriptors only.
+
+        Verifies no raw decimals reach the prompt and that extreme values get
+        their human-readable labels.
+        """
         _clear_narrative_cache(narrative_db_path)
 
-        # Insert an audio profile for Autechre
+        # Insert an audio profile for Autechre with extreme values across the
+        # board so every descriptor has something to render.
         ae_id = narrative_artist_ids["Autechre"]
         conn = sqlite3.connect(narrative_db_path)
         conn.execute(
@@ -465,7 +470,6 @@ class TestAudioProfileEnrichment:
             "recording_count INTEGER NOT NULL DEFAULT 0, "
             "created_at TEXT NOT NULL DEFAULT '')"
         )
-        # Build a 59-dim feature vector with known mood values
         centroid = [0.0] * 59
         # Moods at indices 9-15: acoustic=0.2, aggressive=0.6, electronic=0.8,
         # happy=0.1, party=0.3, relaxed=0.1, sad=0.2
@@ -477,10 +481,10 @@ class TestAudioProfileEnrichment:
             "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 ae_id,
-                0.35,
+                0.15,  # < 0.3 → "minimal pulse"
                 "electronic",
-                0.7,
-                0.15,
+                0.85,  # > 0.7 → "clearly electronic"
+                0.10,  # < 0.2 → "instrumental"
                 json.dumps(centroid),
                 12,
                 "2026-01-01T00:00:00Z",
@@ -501,16 +505,24 @@ class TestAudioProfileEnrichment:
 
         last_call = mock_client.messages.create.call_args
         messages = last_call.kwargs.get("messages") or last_call[1].get("messages", [])
-        prompt_data = json.loads(messages[0]["content"])
+        user_message = messages[0]["content"]
+        prompt_data = json.loads(user_message)
 
         source_audio = prompt_data["source"].get("audio")
         assert source_audio is not None
-        assert source_audio["primary_genre"] == "electronic"
-        assert source_audio["danceability"] == 0.35
+        assert source_audio["primary_genre"] == "clearly electronic"
+        assert source_audio["danceability"] == "minimal pulse"
         assert source_audio["voice_instrumental"] == "instrumental"
         assert "electronic" in source_audio["top_moods"]
         assert "aggressive" in source_audio["top_moods"]
         assert source_audio["recording_count"] == 12
+
+        # No raw decimals anywhere in the prompt — the model should have no
+        # number to quote. The stringified prompt must not contain the input
+        # decimal values.
+        assert "0.15" not in user_message
+        assert "0.85" not in user_message
+        assert "0.10" not in user_message
 
     @pytest.mark.asyncio
     async def test_prompt_graceful_without_audio_profile(
@@ -1136,3 +1148,111 @@ class TestStylesCap:
         conn.close()
 
         assert meta["styles"] == ["Indie", "Krautrock", "Post-Rock"]
+
+
+def _make_audio_row(**fields) -> sqlite3.Row:
+    """Build a sqlite3.Row stand-in for ``_qualitative_audio_descriptors`` tests."""
+    defaults = {
+        "avg_danceability": None,
+        "primary_genre": None,
+        "primary_genre_probability": None,
+        "voice_instrumental_ratio": None,
+        "feature_centroid": None,
+        "recording_count": 1,
+    }
+    defaults.update(fields)
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    cols = ", ".join(defaults.keys())
+    placeholders = ", ".join("?" * len(defaults))
+    conn.execute(f"CREATE TABLE t ({cols})")  # noqa: S608
+    conn.execute(f"INSERT INTO t VALUES ({placeholders})", tuple(defaults.values()))  # noqa: S608
+    return conn.execute("SELECT * FROM t").fetchone()
+
+
+class TestQualitativeAudioDescriptors:
+    """Boundary tests for ``_qualitative_audio_descriptors``.
+
+    The principle is: describe extremes, omit middles. Values in the middle
+    band must produce *no* corresponding key in the output so the model has
+    no number to quote.
+    """
+
+    def test_high_danceability_labeled(self) -> None:
+        from semantic_index.api.narrative import _qualitative_audio_descriptors
+
+        desc = _qualitative_audio_descriptors(_make_audio_row(avg_danceability=0.7), None)
+        assert desc["danceability"] == "highly danceable"
+
+    def test_low_danceability_labeled(self) -> None:
+        from semantic_index.api.narrative import _qualitative_audio_descriptors
+
+        desc = _qualitative_audio_descriptors(_make_audio_row(avg_danceability=0.2), None)
+        assert desc["danceability"] == "minimal pulse"
+
+    def test_middle_danceability_omitted(self) -> None:
+        from semantic_index.api.narrative import _qualitative_audio_descriptors
+
+        desc = _qualitative_audio_descriptors(_make_audio_row(avg_danceability=0.45), None)
+        assert "danceability" not in desc
+
+    def test_vocal_forward_labeled(self) -> None:
+        from semantic_index.api.narrative import _qualitative_audio_descriptors
+
+        desc = _qualitative_audio_descriptors(_make_audio_row(voice_instrumental_ratio=0.85), None)
+        assert desc["voice_instrumental"] == "vocal-forward"
+
+    def test_instrumental_labeled(self) -> None:
+        from semantic_index.api.narrative import _qualitative_audio_descriptors
+
+        desc = _qualitative_audio_descriptors(_make_audio_row(voice_instrumental_ratio=0.05), None)
+        assert desc["voice_instrumental"] == "instrumental"
+
+    def test_ambiguous_voice_omitted(self) -> None:
+        from semantic_index.api.narrative import _qualitative_audio_descriptors
+
+        desc = _qualitative_audio_descriptors(_make_audio_row(voice_instrumental_ratio=0.5), None)
+        assert "voice_instrumental" not in desc
+
+    def test_confident_genre_labeled(self) -> None:
+        from semantic_index.api.narrative import _qualitative_audio_descriptors
+
+        desc = _qualitative_audio_descriptors(
+            _make_audio_row(primary_genre="rock", primary_genre_probability=0.9), None
+        )
+        assert desc["primary_genre"] == "clearly rock"
+
+    def test_low_confidence_genre_omitted(self) -> None:
+        """Below 0.7 confidence the model just learns wrong — drop the genre entirely."""
+        from semantic_index.api.narrative import _qualitative_audio_descriptors
+
+        desc = _qualitative_audio_descriptors(
+            _make_audio_row(primary_genre="rock", primary_genre_probability=0.5), None
+        )
+        assert "primary_genre" not in desc
+
+    def test_missing_audio_profile_returns_minimal(self) -> None:
+        """All-None inputs return only ``recording_count`` (a non-decimal count)."""
+        from semantic_index.api.narrative import _qualitative_audio_descriptors
+
+        desc = _qualitative_audio_descriptors(_make_audio_row(recording_count=3), None)
+        assert desc == {"recording_count": 3}
+
+    def test_no_raw_numbers_in_output(self) -> None:
+        """No value in the descriptor dict (except recording_count) should be a float."""
+        from semantic_index.api.narrative import _qualitative_audio_descriptors
+
+        desc = _qualitative_audio_descriptors(
+            _make_audio_row(
+                avg_danceability=0.05,
+                primary_genre="ambient",
+                primary_genre_probability=0.95,
+                voice_instrumental_ratio=0.99,
+                recording_count=5,
+            ),
+            None,
+        )
+        for key, value in desc.items():
+            if key == "recording_count":
+                continue
+            assert not isinstance(value, float), f"{key} leaks a raw float: {value!r}"

--- a/tests/unit/test_narrative.py
+++ b/tests/unit/test_narrative.py
@@ -1151,7 +1151,11 @@ class TestStylesCap:
 
 
 def _make_audio_row(**fields) -> sqlite3.Row:
-    """Build a sqlite3.Row stand-in for ``_qualitative_audio_descriptors`` tests."""
+    """Build a sqlite3.Row stand-in for ``_qualitative_audio_descriptors`` tests.
+
+    sqlite3.Row holds the column data after the connection closes, so it's
+    safe to close the connection before returning the row.
+    """
     defaults = {
         "avg_danceability": None,
         "primary_genre": None,
@@ -1162,12 +1166,29 @@ def _make_audio_row(**fields) -> sqlite3.Row:
     }
     defaults.update(fields)
     conn = sqlite3.connect(":memory:")
-    conn.row_factory = sqlite3.Row
-    cols = ", ".join(defaults.keys())
-    placeholders = ", ".join("?" * len(defaults))
-    conn.execute(f"CREATE TABLE t ({cols})")  # noqa: S608
-    conn.execute(f"INSERT INTO t VALUES ({placeholders})", tuple(defaults.values()))  # noqa: S608
-    return conn.execute("SELECT * FROM t").fetchone()
+    try:
+        conn.row_factory = sqlite3.Row
+        cols = ", ".join(defaults.keys())
+        placeholders = ", ".join("?" * len(defaults))
+        conn.execute(f"CREATE TABLE t ({cols})")  # noqa: S608
+        conn.execute(  # noqa: S608
+            f"INSERT INTO t VALUES ({placeholders})", tuple(defaults.values())
+        )
+        return conn.execute("SELECT * FROM t").fetchone()
+    finally:
+        conn.close()
+
+
+def _make_bpm_row(avg_bpm: float | None = None, primary_key: str | None = None) -> sqlite3.Row:
+    """Build a sqlite3.Row stand-in for the BPM/key fetch in the helper."""
+    conn = sqlite3.connect(":memory:")
+    try:
+        conn.row_factory = sqlite3.Row
+        conn.execute("CREATE TABLE t (avg_bpm REAL, primary_key TEXT)")
+        conn.execute("INSERT INTO t VALUES (?, ?)", (avg_bpm, primary_key))
+        return conn.execute("SELECT * FROM t").fetchone()
+    finally:
+        conn.close()
 
 
 class TestQualitativeAudioDescriptors:
@@ -1231,12 +1252,92 @@ class TestQualitativeAudioDescriptors:
         )
         assert "primary_genre" not in desc
 
-    def test_missing_audio_profile_returns_minimal(self) -> None:
-        """All-None inputs return only ``recording_count`` (a non-decimal count)."""
+    def test_only_recording_count_returns_empty(self) -> None:
+        """A bare recording_count with no remarkable fields suppresses the whole block.
+
+        A descriptor of ``{"recording_count": 3}`` alone tells the model there's
+        audio data without anchoring it to anything, so the caller drops the
+        ``audio`` field entirely.
+        """
         from semantic_index.api.narrative import _qualitative_audio_descriptors
 
         desc = _qualitative_audio_descriptors(_make_audio_row(recording_count=3), None)
-        assert desc == {"recording_count": 3}
+        assert desc == {}
+
+    def test_recording_count_kept_when_other_field_remarkable(self) -> None:
+        """When one remarkable field surfaces, recording_count rides along."""
+        from semantic_index.api.narrative import _qualitative_audio_descriptors
+
+        desc = _qualitative_audio_descriptors(
+            _make_audio_row(avg_danceability=0.8, recording_count=3), None
+        )
+        assert desc["danceability"] == "highly danceable"
+        assert desc["recording_count"] == 3
+
+    def test_danceability_low_boundary_omitted(self) -> None:
+        """Exactly ``_DANCEABILITY_LOW`` (0.3) sits in the omit band — the cutoff is strict."""
+        from semantic_index.api.narrative import _qualitative_audio_descriptors
+
+        desc = _qualitative_audio_descriptors(_make_audio_row(avg_danceability=0.3), None)
+        assert "danceability" not in desc
+
+    def test_danceability_high_boundary_omitted(self) -> None:
+        """Exactly ``_DANCEABILITY_HIGH`` (0.6) sits in the omit band — the cutoff is strict."""
+        from semantic_index.api.narrative import _qualitative_audio_descriptors
+
+        desc = _qualitative_audio_descriptors(
+            _make_audio_row(
+                avg_danceability=0.6, primary_genre="rock", primary_genre_probability=0.9
+            ),
+            None,
+        )
+        # Genre forces a non-empty descriptor so we can read it back.
+        assert "danceability" not in desc
+
+    def test_slow_tempo_labeled(self) -> None:
+        from semantic_index.api.narrative import _qualitative_audio_descriptors
+
+        desc = _qualitative_audio_descriptors(
+            _make_audio_row(avg_danceability=0.7),
+            _make_bpm_row(avg_bpm=70.0),
+        )
+        assert desc["tempo"] == "slow"
+
+    def test_fast_tempo_labeled(self) -> None:
+        from semantic_index.api.narrative import _qualitative_audio_descriptors
+
+        desc = _qualitative_audio_descriptors(
+            _make_audio_row(avg_danceability=0.7),
+            _make_bpm_row(avg_bpm=145.0),
+        )
+        assert desc["tempo"] == "fast"
+
+    def test_middle_tempo_omitted(self) -> None:
+        from semantic_index.api.narrative import _qualitative_audio_descriptors
+
+        desc = _qualitative_audio_descriptors(
+            _make_audio_row(avg_danceability=0.7),
+            _make_bpm_row(avg_bpm=110.0),
+        )
+        assert "tempo" not in desc
+
+    def test_key_passes_through(self) -> None:
+        """Key is a string ('C major'), not a number — passes through unchanged."""
+        from semantic_index.api.narrative import _qualitative_audio_descriptors
+
+        desc = _qualitative_audio_descriptors(
+            _make_audio_row(avg_danceability=0.7),
+            _make_bpm_row(primary_key="C major"),
+        )
+        assert desc["key"] == "C major"
+
+    def test_missing_bpm_row_skips_tempo_and_key(self) -> None:
+        """A None bpm_row (older schema) cleanly omits tempo + key without erroring."""
+        from semantic_index.api.narrative import _qualitative_audio_descriptors
+
+        desc = _qualitative_audio_descriptors(_make_audio_row(avg_danceability=0.7), None)
+        assert "tempo" not in desc
+        assert "key" not in desc
 
     def test_no_raw_numbers_in_output(self) -> None:
         """No value in the descriptor dict (except recording_count) should be a float."""


### PR DESCRIPTION
## Summary

Raw audio-profile decimals (danceability, voice/instrumental ratio, genre confidence, BPM) were leaking into prose verbatim — generations have quoted \"(0.68 danceability)\" and \"(0.34 danceability)\" because the model treats numeric fields as facts to quote rather than to interpret.

Drops the raw numbers entirely from what the prompt sees. New helper \`_qualitative_audio_descriptors\` maps raw values into human-readable labels *at extremes only* and omits unremarkable middles so the model has no number to quote.

## Cutoffs

| Field | Low | High | Middle |
|---|---|---|---|
| Danceability | <0.3 → \"minimal pulse\" | >0.6 → \"highly danceable\" | omit |
| Voice/instrumental ratio | <0.2 → \"instrumental\" | >0.8 → \"vocal-forward\" | omit |
| Primary genre confidence | — | >0.7 → \"clearly {genre}\" | omit (low-confidence guesses teach the model wrong) |
| BPM | <90 → \"slow\" | >130 → \"fast\" | omit |

\`top_moods\` (already qualitative — labels filtered by weight >0.3), \`key\` (string), and \`recording_count\` (integer count, not a perceptual decimal) pass through unchanged.

Bumps \`_PROMPT_VERSION\` 4 → 5 so cached narratives from the decimal-leaking format evict via read-side version filtering.

## Tests

\`TestQualitativeAudioDescriptors\` — 10 boundary tests on the helper:

- High / low / middle danceability
- Vocal-forward / instrumental / ambiguous voice ratio
- Confident vs low-confidence genre
- All-None inputs return only \`recording_count\`
- A guard test asserts no value in the descriptor (except \`recording_count\`) is a Python \`float\`

\`TestAudioProfileEnrichment.test_prompt_includes_audio_profile\` updated to use extreme values across the board, asserts the new label strings appear in the prompt, **and** asserts the original input decimals (\`0.15\`, \`0.85\`, \`0.10\`) are nowhere in the stringified prompt — so a regression that re-introduces raw-number leakage trips immediately.

## Before/after narrative

Manual verification on real artists (Gang Gang Dance, Matmos) requires production deploy + Haiku key. The unit tests confirm the conversion logic and that the prompt is stripped of decimals; production validation lands when the new prompt version evicts the old cache.

## Test plan

- [x] \`ruff check .\` passes
- [x] \`ruff format --check .\` passes
- [x] \`mypy semantic_index/\` passes
- [x] \`pytest tests/unit/test_narrative.py\` — 39 passed
- [ ] CI green
- [ ] Deploy: cache evicts on first request via read-side version filter

Closes #222.