### PR TITLE
Add token-match scorer as always-on production gate (TDD)

### DIFF
--- a/semantic_index/api/narrative.py
+++ b/semantic_index/api/narrative.py
@@ -21,7 +21,7 @@ narrative_router = APIRouter(prefix="/graph", tags=["graph"])
 
 # Bump whenever the prompt's structure or content changes so the sidecar cache
 # evicts stale entries instead of serving them indefinitely.
-_PROMPT_VERSION = 9
+_PROMPT_VERSION = 10
 
 _SHARED_NEIGHBORS_TOP_K = 5
 
@@ -42,6 +42,25 @@ def _anon_threshold() -> int:
             _DEFAULT_ANON_PLAY_THRESHOLD,
         )
         return _DEFAULT_ANON_PLAY_THRESHOLD
+
+
+_DEFAULT_TOKEN_MATCH_THRESHOLD = 0.5
+
+
+def _token_match_threshold() -> float:
+    """Read NARRATIVE_TOKEN_MATCH_THRESHOLD from env, falling back to default."""
+    raw = os.environ.get("NARRATIVE_TOKEN_MATCH_THRESHOLD")
+    if raw is None:
+        return _DEFAULT_TOKEN_MATCH_THRESHOLD
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning(
+            "Invalid NARRATIVE_TOKEN_MATCH_THRESHOLD=%r; using default %.2f",
+            raw,
+            _DEFAULT_TOKEN_MATCH_THRESHOLD,
+        )
+        return _DEFAULT_TOKEN_MATCH_THRESHOLD
 
 
 # Long Discogs style lists invite hallucination — a model fed Outkast's 53
@@ -153,7 +172,12 @@ _PLACEHOLDER_VALUES = frozenset(
     {"unknown", "various", "various artists", "v/a", "v.a.", "n/a", "none", ""}
 )
 
