### PR TITLE
Add naming-only instruction for shared neighbors in narrative prompt

### DIFF
--- a/semantic_index/api/narrative.py
+++ b/semantic_index/api/narrative.py
@@ -21,7 +21,7 @@ narrative_router = APIRouter(prefix="/graph", tags=["graph"])
 
 # Bump whenever the prompt's structure or content changes so the sidecar cache
 # evicts stale entries instead of serving them indefinitely.
-_PROMPT_VERSION = 6
+_PROMPT_VERSION = 7
 
 _SHARED_NEIGHBORS_TOP_K = 5
 
@@ -98,6 +98,8 @@ _SYSTEM_PROMPT = (
     "history, write 2-3 sentences (under 80 words) explaining their connection in plain "
     "English. Be specific — mention shared genres, personnel names, labels, or play patterns "
     "from the data. Do not add information not present in the data. "
+    "When naming shared neighbors, state ONLY their names. Do not describe, characterize, "
+    "or categorize the neighbors in any way. "
     "If the input includes a 'caveat' field naming an artist with limited metadata, "
     "describe only the co-occurrence pattern (which DJs play these together, when, in which "
     "neighborhood). Do NOT characterize the named artist's sound, genre, or style."

--- a/tests/unit/test_narrative.py
+++ b/tests/unit/test_narrative.py
@@ -1502,3 +1502,34 @@ class TestOmitEmptyAndPlaceholderFields:
         assert "caveat" in data
         assert "Konono No 1" in data["caveat"]
         assert "Pastor T.L. Barrett" in data["caveat"]
+
+
+class TestNamingOnlyInstruction:
+    """The matrix experiment's biggest single lever: 45% → 20% hallucination.
+
+    Adding "When naming shared neighbors, state ONLY their names" to the
+    system prompt cut neighbor-characterization hallucination dramatically
+    (the model inventing adjectives like "folk innovators like Astor Piazzolla"
+    or "introspective indie voices like Jamila Woods" for shared neighbors).
+    """
+
+    @pytest.mark.asyncio
+    async def test_system_prompt_includes_naming_only_instruction(
+        self, client: AsyncClient, narrative_artist_ids: dict[str, int]
+    ) -> None:
+        """The Anthropic call's ``system=`` argument carries the naming-only sentence."""
+        ae_id = narrative_artist_ids["Autechre"]
+        sl_id = narrative_artist_ids["Stereolab"]
+        resp = await client.get(f"/graph/artists/{ae_id}/explain/{sl_id}/narrative")
+        assert resp.status_code == 200
+
+        mock_client = client._transport.app.state.anthropic_client  # type: ignore[union-attr]
+        last_call = mock_client.messages.create.call_args
+        system_prompt = last_call.kwargs.get("system") or last_call[1].get("system", "")
+
+        # Lock the exact instruction so a future edit that softens or drops it
+        # trips the test.
+        assert (
+            "When naming shared neighbors, state ONLY their names. "
+            "Do not describe, characterize, or categorize the neighbors in any way."
+        ) in system_prompt


### PR DESCRIPTION
## Summary

Single-sentence addition to the narrative endpoint's system prompt:

> When naming shared neighbors, state ONLY their names. Do not describe, characterize, or categorize the neighbors in any way.

Across the matrix experiment this was the largest single hallucination lever — drops the rate **45% → 20%**, and hits **0%** on LOW fame + RICH data + SAME genre pairs.

## Why

Neighbor characterization was the dominant failure mode across every risk tier. The model was inventing adjectives for shared neighbors that weren't in the data:

- \"folk innovators like Astor Piazzolla\"
- \"introspective indie voices like Jamila Woods\"
- \"art-rock innovators like U.S. Maple\"

Telling it explicitly to name only — and not to describe, categorize, or characterize — cut the rate dramatically with zero structural changes and ~50 prompt tokens.

## Cache

Bumps \`_PROMPT_VERSION\` 6 → 7. Prior-format narratives evict via read-side version filtering. No code change beyond the prompt string + version bump.

## Tests

\`TestNamingOnlyInstruction.test_system_prompt_includes_naming_only_instruction\` asserts the exact sentence is present in the \`system=\` kwarg of the Anthropic call. A future edit that softens or drops the instruction trips the test.

## Test plan

- [x] \`ruff check .\` passes
- [x] \`ruff format --check .\` passes
- [x] \`mypy semantic_index/\` passes
- [x] \`pytest tests/unit/test_narrative.py\` — 56 passed
- [ ] CI green
- [ ] Deploy + spot-check 5 narratives manually to confirm neighbors are mentioned by name only

Closes #224.