### PR TITLE
Omit empty / placeholder fields from narrative prompt

### DIFF
--- a/semantic_index/api/narrative.py
+++ b/semantic_index/api/narrative.py
@@ -21,7 +21,7 @@ narrative_router = APIRouter(prefix="/graph", tags=["graph"])
 
 # Bump whenever the prompt's structure or content changes so the sidecar cache
 # evicts stale entries instead of serving them indefinitely.
-_PROMPT_VERSION = 5
+_PROMPT_VERSION = 6
 
 _SHARED_NEIGHBORS_TOP_K = 5
 
@@ -97,7 +97,17 @@ _SYSTEM_PROMPT = (
     "Given structured data about the relationship between two artists in the station's play "
     "history, write 2-3 sentences (under 80 words) explaining their connection in plain "
     "English. Be specific — mention shared genres, personnel names, labels, or play patterns "
-    "from the data. Do not add information not present in the data."
+    "from the data. Do not add information not present in the data. "
+    "If the input includes a 'caveat' field naming an artist with limited metadata, "
+    "describe only the co-occurrence pattern (which DJs play these together, when, in which "
+    "neighborhood). Do NOT characterize the named artist's sound, genre, or style."
+)
+
+# Treat these as content-bearing-equivalent to None — placeholder values that
+# tempt the model to invent context just to fill the field. Comparison is
+# case-insensitive and trims whitespace.
+_PLACEHOLDER_VALUES = frozenset(
+    {"unknown", "various", "various artists", "v/a", "v.a.", "n/a", "none", ""}
 )
 
 _REQUIRED_CACHE_COLUMNS = {"edge_type", "prompt_version", "insufficient_signal"}