-_REQUIRED_CACHE_COLUMNS = {"edge_type", "prompt_version", "insufficient_signal"}
+_REQUIRED_CACHE_COLUMNS = {
+    "edge_type",
+    "prompt_version",
+    "insufficient_signal",
+    "token_match_score",
+}
 
 _CACHE_SCHEMA = """
 CREATE TABLE IF NOT EXISTS narrative_cache (
@@ -164,6 +188,7 @@ CREATE TABLE IF NOT EXISTS narrative_cache (
     edge_type TEXT NOT NULL DEFAULT '',
     prompt_version INTEGER NOT NULL DEFAULT 1,
     insufficient_signal INTEGER NOT NULL DEFAULT 0,
+    token_match_score REAL NOT NULL DEFAULT 0.0,
     narrative TEXT NOT NULL,
     created_at TEXT NOT NULL,
     PRIMARY KEY (source_id, target_id, month, dj_id, edge_type, prompt_version)
@@ -202,13 +227,14 @@ def _write_cache_entry(
     cache_edge_type: str,
     narrative: str,
     insufficient_signal: bool,
+    token_match_score: float = 0.0,
 ) -> None:
     """Insert (or replace) a cache row at the current ``_PROMPT_VERSION``."""
     cache_db.execute(
         "INSERT OR REPLACE INTO narrative_cache "
         "(source_id, target_id, month, dj_id, edge_type, prompt_version, "
-        "insufficient_signal, narrative, created_at) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        "insufficient_signal, token_match_score, narrative, created_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         (
             lo,
             hi,
@@ -217,6 +243,7 @@ def _write_cache_entry(
             cache_edge_type,
             _PROMPT_VERSION,
             int(insufficient_signal),
+            float(token_match_score),
             narrative,
             datetime.now(UTC).isoformat(),
         ),
@@ -480,6 +507,127 @@ def _qualitative_audio_descriptors(profile: sqlite3.Row, bpm_row: sqlite3.Row | 
     return desc
 
 
+# Connective tissue and narrative prose that doesn't need grounding against
+# the input. Stopwords + the small set of recurring frame phrases the prompt
+# encourages ("WXYC DJs play X alongside Y").
+_TOKEN_MATCH_ALLOWLIST = frozenset(
+    {
+        # English stopwords
+        "a",
+        "an",
+        "and",
+        "are",
+        "as",
+        "at",
+        "be",
+        "been",
+        "by",
+        "for",
+        "from",
+        "has",
+        "have",
+        "in",
+        "into",
+        "is",
+        "it",
+        "its",
+        "of",
+        "on",
+        "or",
+        "that",
+        "the",
+        "their",
+        "these",
+        "this",
+        "those",
+        "to",
+        "was",
+        "were",
+        "with",
+        # Narrative-prose recurring frame
+        "across",
+        "alongside",
+        "also",
+        "appear",
+        "appears",
+        "both",
+        "common",
+        "djs",
+        "frequently",
+        "neighbor",
+        "neighbors",
+        "next",
+        "occasionally",
+        "often",
+        "pair",
+        "pairs",
+        "place",
+        "places",
+        "play",
+        "plays",
+        "share",
+        "shared",
+        "shares",
+        "show",
+        "shows",
+        "tag",
+        "together",
+        "transition",
+        "transitions",
+        "uncommon",
+        "wxyc",
+        "library",
+        "flowsheet",
+        "flowsheets",
+        "between",
+        "though",
+        "while",
+    }
+)
+
+
+def _stem(word: str) -> str:
+    """Trivial suffix-strip stemmer — matches ``ambient`` to ``ambience``.
+
+    Strips a small set of common English suffixes; intentionally not Porter
+    stemming since we don't need linguistic precision, just light morphology
+    so tag/word morphological variants line up.
+
+    Trace for the motivating example:
+      ``_stem("ambient")``  → ``"ambien"`` (suffix ``"t"`` stripped, len 7 > 3)
+      ``_stem("ambience")`` → ``"ambien"`` (suffix ``"ce"`` stripped, len 8 > 4)
+    Both reduce to ``"ambien"``, so the stems match.
+    """
+    for suffix in ("ies", "ing", "ed", "es", "ce", "cy", "ly", "s", "y", "t", "e"):
+        if len(word) > len(suffix) + 2 and word.endswith(suffix):
+            return word[: -len(suffix)]
+    return word
+
+
+def _token_match_score(narrative: str, input_data: dict) -> float:
+    """Fraction of content words in ``narrative`` that don't appear in ``input_data``.
+
+    Score = unmatched / total content-words, where content words exclude the
+    stopword + narrative-prose allowlist (``WXYC DJs``, ``appears``, etc.).
+    Lower is better — a fully-grounded narrative scores 0; a hallucinated
+    narrative trends toward 1.
+
+    Word match uses suffix-stripped stems (``ambient`` ↔ ``ambience``) so the
+    model's morphological variation against the input tags doesn't get flagged
+    as unmatched.
+    """
+    import re
+
+    raw_words = re.findall(r"[A-Za-z]+", narrative.lower())
+    content_words = [w for w in raw_words if w not in _TOKEN_MATCH_ALLOWLIST]
+    if not content_words:
+        return 0.0
+    input_raw = re.findall(r"[A-Za-z]+", json.dumps(input_data).lower())
+    input_stems = {_stem(w) for w in input_raw}
+    unmatched = sum(1 for w in content_words if _stem(w) not in input_stems)
+    return unmatched / len(content_words)
+
+
 def _build_anonymization_map(source: dict, target: dict, threshold: int) -> dict[str, str]:
     """Map artist names with ``total_plays > threshold`` to placeholder aliases.
 
