### PR TITLE
Add two few-shot example narratives to the system prompt

### DIFF
--- a/semantic_index/api/narrative.py
+++ b/semantic_index/api/narrative.py
@@ -21,7 +21,7 @@ narrative_router = APIRouter(prefix="/graph", tags=["graph"])
 
 # Bump whenever the prompt's structure or content changes so the sidecar cache
 # evicts stale entries instead of serving them indefinitely.
-_PROMPT_VERSION = 8
+_PROMPT_VERSION = 9
 
 _SHARED_NEIGHBORS_TOP_K = 5
 
@@ -122,6 +122,28 @@ _SYSTEM_PROMPT = (
     "If the input includes a 'caveat' field naming an artist with limited metadata, "
     "describe only the co-occurrence pattern (which DJs play these together, when, in which "
     "neighborhood). Do NOT characterize the named artist's sound, genre, or style."
+    "\n\n"
+    "Two examples of grounded narratives. Match this structure and tone — stay close to "
+    "what's in the input, do not reach for extra context.\n\n"
+    "<example_rich>\n"
+    'Input: {"source": {"name": "Stereolab", "genre": "Rock", "styles": '
+    '["Indie Rock", "Post-Rock"], "total_plays": 412}, "target": {"name": "Yo La Tengo", '
+    '"genre": "Rock", "styles": ["Indie Rock", "Indie Pop"], "total_plays": 524}, '
+    '"relationships": [{"type": "djTransition", "raw_count": 8, "pmi": 3.5}, '
+    '{"type": "sharedStyle", "shared_tags": ["Indie Rock"], "jaccard": 0.5}], '
+    '"shared_neighbors": [{"name": "Tortoise"}, {"name": "Lambchop"}]}\n'
+    "Narrative: WXYC DJs pair Stereolab with Yo La Tengo across 8 transitions in our "
+    "flowsheets. Both share the Indie Rock tag, and Tortoise and Lambchop appear as "
+    "common neighbors.\n"
+    "</example_rich>\n\n"
+    "<example_thin>\n"
+    'Input: {"source": {"name": "Pastor T.L. Barrett", "total_plays": 18}, '
+    '"target": {"name": "Konono No 1", "total_plays": 25}, "relationships": '
+    '[{"type": "djTransition", "raw_count": 3, "pmi": 1.8}], '
+    '"caveat": "limited metadata for Pastor T.L. Barrett, Konono No 1"}\n'
+    "Narrative: WXYC DJs place Pastor T.L. Barrett next to Konono No 1 in 3 transitions "
+    "across our flowsheets, an uncommon pairing in the station's library.\n"
+    "</example_thin>"
 )
 
 # Treat these as content-bearing-equivalent to None — placeholder values that

--- a/tests/unit/test_narrative.py
+++ b/tests/unit/test_narrative.py
@@ -1658,3 +1658,73 @@ class TestAnonymization:
         body = resp.json()
         assert "Autechre" in body["narrative"]
         assert "Artist A" not in body["narrative"]