@@ -262,10 +272,18 @@ def _build_prompt(
     data: dict = {
         "source": source_meta,
         "target": target_meta,
-        "relationships": relationships,
     }
+    if relationships:
+        data["relationships"] = relationships
     if shared_neighbors:
         data["shared_neighbors"] = shared_neighbors
+
+    # Limited-metadata caveat: name the artist(s) so the system prompt's
+    # "describe only the co-occurrence pattern" instruction can target them
+    # specifically. Without this the model fills in genre/style invention.
+    limited = [m["name"] for m in (source_meta, target_meta) if _has_limited_metadata(m)]
+    if limited:
+        data["caveat"] = f"limited metadata for {', '.join(limited)}"
     if month is not None or dj_name is not None:
         facet: dict = {}
         if month is not None:
@@ -279,26 +297,41 @@ def _build_prompt(
     return json.dumps(data, separators=(",", ":"))
 
 
+def _is_placeholder(value: str | None) -> bool:
+    """Treat None and known placeholder strings ('Unknown', 'Various', etc.) as missing."""
+    if value is None:
+        return True
+    return value.strip().lower() in _PLACEHOLDER_VALUES
+
+
 def _lookup_artist_metadata(
     db: sqlite3.Connection, artist_id: int, artist_name: str, genre: str | None, total_plays: int
 ) -> dict:
-    """Build an artist metadata dict with genre, total_plays, Discogs styles, and audio profile."""
-    styles: list[str] = []
+    """Build an artist metadata dict, omitting empty/placeholder/unreliable fields.
+
+    Always emits ``name`` and ``total_plays``. Other fields appear only when
+    they have content-bearing values — empty lists, ``None``, and placeholder
+    strings ("Unknown", "Various", etc.) are dropped so the model has no empty
+    field to fill with invention.
+    """
+    meta: dict = {
+        "name": artist_name,
+        "total_plays": total_plays,
+    }
+
+    if not _is_placeholder(genre):
+        meta["genre"] = genre
+
     try:
         rows = db.execute(
             "SELECT style_tag FROM artist_style WHERE artist_id = ? ORDER BY style_tag LIMIT ?",
             (artist_id, _STYLES_TOP_N),
         ).fetchall()
-        styles = [r["style_tag"] for r in rows]
+        styles = [r["style_tag"] for r in rows if not _is_placeholder(r["style_tag"])]
+        if styles:
+            meta["styles"] = styles
     except sqlite3.OperationalError:
         pass  # artist_style table may not exist
-
-    meta: dict = {
-        "name": artist_name,
-        "genre": genre,
-        "total_plays": total_plays,
-        "styles": styles,
-    }
 
     # Audio profile: add qualitative descriptors when available
     try:
@@ -323,6 +356,15 @@ def _lookup_artist_metadata(
         pass  # audio_profile table may not exist
 
     return meta
+
+
+def _has_limited_metadata(meta: dict) -> bool:
+    """An artist is 'limited metadata' when only ``name`` and ``total_plays`` survived filtering.
+
+    Triggers the system-prompt branch that tells the model to describe only
+    the co-occurrence pattern, not the artist's sound.
+    """
+    return set(meta.keys()) <= {"name", "total_plays"}
 
 
 def _qualitative_audio_descriptors(profile: sqlite3.Row, bpm_row: sqlite3.Row | None) -> dict:

--- a/tests/unit/test_narrative.py
+++ b/tests/unit/test_narrative.py
@@ -427,10 +427,14 @@ class TestPromptContent:
         assert set(prompt_data["target"]["styles"]) == {"Post-Rock", "Krautrock"}
 
     @pytest.mark.asyncio
-    async def test_prompt_metadata_graceful_without_styles(
+    async def test_prompt_metadata_omits_empty_styles(
         self, client: AsyncClient, narrative_artist_ids: dict[str, int]
     ) -> None:
-        """Artists without style tags should have an empty styles list."""
+        """Artists with no style tags get the ``styles`` key omitted entirely.
+
+        Empty fields invite the model to invent — it doesn't conclude "this is
+        a data gap," it concludes "I should fill this." So drop the key.
+        """
         ae_id = narrative_artist_ids["Autechre"]
         cp_id = narrative_artist_ids["Cat Power"]
         resp = await client.get(f"/graph/artists/{ae_id}/explain/{cp_id}/narrative")
@@ -442,7 +446,7 @@ class TestPromptContent:
         prompt_data = json.loads(messages[0]["content"])
 
         assert prompt_data["target"]["name"] == "Cat Power"
-        assert prompt_data["target"]["styles"] == []
+        assert "styles" not in prompt_data["target"]
         assert prompt_data["target"]["total_plays"] == 20
 
 
@@ -1357,3 +1361,144 @@ class TestQualitativeAudioDescriptors:
             if key == "recording_count":
                 continue
             assert not isinstance(value, float), f"{key} leaks a raw float: {value!r}"
+
+
+class TestOmitEmptyAndPlaceholderFields:
+    """The ``Konono No 1`` failure mode: empty fields tempt the model to invent.
+
+    Verifies that empty lists, ``None``, and placeholder strings ("Unknown",
+    "Various", "Various Artists", "V/A", etc.) are stripped before the prompt
+    is built, and that the system prompt is told via a ``caveat`` field when
+    an artist has only ``name`` + ``total_plays`` after filtering.
+    """
+
+    def test_konono_empty_styles_drops_key(self) -> None:
+        """An artist with zero Discogs styles gets ``styles`` omitted from the prompt."""
+        from semantic_index.api.narrative import _lookup_artist_metadata
+
+        path = tempfile.mktemp(suffix=".db")
+        conn = sqlite3.connect(path)
+        conn.row_factory = sqlite3.Row
+        conn.executescript(
+            """
+            CREATE TABLE artist (id INTEGER PRIMARY KEY, canonical_name TEXT, genre TEXT);
+            CREATE TABLE artist_style (artist_id INTEGER, style_tag TEXT,
+                                       PRIMARY KEY (artist_id, style_tag));
+            INSERT INTO artist (id, canonical_name, genre)
+                VALUES (1, 'Konono No 1', 'World');
+            """
+        )
+        meta = _lookup_artist_metadata(conn, 1, "Konono No 1", "World", 25)
+        conn.close()
+
+        assert "styles" not in meta, "empty styles should be omitted, not emitted as []"
+        assert meta["genre"] == "World"
+        assert meta["name"] == "Konono No 1"
+
+    def test_unknown_genre_dropped(self) -> None:
+        """Genre = 'Unknown' is a placeholder; treat as missing."""
+        from semantic_index.api.narrative import _lookup_artist_metadata
+
+        path = tempfile.mktemp(suffix=".db")
+        conn = sqlite3.connect(path)
+        conn.row_factory = sqlite3.Row
+        conn.executescript(
+            "CREATE TABLE artist (id INTEGER PRIMARY KEY, canonical_name TEXT);"
+            "CREATE TABLE artist_style (artist_id INTEGER, style_tag TEXT,"
+            " PRIMARY KEY (artist_id, style_tag));"
+            "INSERT INTO artist (id, canonical_name) VALUES (1, 'Test');"
+        )
+        meta = _lookup_artist_metadata(conn, 1, "Test", "Unknown", 5)
+        conn.close()
+
+        assert "genre" not in meta
+
+    def test_various_artists_genre_dropped(self) -> None:
+        """Genre = 'Various Artists' is a compilation indicator, not a real genre."""
+        from semantic_index.api.narrative import _lookup_artist_metadata
+
+        path = tempfile.mktemp(suffix=".db")
+        conn = sqlite3.connect(path)
+        conn.row_factory = sqlite3.Row
+        conn.executescript(
+            "CREATE TABLE artist (id INTEGER PRIMARY KEY, canonical_name TEXT);"
+            "CREATE TABLE artist_style (artist_id INTEGER, style_tag TEXT,"
+            " PRIMARY KEY (artist_id, style_tag));"
+            "INSERT INTO artist (id, canonical_name) VALUES (1, 'Test');"
+        )
+        for placeholder in ("Various Artists", "Various", "V/A", "v.a.", "  unknown "):
+            meta = _lookup_artist_metadata(conn, 1, "Test", placeholder, 5)
+            assert "genre" not in meta, f"placeholder {placeholder!r} should be dropped"
+        conn.close()
+
+    def test_placeholder_styles_filtered_out(self) -> None:
+        """Individual placeholder style tags drop out of the styles list."""
+        from semantic_index.api.narrative import _lookup_artist_metadata
+
+        path = tempfile.mktemp(suffix=".db")
+        conn = sqlite3.connect(path)
+        conn.row_factory = sqlite3.Row
+        conn.executescript(
+            "CREATE TABLE artist (id INTEGER PRIMARY KEY, canonical_name TEXT);"
+            "CREATE TABLE artist_style (artist_id INTEGER, style_tag TEXT,"
+            " PRIMARY KEY (artist_id, style_tag));"
+            "INSERT INTO artist (id, canonical_name) VALUES (1, 'Test');"
+            "INSERT INTO artist_style VALUES (1, 'Folk'), (1, 'Unknown'),"
+            " (1, 'Rock'), (1, 'N/A');"
+        )
+        meta = _lookup_artist_metadata(conn, 1, "Test", None, 5)
+        conn.close()
+
+        assert meta["styles"] == ["Folk", "Rock"]
+
+    def test_empty_relationships_omitted_from_prompt(self) -> None:
+        """An empty ``relationships`` list is dropped — no key in the prompt JSON."""
+        from semantic_index.api.narrative import _build_prompt
+
+        prompt = _build_prompt(
+            source_meta={"name": "A", "total_plays": 10, "genre": "Rock"},
+            target_meta={"name": "B", "total_plays": 8, "genre": "Jazz"},
+            relationships=[],
+        )
+        data = json.loads(prompt)
+        assert "relationships" not in data
+
+    def test_limited_metadata_sets_caveat(self) -> None:
+        """Artist with only name + total_plays after filtering triggers the caveat."""
+        from semantic_index.api.narrative import _build_prompt
+
+        prompt = _build_prompt(
+            source_meta={"name": "Konono No 1", "total_plays": 25},
+            target_meta={"name": "Stereolab", "total_plays": 30, "genre": "Rock"},
+            relationships=[{"type": "djTransition", "raw_count": 3, "pmi": 2.1}],
+        )
+        data = json.loads(prompt)
+        assert "caveat" in data
+        assert "Konono No 1" in data["caveat"]
+        assert "Stereolab" not in data["caveat"]
+
+    def test_no_caveat_when_both_artists_rich(self) -> None:
+        """Both artists with content fields → no caveat in the prompt."""
+        from semantic_index.api.narrative import _build_prompt
+
+        prompt = _build_prompt(
+            source_meta={"name": "A", "total_plays": 10, "genre": "Rock"},
+            target_meta={"name": "B", "total_plays": 8, "styles": ["Jazz"]},
+            relationships=[{"type": "djTransition", "raw_count": 3, "pmi": 2.1}],
+        )
+        data = json.loads(prompt)
+        assert "caveat" not in data
+
+    def test_caveat_lists_both_when_both_limited(self) -> None:
+        """Both artists thin → caveat names both."""
+        from semantic_index.api.narrative import _build_prompt
+
+        prompt = _build_prompt(
+            source_meta={"name": "Konono No 1", "total_plays": 25},
+            target_meta={"name": "Pastor T.L. Barrett", "total_plays": 12},
+            relationships=[],
+        )
+        data = json.loads(prompt)
+        assert "caveat" in data
+        assert "Konono No 1" in data["caveat"]
+        assert "Pastor T.L. Barrett" in data["caveat"]


### PR DESCRIPTION
## Summary

Empty fields tempt the model to invent. The experiment runs caught two failures:

- **Konono No 1** (zero Discogs styles): with \`styles: []\` in the prompt, the model hallucinated genre descriptions to fill the void.
- **Pastor T.L. Barrett** (thin metadata): described as \"instrumental and experimental\" when he sings religious soul/gospel.

When the model sees an empty field it doesn't conclude \"this is a data gap.\" It concludes \"I should fill this.\" The fix: never show the field at all.

## What changes

**Filtering in \`_lookup_artist_metadata\`** — \`genre\`, \`styles\`, and (already) \`audio\` are emitted only when content-bearing. Empty lists, \`None\`, and placeholder strings (\"Unknown\", \"Various\", \"Various Artists\", \"V/A\", \"v.a.\", \"N/A\", \"None\") are dropped. Comparison is case-insensitive and whitespace-trimmed (`_is_placeholder`). Individual placeholder values inside style lists are filtered too.

**Filtering in \`_build_prompt\`** — \`relationships\` is emitted only when non-empty.

**Limited-metadata caveat** — when an artist has only \`name\` + \`total_plays\` after filtering, the prompt emits a top-level \`caveat\` field naming the artist(s). The system prompt is updated to instruct the model to describe only the co-occurrence pattern (which DJs play these together, when, in which neighborhood) and **not** to characterize the named artist's sound, genre, or style.

\`_PROMPT_VERSION\` 5 → 6; cached narratives from the prior prompt evict via read-side version filtering.

## Tests

\`TestOmitEmptyAndPlaceholderFields\` — 8 new tests:

- Konono No 1 with zero styles → \`styles\` not in prompt
- Genre = \"Unknown\" / \"Various Artists\" / \"V/A\" / \"v.a.\" / \"  unknown \" all dropped
- Style row tagged \"Unknown\" filtered out of the styles list
- Empty \`relationships\` → key dropped
- Limited-metadata artist → caveat names them
- No caveat when both artists have content
- Caveat lists both when both are limited

\`TestPromptContent.test_prompt_metadata_omits_empty_styles\` (renamed) updated to assert \`\"styles\" not in target\` instead of \`styles == []\`.

## Test plan

- [x] \`ruff check .\` passes
- [x] \`ruff format --check .\` passes
- [x] \`mypy semantic_index/\` passes
- [x] \`pytest tests/unit/test_narrative.py\` — 55 passed
- [ ] CI green
- [ ] Deploy: cache evicts on first request

Closes #223. Closes parent epic #209 (last sub-issue).