### PR TITLE
Address review feedback on token-match scorer

### DIFF
--- a/semantic_index/api/narrative.py
+++ b/semantic_index/api/narrative.py
@@ -775,7 +775,7 @@ def get_narrative(
                 token_match_score=cached_score,
                 # Threshold is read live so a deploy-time tuning change takes
                 # effect even on cached entries without invalidating them.
-                low_grounding=cached_score >= _token_match_threshold(),
+                low_grounding=cached_score > _token_match_threshold(),
             )
     finally:
         pass  # keep cache_db open for potential write below
@@ -788,7 +788,9 @@ def get_narrative(
     total_aa = sum(n["aa_score"] for n in all_shared_neighbors)
     if total_aa < _min_aa_score():
         # No real connection — skip the LLM, cache a deterministic placeholder
-        # so subsequent identical requests stay cheap.
+        # so subsequent identical requests stay cheap. token_match_score is
+        # left at the default 0.0 here: the canned narrative is grounded by
+        # construction (we wrote it), so we don't run the scorer on it.
         narrative = _INSUFFICIENT_SIGNAL_NARRATIVE
         _write_cache_entry(
             cache_db, lo, hi, cache_month, cache_dj, cache_edge_type, narrative, True
@@ -879,13 +881,20 @@ def get_narrative(
 
     # Score grounding against the post-anonymization-restored narrative AND the
     # un-anonymized input meta — the score reflects what the user sees vs the
-    # data we actually had, not the model's internal representation.
-    score_input = {
+    # data we actually had, not the model's internal representation. Facet
+    # context (resolved month name, DJ name) is included so a narrative that
+    # correctly mentions "January" or the DJ doesn't get penalized for using
+    # input the model was given.
+    score_input: dict = {
         "source": source_meta,
         "target": target_meta,
         "relationships": relationships,
         "shared_neighbors": shared_neighbors,
     }
+    if month is not None:
+        score_input["facet_month"] = MONTH_NAMES[month] if 1 <= month <= 12 else str(month)
+    if dj_name is not None:
+        score_input["facet_dj"] = dj_name
     token_score = _token_match_score(narrative, score_input)
 
     # Write to cache
@@ -910,5 +919,5 @@ def get_narrative(
         narrative=narrative,
         cached=False,
         token_match_score=token_score,
-        low_grounding=token_score >= _token_match_threshold(),
+        low_grounding=token_score > _token_match_threshold(),
     )

--- a/tests/unit/test_narrative.py
+++ b/tests/unit/test_narrative.py
@@ -1835,3 +1835,87 @@ class TestTokenMatchScorer:
         body = resp.json()
         assert body["low_grounding"] is True
         assert body["token_match_score"] > 0.0
+
+    @pytest.mark.asyncio
+    async def test_facet_month_name_counts_as_grounded(
+        self,
+        narrative_db_path: str,
+        narrative_artist_ids: dict[str, int],
+    ) -> None:
+        """A month-faceted narrative mentioning ``January`` shouldn't be penalized.
+
+        ``_build_prompt`` passes ``facet.month`` as the resolved name (``"January"``
+        for ``month=1``); the scorer must see the same so the model isn't
+        flagged for using the input data as instructed.
+        """
+        _clear_narrative_cache(narrative_db_path)
+        # Mock returns a narrative that says only allowlisted prose + the month name.
+        # If the scorer sees the facet, "January" is matched and the score is 0.
+        # If it doesn't, "January" is unmatched and the score is positive.
+        ungrounded_if_no_facet = "WXYC DJs pair these in January."
+        mock_client = _mock_anthropic_client(ungrounded_if_no_facet)
+        app = create_app(narrative_db_path, anthropic_api_key="test-key")
+        app.state.anthropic_client = mock_client
+        transport = ASGITransport(app=app)
+
+        ae_id = narrative_artist_ids["Autechre"]
+        sl_id = narrative_artist_ids["Stereolab"]
+
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get(
+                f"/graph/artists/{ae_id}/explain/{sl_id}/narrative", params={"month": 1}
+            )
+        body = resp.json()
+        # Source/target names from the fixture ("Autechre", "Stereolab") and
+        # "January" are all in the input the model received. The narrative
+        # uses none of those names — only "January" — so the score reflects
+        # whether the facet field is in the score input.
+        assert body["token_match_score"] == 0.0
+
+    @pytest.mark.asyncio
+    async def test_low_grounding_strict_above_threshold(
+        self,
+        narrative_db_path: str,
+        narrative_artist_ids: dict[str, int],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A score equal to the threshold is *not* low_grounding (issue: 'above 0.5').
+
+        The boundary convention is strict greater-than — at exactly the
+        threshold, narratives count as acceptable. Lock this so a future swap
+        to ``>=`` trips the test.
+        """
+        # Generate a narrative with a known score, then set the threshold to that
+        # exact value and assert low_grounding is False.
+        _clear_narrative_cache(narrative_db_path)
+        # Narrative with one unmatched content word out of two → score = 0.5.
+        # ("WXYC", "DJs", "play" are allowlist; "Stereolab" matches input;
+        # "Beethoven" doesn't.)
+        partial = "WXYC DJs play Stereolab and Beethoven."
+        mock_client = _mock_anthropic_client(partial)
+        app = create_app(narrative_db_path, anthropic_api_key="test-key")
+        app.state.anthropic_client = mock_client
+        transport = ASGITransport(app=app)
+
+        ae_id = narrative_artist_ids["Autechre"]
+        sl_id = narrative_artist_ids["Stereolab"]
+
+        # First call to populate score, threshold doesn't matter.
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get(f"/graph/artists/{ae_id}/explain/{sl_id}/narrative")
+        score = resp.json()["token_match_score"]
+        assert score == pytest.approx(0.5, abs=1e-6), (
+            f"test relies on a score of exactly 0.5; got {score}"
+        )
+
+        # Set threshold to the exact score value; expect low_grounding to be False
+        # because the convention is strict above.
+        monkeypatch.setenv("NARRATIVE_TOKEN_MATCH_THRESHOLD", str(score))
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp2 = await ac.get(f"/graph/artists/{ae_id}/explain/{sl_id}/narrative")
+        body = resp2.json()
+        assert body["cached"] is True, "second call should hit the cache"
+        assert body["token_match_score"] == pytest.approx(score, abs=1e-6)
+        assert body["low_grounding"] is False, (
+            "score == threshold should NOT trigger low_grounding (convention is strict above)"
+        )


### PR DESCRIPTION
Follow-up to #266. Three of the review findings were actionable; two were confirmed harmless on inspection.

## Real fix: facet fields missing from score input

\`_build_prompt\` puts the resolved \`facet.month\` (e.g. \"January\") and \`facet.dj\` into the prompt JSON the model sees, but the scorer's \`score_input\` only had source/target/relationships/shared_neighbors. A narrative correctly mentioning \"January\" against an input with \`month=1\` was therefore unfairly flagged as ungrounded — the integer \`1\` was in the input pool but the month name wasn't.

Fix: include \`facet_month\` (resolved name) and \`facet_dj\` in \`score_input\` whenever the facet is set. \`test_facet_month_name_counts_as_grounded\` locks the fix.

## Boundary semantics: strict above

Issue text says \"score above threshold (0.5) returns a flag\" — strict \`>\`. Implementation was using \`>=\`. A score of exactly 0.5 was flipping the flag in violation of spec. Switched both the cache-hit and fresh-generation sites to \`>\`. \`test_low_grounding_strict_above_threshold\` runs a generation that produces a known score, then sets the env var to that exact value and asserts \`low_grounding\` stays False.

This test doubles as the cache-roundtrip lock the review called out as a coverage gap — it asserts \`cached: True\` and that the score reads back equal on the second call.

## Comment on the insufficient-signal short-circuit

The canned-narrative path writes \`token_match_score=0.0\` by default. Added an inline comment explaining this is intentional: the canned narrative is grounded by construction (we wrote it), so the scorer isn't run on it.

## Confirmed harmless on inspection

- **Stemmer overstems short words.** \`_stem(\"play\")\` → \`\"pla\"\`, \`_stem(\"show\")\` → \`\"sho\"\`. None of these words actually reach the stemmer because they're all in \`_TOKEN_MATCH_ALLOWLIST\` and excluded from \`content_words\` before stemming. No fix needed unless \`_stem\` grows other callers.
- **\`json.dumps\` flattening pulls structural keys into the matched-words pool.** \`shared_neighbors\` splits to \`[\"shared\", \"neighbors\"]\` (regex is \`[A-Za-z]+\`, no \`_\`); both are already allowlisted. Other JSON keys (\`source\`, \`name\`, \`type\`) are stopword-shaped and unlikely to appear in narrative prose. Roundabout but not a functional issue.

## Tests

74 → 76 passing. Two new tests:
- \`test_facet_month_name_counts_as_grounded\`
- \`test_low_grounding_strict_above_threshold\` (also covers the cache round-trip)

## Test plan

- [x] \`ruff check .\` passes
- [x] \`ruff format --check .\` passes
- [x] \`mypy semantic_index/\` passes
- [x] \`pytest tests/unit/test_narrative.py\` — 76 passed
- [ ] CI green