+
+
+class TestFewShotExamples:
+    """Two gold-standard narratives in the system prompt — the matrix experiment's
+    second-largest lever (45% → 21% baseline-wide; 7% on HIGH+RICH+SAME).
+
+    Few-shot demonstrates what a grounded output looks like more reliably than
+    negative instructions alone.
+    """
+
+    @pytest.mark.asyncio
+    async def test_system_prompt_includes_both_examples(
+        self, client: AsyncClient, narrative_artist_ids: dict[str, int]
+    ) -> None:
+        """Both rich-data and thin-data examples appear in the system prompt."""
+        ae_id = narrative_artist_ids["Autechre"]
+        sl_id = narrative_artist_ids["Stereolab"]
+        resp = await client.get(f"/graph/artists/{ae_id}/explain/{sl_id}/narrative")
+        assert resp.status_code == 200
+
+        mock_client = client._transport.app.state.anthropic_client  # type: ignore[union-attr]
+        last_call = mock_client.messages.create.call_args
+        system_prompt = last_call.kwargs.get("system") or last_call[1].get("system", "")
+
+        assert "<example_rich>" in system_prompt
+        assert "</example_rich>" in system_prompt
+        assert "<example_thin>" in system_prompt
+        assert "</example_thin>" in system_prompt
+
+        # Both example narratives are present verbatim — guards against accidental
+        # truncation or whitespace mangling in future edits.
+        assert "Stereolab" in system_prompt
+        assert "Yo La Tengo" in system_prompt
+        assert "Tortoise" in system_prompt
+        assert "Pastor T.L. Barrett" in system_prompt
+        assert "Konono No 1" in system_prompt
+
+    @pytest.mark.asyncio
+    async def test_examples_avoid_banned_phrasings(
+        self, client: AsyncClient, narrative_artist_ids: dict[str, int]
+    ) -> None:
+        """Few-shot must not teach the model the failure-mode phrasings.
+
+        ``occupy`` / ``reach for`` / ``represent`` are flagged as banned in
+        plan §4 — symptomatic of the inventing-context failure mode. Examples
+        that contain them would teach the model to produce them too.
+        """
+        import re
+
+        ae_id = narrative_artist_ids["Autechre"]
+        sl_id = narrative_artist_ids["Stereolab"]
+        resp = await client.get(f"/graph/artists/{ae_id}/explain/{sl_id}/narrative")
+        assert resp.status_code == 200
+
+        mock_client = client._transport.app.state.anthropic_client  # type: ignore[union-attr]
+        last_call = mock_client.messages.create.call_args
+        system_prompt = last_call.kwargs.get("system") or last_call[1].get("system", "")
+
+        # Extract just the example narratives so we don't false-trigger on
+        # instruction text that legitimately uses words like "characterize".
+        examples_text = "\n".join(
+            re.findall(r"<example_\w+>(.*?)</example_\w+>", system_prompt, re.DOTALL)
+        )
+        assert examples_text, "examples should be extractable from system prompt"
+
+        for banned in ("occupy", "reach for", "represent"):
+            assert banned.lower() not in examples_text.lower(), (
+                f"banned phrasing {banned!r} found in few-shot examples — "
+                f"would teach the model the failure-mode phrasing"
+            )


### PR DESCRIPTION
## Summary

Appends two gold-standard examples to the narrative system prompt — one demonstrating handling of rich data, one demonstrating handling of thin data. Wrapped in \`<example_rich>\` / \`<example_thin>\` XML tags.

Across the matrix experiment few-shot was the second-largest single lever — dropped hallucination **45% → 21%** baseline-wide and hit **7%** on HIGH fame + RICH data + SAME genre (best single-cell result in the study).

## The examples

**Rich (Stereolab × Yo La Tengo)** — shows two shared styles, a sharedStyle relationship, and two named shared neighbors (Tortoise, Lambchop). Demonstrates the naming-only rule from #224 by stating the neighbors without characterizing them.

**Thin (Pastor T.L. Barrett × Konono No 1)** — shows only a co-occurrence count and a \`caveat\` field. Demonstrates the limited-metadata branch from #223 without inventing sonic descriptions.

## Banned phrasing guard

Plan §4 lists three failure-mode phrasings (\"occupy\", \"reach for\", \"represent\") that signal the inventing-context mode. \`test_examples_avoid_banned_phrasings\` extracts the example block via regex from the system prompt and asserts none of them appear, so a future edit can't sneak the failure-mode phrasing into the few-shot.

## Cost

~250 prompt tokens added per call. At Haiku input pricing (~$0.80/MTok), about $0.0002/call. At the cached top-5-per-artist scale (~34K pairs), ~$1 over the lifetime of the cache.

## Cache

Bumps \`_PROMPT_VERSION\` 7 → 8. Prior-format narratives evict via read-side version filtering.

## Test plan

- [x] \`ruff check .\` passes
- [x] \`ruff format --check .\` passes
- [x] \`mypy semantic_index/\` passes
- [x] \`pytest tests/unit/test_narrative.py\` — 58 passed
- [ ] CI green
- [ ] Deploy + spot-check generated narratives don't accidentally adopt the example wording verbatim (the model should imitate structure, not copy specific names like \"Tortoise\" into unrelated narratives)

Closes #225.