### PR TITLE
Anonymize >threshold-play artists before generation (TDD)

### DIFF
--- a/semantic_index/api/narrative.py
+++ b/semantic_index/api/narrative.py
@@ -21,9 +21,28 @@ narrative_router = APIRouter(prefix="/graph", tags=["graph"])
 
 # Bump whenever the prompt's structure or content changes so the sidecar cache
 # evicts stale entries instead of serving them indefinitely.
-_PROMPT_VERSION = 7
+_PROMPT_VERSION = 8
 
 _SHARED_NEIGHBORS_TOP_K = 5
+
+_DEFAULT_ANON_PLAY_THRESHOLD = 800
+
+
+def _anon_threshold() -> int:
+    """Read NARRATIVE_ANON_PLAY_THRESHOLD from env, falling back to default."""
+    raw = os.environ.get("NARRATIVE_ANON_PLAY_THRESHOLD")
+    if raw is None:
+        return _DEFAULT_ANON_PLAY_THRESHOLD
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning(
+            "Invalid NARRATIVE_ANON_PLAY_THRESHOLD=%r; using default %d",
+            raw,
+            _DEFAULT_ANON_PLAY_THRESHOLD,
+        )
+        return _DEFAULT_ANON_PLAY_THRESHOLD
+
 
 # Long Discogs style lists invite hallucination — a model fed Outkast's 53
 # styles latches onto an outlier ("makina", "breakbeat") and describes a hip