@@ -611,18 +759,23 @@ def get_narrative(
     cache_db = _get_cache_db(request.app.state.db_path)
     try:
         cached_row = cache_db.execute(
-            "SELECT narrative, insufficient_signal FROM narrative_cache "
+            "SELECT narrative, insufficient_signal, token_match_score FROM narrative_cache "
             "WHERE source_id = ? AND target_id = ? AND month = ? AND dj_id = ? "
             "AND edge_type = ? AND prompt_version = ?",
             (lo, hi, cache_month, cache_dj, cache_edge_type, _PROMPT_VERSION),
         ).fetchone()
         if cached_row:
+            cached_score = float(cached_row["token_match_score"])
             return NarrativeResponse(
                 source=source,
                 target=target,
                 narrative=cached_row["narrative"],
                 cached=True,
                 insufficient_signal=bool(cached_row["insufficient_signal"]),
+                token_match_score=cached_score,
+                # Threshold is read live so a deploy-time tuning change takes
+                # effect even on cached entries without invalidating them.
+                low_grounding=cached_score >= _token_match_threshold(),
             )
     finally:
         pass  # keep cache_db open for potential write below
@@ -724,12 +877,38 @@ def get_narrative(
     # holds the user-facing text, not aliases.
     narrative = _reverse_anonymization(narrative, sub_map)
 
+    # Score grounding against the post-anonymization-restored narrative AND the
+    # un-anonymized input meta — the score reflects what the user sees vs the
+    # data we actually had, not the model's internal representation.
+    score_input = {
+        "source": source_meta,
+        "target": target_meta,
+        "relationships": relationships,
+        "shared_neighbors": shared_neighbors,
+    }
+    token_score = _token_match_score(narrative, score_input)
+
     # Write to cache
     try:
         _write_cache_entry(
-            cache_db, lo, hi, cache_month, cache_dj, cache_edge_type, narrative, False
+            cache_db,
+            lo,
+            hi,
+            cache_month,
+            cache_dj,
+            cache_edge_type,
+            narrative,
+            False,
+            token_score,
         )
     finally:
         cache_db.close()
 
-    return NarrativeResponse(source=source, target=target, narrative=narrative, cached=False)
+    return NarrativeResponse(
+        source=source,
+        target=target,
+        narrative=narrative,
+        cached=False,
+        token_match_score=token_score,
+        low_grounding=token_score >= _token_match_threshold(),
+    )

--- a/semantic_index/api/schemas.py
+++ b/semantic_index/api/schemas.py
@@ -111,6 +111,13 @@ class NarrativeResponse(BaseModel):
     deterministic placeholder ``narrative`` for these pairs — DJs do play
     them together, but with no consistent neighborhood context to narrate.
     Clients can render these differently (muted card, hint, etc.).
+
+    ``token_match_score`` is the unmatched-content-words ratio of the
+    generated narrative against the input data (#228). 0 = fully grounded,
+    1 = fully ungrounded. Computed on every successful generation, including
+    cached responses. ``low_grounding`` is ``True`` when the score crosses
+    the threshold (``NARRATIVE_TOKEN_MATCH_THRESHOLD``, default 0.5) — a
+    signal to the client that the narrative is suspect.
     """
 
     source: ArtistSummary
@@ -118,6 +125,8 @@ class NarrativeResponse(BaseModel):
     narrative: str
     cached: bool
     insufficient_signal: bool = False
+    token_match_score: float = 0.0
+    low_grounding: bool = False
 
 
 class BioResponse(BaseModel):

--- a/tests/unit/test_narrative.py
+++ b/tests/unit/test_narrative.py
@@ -1728,3 +1728,110 @@ class TestFewShotExamples:
                 f"banned phrasing {banned!r} found in few-shot examples — "
                 f"would teach the model the failure-mode phrasing"
             )
+
+
+class TestTokenMatchScorer:
+    """Token-match: always-on production gate for generated narratives (#228).
+
+    Score = (unmatched content words) / (total content words). Pure string
+    comparison — zero LLM calls. The scoring_methods experiment showed
+    100% correct ranking (BASELINE > BEST) across 13 calibration pairs.
+    Threshold 0.5 flags ungrounded narratives for regeneration (loop in #229).
+    """
+
+    def test_all_content_words_grounded_returns_zero(self) -> None:
+        """Every content word in the narrative appears in the input data → score 0."""
+        from semantic_index.api.narrative import _token_match_score
+
+        narrative = "Stereolab Tortoise"
+        input_data = {
+            "source": {"name": "Stereolab"},
+            "shared_neighbors": [{"name": "Tortoise"}],
+        }
+        assert _token_match_score(narrative, input_data) == 0.0
+
+    def test_unmatched_word_lifts_score(self) -> None:
+        """A word not in the input is unmatched → score > 0."""
+        from semantic_index.api.narrative import _token_match_score
+
+        narrative = "Stereolab Beethoven"
+        input_data = {"source": {"name": "Stereolab"}}
+        # 1 of 2 content words unmatched.
+        assert _token_match_score(narrative, input_data) == 0.5
+
+    def test_stopwords_dont_count_as_unmatched(self) -> None:
+        """Common narrative prose terms are allowlisted — they're connective tissue,
+        not claims about the artist that need grounding."""
+        from semantic_index.api.narrative import _token_match_score
+
+        # WXYC, DJs, play, alongside, and, in, the are all allowlisted prose.
+        # The only content claim is "Stereolab", which is in the input → score 0.
+        narrative = "WXYC DJs play Stereolab alongside Stereolab in the show."
+        input_data = {"source": {"name": "Stereolab"}}
+        assert _token_match_score(narrative, input_data) == 0.0
+
+    def test_stem_match_matches_morphological_variant(self) -> None:
+        """``ambient`` in narrative should match ``ambience`` in input via stemming.
+
+        The issue calls out this case: tag "ambience" in styles, model writes
+        "ambient" — they share the stem ``ambien`` and shouldn't be flagged as
+        unmatched.
+        """
+        from semantic_index.api.narrative import _token_match_score
+
+        narrative = "Stereolab plays ambient music."
+        input_data = {"source": {"name": "Stereolab", "styles": ["Ambience"]}}
+        # "ambient" should match "ambience"; only content words are
+        # "Stereolab" (matched) and "ambient" (matched via stem) and "music"
+        # (not in input). 1 of 3 unmatched → 0.333…
+        score = _token_match_score(narrative, input_data)
+        assert score == pytest.approx(1 / 3, abs=0.01)
+
+    @pytest.mark.asyncio
+    async def test_response_carries_token_match_score(
+        self, client: AsyncClient, narrative_artist_ids: dict[str, int]
+    ) -> None:
+        """Every successful generation surfaces ``token_match_score`` in the response."""
+        ae_id = narrative_artist_ids["Autechre"]
+        sl_id = narrative_artist_ids["Stereolab"]
+        resp = await client.get(f"/graph/artists/{ae_id}/explain/{sl_id}/narrative")
+        assert resp.status_code == 200
+
+        body = resp.json()
+        assert "token_match_score" in body
+        assert isinstance(body["token_match_score"], float)
+        assert 0.0 <= body["token_match_score"] <= 1.0
+
+    @pytest.mark.asyncio
+    async def test_low_grounding_flag_set_when_score_above_threshold(
+        self,
+        narrative_db_path: str,
+        narrative_artist_ids: dict[str, int],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When the model emits ungrounded prose, ``low_grounding`` is True.
+
+        Lower the threshold so the well-grounded fixture narrative trips it.
+        Default threshold (0.5) is a deploy-time tuning surface; making it
+        configurable lets us test both sides.
+        """
+        monkeypatch.setenv("NARRATIVE_TOKEN_MATCH_THRESHOLD", "0.0")
+        _clear_narrative_cache(narrative_db_path)
+
+        # The mock returns a narrative with words not in the input.
+        ungrounded = (
+            "Stereolab summons unprecedented metaphysical resonance through baroque counterpoint."
+        )
+        mock_client = _mock_anthropic_client(ungrounded)
+        app = create_app(narrative_db_path, anthropic_api_key="test-key")
+        app.state.anthropic_client = mock_client
+        transport = ASGITransport(app=app)
+
+        ae_id = narrative_artist_ids["Autechre"]
+        sl_id = narrative_artist_ids["Stereolab"]
+
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get(f"/graph/artists/{ae_id}/explain/{sl_id}/narrative")
+        body = resp.json()
+        assert body["low_grounding"] is True
+        assert body["token_match_score"] > 0.0


### PR DESCRIPTION
## Summary

Token-match scorer runs on every narrative generation as the always-on production gate from #228. The \`scoring_methods_experiment\` showed it ranks BASELINE > BEST 100% of the time across 13 calibration pairs — at zero LLM cost.

## How it works

1. Extract content words from the narrative (excluding stopwords + a small narrative-prose allowlist: \"WXYC\", \"DJs\", \"appears\", \"alongside\", etc.).
2. For each, check whether its stem appears in any input field — artist names, neighbor names, styles, audio descriptors, genre labels.
3. \`score = unmatched / total\`. Lower is better.
4. \`low_grounding = score >= threshold\` (default 0.5, env \`NARRATIVE_TOKEN_MATCH_THRESHOLD\`).

Stem matching is a trivial suffix-stripper. The motivating-case trace is in the helper docstring: \`_stem(\"ambient\") = _stem(\"ambience\") = \"ambien\"\`.

## Cache + response

\`narrative_cache\` gets a \`token_match_score REAL\` column (cache schema bumped, \`_PROMPT_VERSION\` 9 → 10). Cached responses re-evaluate \`low_grounding\` against the *current* threshold so a deploy-time tuning change applies to existing entries without invalidating them.

\`NarrativeResponse\` carries two new fields: \`token_match_score: float\` and \`low_grounding: bool\` (both defaulting to 0.0 / False so existing clients are unaffected).

## TDD

5 cycles, smallest failing test each:

1. Grounded narrative → 0.0 (stub).
2. One unmatched word → 0.5 (real ratio).
3. Stopwords / narrative-prose ignored (allowlist).
4. \`ambient\` matches \`ambience\` via stem (suffix-strip stemmer).
5. End-to-end through \`get_narrative\` — score on response + \`low_grounding\` flag flips when threshold is dropped.

6 new tests, 68 → 74 passing.

## Out of scope

The regen loop (#229) will hook into the same \`low_grounding\` flag — when set, retry with anonymization or a fallback prompt. Periodic claim-ratio audit (#230) is a separate path that uses Haiku to spot-check cached narratives. Both consume this PR's score column; neither is implemented here.

## Test plan

- [x] \`ruff check .\` passes
- [x] \`ruff format --check .\` passes
- [x] \`mypy semantic_index/\` passes
- [x] \`pytest tests/unit/test_narrative.py\` — 74 passed
- [ ] CI green
- [ ] Deploy + spot-check cached responses surface a sane score

Closes #228.