@@ -439,6 +458,48 @@ def _qualitative_audio_descriptors(profile: sqlite3.Row, bpm_row: sqlite3.Row | 
     return desc
 
 
+def _build_anonymization_map(source: dict, target: dict, threshold: int) -> dict[str, str]:
+    """Map artist names with ``total_plays > threshold`` to placeholder aliases.
+
+    The cutoff is strict ``>``: a name at exactly the threshold is *not*
+    anonymized. Source maps to ``Artist A``, target to ``Artist B``.
+    """
+    sub_map: dict[str, str] = {}
+    if source.get("total_plays", 0) > threshold:
+        sub_map[source["name"]] = "Artist A"
+    if target.get("total_plays", 0) > threshold:
+        sub_map[target["name"]] = "Artist B"
+    return sub_map
+
+
+def _apply_anonymization(meta: dict, sub_map: dict[str, str]) -> dict:
+    """Return a copy of ``meta`` with ``name`` swapped for its alias if mapped."""
+    if not sub_map:
+        return meta
+    out = dict(meta)
+    if out.get("name") in sub_map:
+        out["name"] = sub_map[out["name"]]
+    return out
+
+
+def _reverse_anonymization(narrative: str, sub_map: dict[str, str]) -> str:
+    """Substitute aliases in ``narrative`` back to their real names.
+
+    Uses word-boundary matching (``\\b``) so ``Tina`` doesn't match the ``tina``
+    inside ``Argentina``. Aliases are still expected to be deliberately
+    distinctive (``Artist A``, ``Neighbor 1``); the boundary is a safety net
+    for the rare alias that happens to be a real substring.
+    """
+    import re
+
+    if not sub_map:
+        return narrative
+    out = narrative
+    for real_name, alias in sub_map.items():
+        out = re.sub(rf"\b{re.escape(alias)}\b", real_name, out)
+    return out
+
+
 def _lookup_dj_name(db: sqlite3.Connection, dj_id: int) -> str | None:
     """Look up a DJ's display name from the dj table."""
     try:
@@ -606,9 +667,16 @@ def get_narrative(
     # Cap to top-K only for the prompt; threshold check above used the full sum.
     shared_neighbors = all_shared_neighbors[:_SHARED_NEIGHBORS_TOP_K]
 
+    # Anonymize >threshold-play artists so the model can't activate pretraining
+    # knowledge about famous names (#227). The map is empty when neither artist
+    # clears the threshold, in which case _apply_anonymization is a no-op.
+    sub_map = _build_anonymization_map(source_meta, target_meta, _anon_threshold())
+    prompt_source = _apply_anonymization(source_meta, sub_map)
+    prompt_target = _apply_anonymization(target_meta, sub_map)
+
     user_message = _build_prompt(
-        source_meta=source_meta,
-        target_meta=target_meta,
+        source_meta=prompt_source,
+        target_meta=prompt_target,
         relationships=relationships,
         shared_neighbors=shared_neighbors,
         month=month,
@@ -629,6 +697,10 @@ def get_narrative(
         logger.exception("Anthropic API call failed")
         cache_db.close()
         raise HTTPException(status_code=502, detail="Narrative generation failed") from None
+
+    # Restore real names in the output before caching/returning so the cache
+    # holds the user-facing text, not aliases.
+    narrative = _reverse_anonymization(narrative, sub_map)
 
     # Write to cache
     try:

--- a/tests/unit/test_narrative.py
+++ b/tests/unit/test_narrative.py
@@ -1533,3 +1533,128 @@ class TestNamingOnlyInstruction:
             "When naming shared neighbors, state ONLY their names. "
             "Do not describe, characterize, or categorize the neighbors in any way."
         ) in system_prompt
+
+
+class TestAnonymization:
+    """Anonymize >threshold-play artist names before generation, restore after (#227)."""
+
+    def test_no_anonymization_below_threshold(self) -> None:
+        """Both artists under the threshold → empty substitution map."""
+        from semantic_index.api.narrative import _build_anonymization_map
+
+        source = {"name": "Niche A", "total_plays": 50}
+        target = {"name": "Niche B", "total_plays": 100}
+        sub_map = _build_anonymization_map(source, target, threshold=800)
+        assert sub_map == {}
+
+    def test_high_fame_source_mapped_to_artist_a(self) -> None:
+        from semantic_index.api.narrative import _build_anonymization_map
+
+        source = {"name": "Bob Dylan", "total_plays": 1500}
+        target = {"name": "Niche Folk", "total_plays": 80}
+        sub_map = _build_anonymization_map(source, target, threshold=800)
+        assert sub_map == {"Bob Dylan": "Artist A"}
+
+    def test_high_fame_target_mapped_to_artist_b(self) -> None:
+        from semantic_index.api.narrative import _build_anonymization_map
+
+        source = {"name": "Niche Folk", "total_plays": 80}
+        target = {"name": "Joni Mitchell", "total_plays": 1200}
+        sub_map = _build_anonymization_map(source, target, threshold=800)
+        assert sub_map == {"Joni Mitchell": "Artist B"}
+
+    def test_both_high_fame(self) -> None:
+        from semantic_index.api.narrative import _build_anonymization_map
+
+        source = {"name": "Bob Dylan", "total_plays": 1500}
+        target = {"name": "Joan Baez", "total_plays": 950}
+        sub_map = _build_anonymization_map(source, target, threshold=800)
+        assert sub_map == {"Bob Dylan": "Artist A", "Joan Baez": "Artist B"}
+
+    def test_threshold_is_strict_greater(self) -> None:
+        """Exactly at threshold → not anonymized. The cutoff is strict ``>``."""
+        from semantic_index.api.narrative import _build_anonymization_map
+
+        source = {"name": "Edge Case", "total_plays": 800}
+        target = {"name": "Niche", "total_plays": 50}
+        sub_map = _build_anonymization_map(source, target, threshold=800)
+        assert sub_map == {}
+
+    def test_apply_substitution_replaces_name_in_meta_dict(self) -> None:
+        """Apply the sub map to an artist meta dict — name field gets the alias."""
+        from semantic_index.api.narrative import _apply_anonymization
+
+        meta = {"name": "Bob Dylan", "total_plays": 1500, "genre": "Folk"}
+        sub_map = {"Bob Dylan": "Artist A"}
+        out = _apply_anonymization(meta, sub_map)
+        assert out["name"] == "Artist A"
+        # Other fields untouched.
+        assert out["genre"] == "Folk"
+        assert out["total_plays"] == 1500
+
+    def test_apply_substitution_no_op_when_name_not_in_map(self) -> None:
+        from semantic_index.api.narrative import _apply_anonymization
+
+        meta = {"name": "Niche", "total_plays": 50}
+        out = _apply_anonymization(meta, {"Bob Dylan": "Artist A"})
+        assert out["name"] == "Niche"
+
+    def test_reverse_anonymization_restores_real_names(self) -> None:
+        """``Artist A`` in the model output gets swapped back to the real name."""
+        from semantic_index.api.narrative import _reverse_anonymization
+
+        sub_map = {"Bob Dylan": "Artist A", "Joan Baez": "Artist B"}
+        narrative = "WXYC DJs pair Artist A with Artist B in 12 transitions."
+        out = _reverse_anonymization(narrative, sub_map)
+        assert out == "WXYC DJs pair Bob Dylan with Joan Baez in 12 transitions."
+
+    def test_reverse_anonymization_uses_word_boundaries(self) -> None:
+        """Don't substitute ``Tina`` inside ``Argentina`` — issue's stated robustness criterion."""
+        from semantic_index.api.narrative import _reverse_anonymization
+
+        # Place an alias that's a substring of an unrelated word in the narrative.
+        sub_map = {"Tina Turner": "Tina"}
+        narrative = "Argentina's tradition pairs Tina with the local scene."
+        out = _reverse_anonymization(narrative, sub_map)
+        # The standalone "Tina" gets restored; the "tina" inside "Argentina" doesn't.
+        assert out == "Argentina's tradition pairs Tina Turner with the local scene."
+
+    @pytest.mark.asyncio
+    async def test_high_fame_pair_anonymized_in_prompt_and_restored_in_response(
+        self,
+        narrative_db_path: str,
+        narrative_artist_ids: dict[str, int],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """End-to-end: high-fame source has its name anonymized in the LLM prompt,
+        and the LLM's response (which references ``Artist A``) gets the real name
+        substituted back before being returned and cached."""
+        # Force Autechre into the high-fame band for this test.
+        monkeypatch.setenv("NARRATIVE_ANON_PLAY_THRESHOLD", "10")
+        _clear_narrative_cache(narrative_db_path)
+
+        # Mock returns the canned alias-shaped response.
+        anon_response = "WXYC DJs pair Artist A with Stereolab across many transitions."
+        mock_client = _mock_anthropic_client(anon_response)
+        app = create_app(narrative_db_path, anthropic_api_key="test-key")
+        app.state.anthropic_client = mock_client
+        transport = ASGITransport(app=app)
+
+        ae_id = narrative_artist_ids["Autechre"]  # 50 plays in fixture
+        sl_id = narrative_artist_ids["Stereolab"]  # 30 plays in fixture
+
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get(f"/graph/artists/{ae_id}/explain/{sl_id}/narrative")
+        assert resp.status_code == 200
+
+        # The prompt sent to the mock contains the alias, not the real name.
+        last_call = mock_client.messages.create.call_args
+        messages = last_call.kwargs.get("messages") or last_call[1].get("messages", [])
+        sent_prompt = messages[0]["content"]
+        assert "Artist A" in sent_prompt
+        assert "Autechre" not in sent_prompt, "real high-fame name leaked into the prompt"
+
+        # The response we return has the real name back.
+        body = resp.json()
+        assert "Autechre" in body["narrative"]
+        assert "Artist A" not in body["narrative"]


### PR DESCRIPTION
## Summary

High-fame artist names trigger the model's pretraining knowledge override:

- **Bob Dylan** described as \"lyrically innovative\" with no lyrical data in the input
- **Elvis Costello** described as \"literary\" inferred from a single \"Art Song\" tag
- **Muddy Waters** conflated with **Crystal Waters**

Replacing high-fame names with deterministic placeholders (\"Artist A\", \"Artist B\") in the prompt — and substituting them back in the response — forces the model to ground in the provided data only. The matrix experiment confirmed the fame hypothesis: **ANONYMIZED hit 13–17% on HIGH-fame cells vs 38–47% baseline**.

## How it works

1. \`_build_anonymization_map(source, target, threshold)\` — returns \`{ \"Bob Dylan\": \"Artist A\", \"Joan Baez\": \"Artist B\" }\` for any artist whose \`total_plays\` strictly exceeds the threshold. Empty when neither artist crosses.
2. \`_apply_anonymization(meta, sub_map)\` — copies the source/target meta dict with \`name\` swapped for the alias.
3. LLM is called with the anonymized prompt.
4. \`_reverse_anonymization(response, sub_map)\` — substitutes aliases back to real names. Uses \`\\b\` word boundaries so \`Tina\` doesn't match inside \`Argentina\` (the issue's stated robustness criterion).

## Configuration

\`NARRATIVE_ANON_PLAY_THRESHOLD\` env var, default 800. Invalid values log a warning and fall back. \`_PROMPT_VERSION\` 7 → 8 to evict prior-format cache entries.

## Open question — resolved

\"What about *one* high-fame and one low-fame artist?\" — Plan recommended anonymizing the high-fame one, leaving the low-fame one as-is so it can still anchor the description. The implementation already does this: \`_build_anonymization_map\` checks each artist independently. Locked by \`test_high_fame_source_mapped_to_artist_a\` and \`test_high_fame_target_mapped_to_artist_b\`.

## Out of scope

Neighbor anonymization (the issue mentions \"Neighbor 1 / Neighbor 2 / etc.\") is not implemented in this PR. \`shared_neighbors\` doesn't carry play counts, and the matrix experiment's measured fame-mitigation impact is on the source/target pair specifically. Could be a follow-up if production spot-checks show the model leaning on neighbor names from pretraining knowledge.

## TDD process

Wrote each test first, ran to confirm RED, implemented minimum to GREEN, then next test. 6 cycles end-to-end: empty map → source mapping → target mapping → strict-> threshold → forward apply → reverse with word boundaries → end-to-end integration. 10 new tests, 66/66 passing overall.

## Test plan

- [x] \`ruff check .\` passes
- [x] \`ruff format --check .\` passes
- [x] \`mypy semantic_index/\` passes
- [x] \`pytest tests/unit/test_narrative.py\` — 66 passed
- [ ] CI green
- [ ] Deploy + spot-check that response text doesn't leak \"Artist A\" / \"Artist B\" placeholders for any pair

Closes #227.