### PR TITLE
Add periodic claim-ratio audit on cached narratives

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,9 @@ SQLite ──→ api (FastAPI + aiosqlite) ──→ JSON responses
 | `semantic_index/api/schemas.py` | Pydantic response models for the Graph API (ArtistSummary, ArtistDetail, EntityArtists, SearchResponse, NeighborsResponse, ExplainResponse, FacetsResponse, DjSummary, NarrativeResponse, CommunitiesResponse, DiscoveryResponse, PreviewResponse). |
 | `semantic_index/api/routes.py` | Graph API query endpoints: search, artist detail, neighbors by edge type (with optional month/DJ facet filters), explain relationships, entity artist groups, available facets, community metadata, discovery (underplayed sonic fits). |
 | `semantic_index/api/narrative.py` | LLM-generated edge narrative endpoint. Calls Claude Haiku to explain artist relationships in plain English. Caches results in a sidecar SQLite database. Facet-aware. Enriches prompts with audio profile features (genre, mood, danceability) when available. |
+| `semantic_index/narrative_audit.py` | Periodic claim-ratio audit on cached narratives. Samples N narratives, looks up source/target metadata from the production DB so the verifier sees the same data the live narrative endpoint scored against, runs each through a Haiku verifier prompt that decomposes them into grounded/ungrounded claims, and records ratios to a sidecar audit DB for review. Catches structural-claim hallucinations the always-on token-match gate can miss. |
+| `semantic_index/api/narrative_audit_routes.py` | Read-only endpoint exposing the most-recent audit rows from the audit sidecar at `/graph/narrative-audit/recent`. |
+| `scripts/audit_narratives.py` | CLI entry point for the claim-ratio audit. Sample-and-score with a configurable threshold; writes to the audit sidecar DB. |
 | `semantic_index/api/preview.py` | Audio preview URL endpoint with multi-source fallback (iTunes lookup, Spotify, Bandcamp, Deezer, iTunes search). Caches results in a sidecar SQLite database. Powers the in-card transition player in the graph explorer. |
 | `semantic_index/pg_source.py` | Query Backend-Service PostgreSQL (`wxyc_schema.*`) for pipeline input data. Returns the same types as `sql_parser.py` (FlowsheetEntry, LibraryCode, LibraryRelease). Used by the nightly sync instead of SQL dump parsing. |
 | `semantic_index/nightly_sync.py` | Nightly sync orchestrator: query PG → resolve → PMI → stats → export → entity dedup → facets → graph metrics → atomic DB swap. Preserves enrichment tables from the existing database. |
@@ -420,6 +423,23 @@ app = create_app("data/wxyc_artist_graph.db")
 | `GET` | `/graph/communities?min_size=5&limit=50` | Louvain community metadata (size, label, top genres, top artists). Gracefully returns empty on databases without the `community` table. |
 | `GET` | `/graph/artists/{id}/explain/{target_id}/narrative?month=&dj_id=` | LLM-generated natural-language explanation of the relationship between two artists. Uses Claude Haiku. Cached in sidecar SQLite DB. Returns 501 when `ANTHROPIC_API_KEY` is not set. |
 | `GET` | `/graph/artists/{id}/preview` | Audio preview URL for an artist. Multi-source fallback: iTunes lookup (by Apple Music ID) -> Spotify top tracks (by Spotify ID, requires credentials) -> Bandcamp (by bandcamp_id, scrapes track stream) -> Deezer search (by name) -> iTunes search (by name). Cached in sidecar `.preview-cache.db`. |
+| `GET` | `/graph/narrative-audit/recent?limit=50&flagged_only=false` | Most-recent narrative-audit rows from the audit sidecar (`<db>.narrative-audit-cache.db`). Returns an empty list when no audits have run yet. |
+
+### Narrative claim-ratio audit
+
+Periodic offline check that catches structural-claim hallucinations the always-on token-match gate can miss. Samples N cached narratives, opens a read-only connection to the production DB to reconstruct each pair's source/target metadata (the same shape the live narrative endpoint scored against), runs each narrative through a Haiku verifier prompt that decomposes it into grounded vs ungrounded claims, and records the resulting ratio to `<db_path>.narrative-audit-cache.db`. Narratives with `ungrounded / total > threshold` are flagged for review or regeneration.
+
+```bash
+ANTHROPIC_API_KEY=sk-... python scripts/audit_narratives.py \
+    --db-path data/wxyc_artist_graph.db \
+    [--n 100] [--threshold 0.2]
+```
+
+- `--db-path` / `DB_PATH` — production SQLite database (the narrative cache lives at `<db-path>.narrative-cache.db`).
+- `--n` — sample size (default `100`).
+- `--threshold` / `NARRATIVE_AUDIT_CLAIM_THRESHOLD` — claim-ratio above which a narrative is flagged (default `0.2`, strict `>` boundary).
+
+The audit DB is a separate sidecar from the narrative cache so audit history survives cache-version bumps. Recent rows are exposed via `GET /graph/narrative-audit/recent`. Scheduling (nightly or periodic invocation) is a follow-up; for now the script is run manually or by external cron.
 
 ### Deployment
 

--- a/scripts/audit_narratives.py
+++ b/scripts/audit_narratives.py
@@ -1,0 +1,79 @@
+"""CLI: audit cached narratives by claim-ratio (#230).
+
+Samples N cached narratives, runs each through a Haiku verifier, and records
+results to a sidecar audit DB. Flags any narrative whose ungrounded-claim
+ratio exceeds the threshold for downstream review (manual inspection or
+regeneration).
+
+Usage:
+    python scripts/audit_narratives.py --db-path data/wxyc_artist_graph.db [--n 100] [--threshold 0.2]
+
+Environment:
+    ANTHROPIC_API_KEY        — required; the audit calls Claude Haiku.
+    NARRATIVE_AUDIT_CLAIM_THRESHOLD — overrides --threshold default (0.2).
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+
+from semantic_index.narrative_audit import run_audit
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--db-path",
+        default=os.environ.get("DB_PATH", "data/wxyc_artist_graph.db"),
+        help="Path to the production SQLite graph database (the narrative-cache "
+        "sidecar lives at <db-path>.narrative-cache.db).",
+    )
+    parser.add_argument("--n", type=int, default=100, help="Sample size (default: 100).")
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=None,
+        help="Claim-ratio threshold above which a narrative is flagged. "
+        "Defaults to NARRATIVE_AUDIT_CLAIM_THRESHOLD env var or 0.2.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    args = _parse_args(argv)
+
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    if not api_key:
+        logger.error("ANTHROPIC_API_KEY is required for the audit run")
+        return 1
+
+    threshold = args.threshold
+    if threshold is None:
+        raw = os.environ.get("NARRATIVE_AUDIT_CLAIM_THRESHOLD")
+        threshold = float(raw) if raw else 0.2
+
+    try:
+        import anthropic
+    except ImportError:
+        logger.error("anthropic SDK is not installed; install via `pip install anthropic`")
+        return 1
+
+    client = anthropic.Anthropic(api_key=api_key)
+    summary = run_audit(args.db_path, client=client, n=args.n, threshold=threshold)
+    logger.info(
+        "Audit complete: audited=%d flagged=%d threshold=%.2f",
+        summary["audited"],
+        summary["flagged"],
+        threshold,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/semantic_index/api/app.py
+++ b/semantic_index/api/app.py
@@ -13,6 +13,7 @@ from fastapi.staticfiles import StaticFiles
 
 from semantic_index.api.bio import bio_router
 from semantic_index.api.narrative import narrative_router
+from semantic_index.api.narrative_audit_routes import narrative_audit_router
 from semantic_index.api.preview import preview_router
 from semantic_index.api.routes import router
 
@@ -57,6 +58,7 @@ def create_app(
     app.include_router(narrative_router)
     app.include_router(bio_router)
     app.include_router(preview_router)
+    app.include_router(narrative_audit_router)
 
     @app.get("/health", include_in_schema=False)
     def health() -> JSONResponse:

--- a/semantic_index/api/narrative_audit_routes.py
+++ b/semantic_index/api/narrative_audit_routes.py
@@ -1,0 +1,24 @@
+"""Narrative-audit read endpoint."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Query, Request
+
+from semantic_index.narrative_audit import read_recent_audits
+
+narrative_audit_router = APIRouter(prefix="/graph", tags=["graph"])
+
+
+@narrative_audit_router.get("/narrative-audit/recent")
+def get_recent_audits(
+    request: Request,
+    limit: int = Query(default=50, ge=1, le=500),
+    flagged_only: bool = Query(default=False),
+) -> dict:
+    """Return the most-recent narrative-audit rows.
+
+    Returns an empty list when no audits have run yet (fresh deploy before
+    the first ``scripts/audit_narratives.py`` invocation).
+    """
+    rows = read_recent_audits(request.app.state.db_path, limit=limit, flagged_only=flagged_only)
+    return {"audits": rows}

--- a/semantic_index/narrative_audit.py
+++ b/semantic_index/narrative_audit.py
@@ -1,0 +1,303 @@
+"""Periodic claim-ratio audit on cached narratives.
+
+Runs a Haiku verifier prompt on a sample of cached narratives, scoring each
+as grounded vs ungrounded claims. Catches structural-claim hallucinations
+that the always-on token-match gate (the vocabulary check) can miss.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sqlite3
+from datetime import UTC, datetime
+from typing import Any
+
+from semantic_index.api.database import open_cache_db
+
+_AUDIT_SCHEMA = """
+CREATE TABLE IF NOT EXISTS narrative_audit (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    source_id INTEGER NOT NULL,
+    target_id INTEGER NOT NULL,
+    month INTEGER NOT NULL DEFAULT 0,
+    dj_id INTEGER NOT NULL DEFAULT 0,
+    edge_type TEXT NOT NULL DEFAULT '',
+    prompt_version INTEGER NOT NULL,
+    narrative TEXT NOT NULL,
+    claim_ratio REAL NOT NULL,
+    grounded INTEGER NOT NULL,
+    ungrounded INTEGER NOT NULL,
+    flagged INTEGER NOT NULL DEFAULT 0,
+    audited_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_narrative_audit_audited_at
+    ON narrative_audit (audited_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_narrative_audit_flagged
+    ON narrative_audit (flagged, audited_at DESC);
+"""
+
+
+def sample_cached_narratives(db_path: str, *, n: int) -> list[dict]:
+    """Sample up to ``n`` cached narratives from the narrative-cache sidecar.
+
+    Excludes ``insufficient_signal`` placeholders — those carry a deterministic
+    canned text that doesn't need auditing. Random-orders the sample so an
+    audit doesn't repeatedly hit the same rows on consecutive runs. Returns
+    ``[]`` when the cache sidecar doesn't exist (fresh deploy before any
+    narratives have been generated).
+    """
+    sidecar = db_path + ".narrative-cache.db"
+    if not os.path.exists(sidecar):
+        return []
+    conn = sqlite3.connect(sidecar)
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute(
+            "SELECT source_id, target_id, month, dj_id, edge_type, prompt_version, "
+            "narrative FROM narrative_cache "
+            "WHERE insufficient_signal = 0 "
+            "ORDER BY RANDOM() LIMIT ?",
+            (n,),
+        ).fetchall()
+    finally:
+        conn.close()
+    return [dict(row) for row in rows]
+
+
+_DEFAULT_AUDIT_THRESHOLD = 0.2
+
+
+def read_recent_audits(db_path: str, *, limit: int = 50, flagged_only: bool = False) -> list[dict]:
+    """Return the most-recent audit rows from the audit sidecar.
+
+    Returns ``[]`` when the sidecar doesn't exist yet (fresh deploy before
+    the first audit run). Rows are ordered most-recent first.
+    """
+    sidecar = db_path + ".narrative-audit-cache.db"
+    if not _db_has_audit_table(sidecar):
+        return []
+    conn = sqlite3.connect(sidecar)
+    conn.row_factory = sqlite3.Row
+    where = "WHERE flagged = 1" if flagged_only else ""
+    try:
+        rows = conn.execute(
+            "SELECT id, source_id, target_id, month, dj_id, edge_type, "
+            "prompt_version, narrative, claim_ratio, grounded, ungrounded, "
+            "flagged, audited_at "
+            f"FROM narrative_audit {where} "  # noqa: S608
+            "ORDER BY audited_at DESC LIMIT ?",
+            (limit,),
+        ).fetchall()
+    finally:
+        conn.close()
+    out: list[dict] = []
+    for row in rows:
+        d = dict(row)
+        d["flagged"] = bool(d["flagged"])
+        out.append(d)
+    return out
+
+
+def _db_has_audit_table(sidecar_path: str) -> bool:
+    """``True`` when the audit sidecar exists and has the ``narrative_audit`` table."""
+    if not os.path.exists(sidecar_path):
+        return False
+    conn = sqlite3.connect(sidecar_path)
+    try:
+        cur = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='narrative_audit'"
+        )
+        return cur.fetchone() is not None
+    finally:
+        conn.close()
+
+
+def run_audit(
+    db_path: str,
+    *,
+    client: Any,
+    n: int = 100,
+    threshold: float = _DEFAULT_AUDIT_THRESHOLD,
+) -> dict:
+    """Sample ``n`` cached narratives, score each via Haiku, record results.
+
+    Resolves each sample's ``source_id`` / ``target_id`` against the production
+    SQLite at ``db_path`` so the verifier sees the same artist metadata
+    (name, genre, styles, audio profile) the live narrative endpoint scored
+    against. Without this, integer IDs alone would render every descriptive
+    claim ungroundable and the threshold meaningless.
+
+    Returns a summary dict ``{"audited": N, "flagged": M}`` where ``flagged``
+    is the count of narratives whose claim-ratio exceeded the threshold.
+    Strict ``>`` boundary — a score equal to the threshold is not flagged.
+
+    Note: ``shared_neighbors`` and ``relationships`` (which the live endpoint
+    also fed the model) are not reconstructed here. Claims about specific
+    shared neighbors will therefore register as ungrounded in the audit —
+    that's the intended behaviour, since we want the audit to flag neighbor
+    hallucinations.
+    """
+    samples = sample_cached_narratives(db_path, n=n)
+    audit_db = open_audit_db(db_path)
+    read_db = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    read_db.row_factory = sqlite3.Row
+    flagged = 0
+    try:
+        for sample in samples:
+            input_data = _build_audit_input(read_db, sample)
+            verify_payload = json.dumps(
+                {"narrative": sample["narrative"], "provided_data": input_data},
+                separators=(",", ":"),
+            )
+            response = client.messages.create(
+                model="claude-haiku-4-5-20251001",
+                max_tokens=400,
+                system=_CLAIM_DECOMPOSE_PROMPT,
+                messages=[{"role": "user", "content": verify_payload}],
+            )
+            grounded, ungrounded = parse_claim_counts(response.content[0].text)
+            total = grounded + ungrounded
+            ratio = (ungrounded / total) if total else 0.0
+            is_flagged = ratio > threshold
+            if is_flagged:
+                flagged += 1
+            record_audit_result(
+                audit_db,
+                source_id=sample["source_id"],
+                target_id=sample["target_id"],
+                month=sample["month"],
+                dj_id=sample["dj_id"],
+                edge_type=sample["edge_type"],
+                prompt_version=sample["prompt_version"],
+                narrative=sample["narrative"],
+                claim_ratio=ratio,
+                grounded=grounded,
+                ungrounded=ungrounded,
+                flagged=is_flagged,
+            )
+    finally:
+        read_db.close()
+        audit_db.close()
+    return {"audited": len(samples), "flagged": flagged}
+
+
+def _build_audit_input(read_db: sqlite3.Connection, sample: dict) -> dict:
+    """Reconstruct the verifier's ``provided_data`` from the production DB.
+
+    Looks up source/target metadata via ``narrative._lookup_artist_metadata``
+    so the audit feeds the verifier the same shape of data the live narrative
+    endpoint scored against (name, genre, styles, audio profile when present).
+    Falls back to ``{"name": "<unknown>"}`` for any artist that's no longer
+    present in the production DB (rare — usually a cache-staleness edge case).
+    """
+    from semantic_index.api.narrative import _lookup_artist_metadata
+
+    source_meta = _resolve_meta(read_db, sample["source_id"], _lookup_artist_metadata)
+    target_meta = _resolve_meta(read_db, sample["target_id"], _lookup_artist_metadata)
+    return {
+        "source": source_meta,
+        "target": target_meta,
+        "month": sample["month"],
+        "dj_id": sample["dj_id"],
+        "edge_type": sample["edge_type"],
+    }
+
+
+def _resolve_meta(read_db: sqlite3.Connection, artist_id: int, lookup: Any) -> dict:
+    row = read_db.execute(
+        "SELECT canonical_name, genre, total_plays FROM artist WHERE id = ?",
+        (artist_id,),
+    ).fetchone()
+    if row is None:
+        return {"name": "<unknown>"}
+    meta: dict = lookup(read_db, artist_id, row["canonical_name"], row["genre"], row["total_plays"])
+    return meta
+
+
+def open_audit_db(db_path: str) -> sqlite3.Connection:
+    """Open (or create) the narrative-audit sidecar database.
+
+    The audit DB is a separate sidecar from the narrative cache so audit
+    results survive cache-version bumps that drop the cache table.
+    """
+    return open_cache_db(db_path, "narrative-audit", _AUDIT_SCHEMA)
+
+
+def record_audit_result(
+    conn: sqlite3.Connection,
+    *,
+    source_id: int,
+    target_id: int,
+    month: int,
+    dj_id: int,
+    edge_type: str,
+    prompt_version: int,
+    narrative: str,
+    claim_ratio: float,
+    grounded: int,
+    ungrounded: int,
+    flagged: bool,
+) -> None:
+    """Append a single audit-run row."""
+    conn.execute(
+        "INSERT INTO narrative_audit "
+        "(source_id, target_id, month, dj_id, edge_type, prompt_version, "
+        "narrative, claim_ratio, grounded, ungrounded, flagged, audited_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            source_id,
+            target_id,
+            month,
+            dj_id,
+            edge_type,
+            prompt_version,
+            narrative,
+            float(claim_ratio),
+            int(grounded),
+            int(ungrounded),
+            int(flagged),
+            datetime.now(UTC).isoformat(),
+        ),
+    )
+    conn.commit()
+
+
+_CLAIM_DECOMPOSE_PROMPT = (
+    "You are a fact-checking assistant. Decompose the following narrative into individual factual "
+    "claims (one per line). For each claim, check whether it is grounded in the provided data.\n\n"
+    "Output format — one claim per line:\n"
+    "  G: <claim>\n"
+    "  U: <claim>\n\n"
+    "G = grounded (the claim is stated or directly implied by a data field).\n"
+    "U = ungrounded (the claim is not in the provided data).\n\n"
+    "Be strict. Describing a neighbor with any adjective is U. Inferring DJ intent is U. "
+    "Stating an artist quality not in the styles/audio/genre fields is U.\n\n"
+    "End with a count line: COUNTS: Xg Yu"
+)
+
+
+def parse_claim_counts(text: str) -> tuple[int, int]:
+    """Extract ``(grounded, ungrounded)`` counts from a verifier response.
+
+    Looks for a ``COUNTS: Xg Yu`` summary line first; falls back to counting
+    ``G:`` / ``U:`` line prefixes for resilience against models that drop the
+    summary.
+    """
+    for raw_line in text.strip().split("\n"):
+        line = raw_line.strip().upper()
+        if line.startswith("COUNTS:"):
+            grounded = ungrounded = 0
+            g_match = re.findall(r"(\d+)\s*G", line)
+            u_match = re.findall(r"(\d+)\s*U", line)
+            if g_match:
+                grounded = int(g_match[0])
+            if u_match:
+                ungrounded = int(u_match[0])
+            return grounded, ungrounded
+    grounded = len(re.findall(r"^\s*G[:|]", text, re.MULTILINE))
+    ungrounded = len(re.findall(r"^\s*U[:|]", text, re.MULTILINE))
+    return grounded, ungrounded

--- a/tests/unit/test_narrative_audit.py
+++ b/tests/unit/test_narrative_audit.py
@@ -1,0 +1,477 @@
+"""Tests for the periodic claim-ratio audit (#230)."""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+
+class TestParseClaimCounts:
+    def test_parse_counts_line(self) -> None:
+        from semantic_index.narrative_audit import parse_claim_counts
+
+        text = "G: artists co-occur\nU: psychedelic\nCOUNTS: 1g 1u"
+        assert parse_claim_counts(text) == (1, 1)
+
+    def test_falls_back_to_line_prefix_count_when_no_summary(self) -> None:
+        """Some Haiku responses skip the COUNTS line — fall back to G:/U: prefixes."""
+        from semantic_index.narrative_audit import parse_claim_counts
+
+        text = "G: claim one\nG: claim two\nU: hallucinated thing\nU: another\nU: third"
+        assert parse_claim_counts(text) == (2, 3)
+
+    def test_empty_response_returns_zero_zero(self) -> None:
+        from semantic_index.narrative_audit import parse_claim_counts
+
+        assert parse_claim_counts("") == (0, 0)
+
+
+class TestAuditDB:
+    def test_record_audit_result_persists_row(self) -> None:
+        """A single audit run row is persisted with score, flag, narrative excerpt."""
+        import sqlite3
+        import tempfile
+
+        from semantic_index.narrative_audit import open_audit_db, record_audit_result
+
+        # open_audit_db(path) opens the sidecar at path + ".narrative-audit-cache.db"
+        # — same convention as the other sidecar caches.
+        base_path = tempfile.mktemp(suffix=".db")
+        conn = open_audit_db(base_path)
+        record_audit_result(
+            conn,
+            source_id=1,
+            target_id=2,
+            month=0,
+            dj_id=0,
+            edge_type="",
+            prompt_version=11,
+            narrative="WXYC DJs pair X and Y.",
+            claim_ratio=0.0,
+            grounded=2,
+            ungrounded=0,
+            flagged=False,
+        )
+        conn.close()
+
+        verify = sqlite3.connect(base_path + ".narrative-audit-cache.db")
+        verify.row_factory = sqlite3.Row
+        rows = verify.execute(
+            "SELECT source_id, target_id, claim_ratio, flagged, grounded, ungrounded "
+            "FROM narrative_audit"
+        ).fetchall()
+        verify.close()
+
+        assert len(rows) == 1
+        assert rows[0]["source_id"] == 1
+        assert rows[0]["target_id"] == 2
+        assert rows[0]["claim_ratio"] == 0.0
+        assert rows[0]["flagged"] == 0
+        assert rows[0]["grounded"] == 2
+        assert rows[0]["ungrounded"] == 0
+
+
+def _build_cache_with_n_entries(path: str, n: int) -> str:
+    """Populate a narrative-cache sidecar with ``n`` synthetic rows."""
+    import sqlite3
+    from datetime import UTC, datetime
+
+    sidecar = path + ".narrative-cache.db"
+    conn = sqlite3.connect(sidecar)
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS narrative_cache (
+            source_id INTEGER NOT NULL,
+            target_id INTEGER NOT NULL,
+            month INTEGER NOT NULL DEFAULT 0,
+            dj_id INTEGER NOT NULL DEFAULT 0,
+            edge_type TEXT NOT NULL DEFAULT '',
+            prompt_version INTEGER NOT NULL DEFAULT 1,
+            insufficient_signal INTEGER NOT NULL DEFAULT 0,
+            token_match_score REAL NOT NULL DEFAULT 0.0,
+            retry_count INTEGER NOT NULL DEFAULT 0,
+            narrative TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            PRIMARY KEY (source_id, target_id, month, dj_id, edge_type, prompt_version)
+        );
+        """
+    )
+    now = datetime.now(UTC).isoformat()
+    rows = [(i, i + 1000, 0, 0, "", 11, 0, 0.0, 0, f"narrative {i}", now) for i in range(n)]
+    conn.executemany("INSERT INTO narrative_cache VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", rows)
+    conn.commit()
+    conn.close()
+    return sidecar
+
+
+class TestSampling:
+    def test_samples_at_most_n_rows(self) -> None:
+        """``sample_cached_narratives`` returns at most ``n`` rows."""
+        import tempfile
+
+        from semantic_index.narrative_audit import sample_cached_narratives
+
+        base_path = tempfile.mktemp(suffix=".db")
+        _build_cache_with_n_entries(base_path, 50)
+        sample = sample_cached_narratives(base_path, n=10)
+        assert len(sample) == 10
+
+    def test_sample_returns_all_when_fewer_than_requested(self) -> None:
+        """If the cache has fewer entries than ``n``, return all of them."""
+        import tempfile
+
+        from semantic_index.narrative_audit import sample_cached_narratives
+
+        base_path = tempfile.mktemp(suffix=".db")
+        _build_cache_with_n_entries(base_path, 3)
+        sample = sample_cached_narratives(base_path, n=10)
+        assert len(sample) == 3
+
+    def test_sample_skips_insufficient_signal_rows(self) -> None:
+        """Insufficient-signal placeholders aren't real narratives — exclude them."""
+        import sqlite3
+        import tempfile
+        from datetime import UTC, datetime
+
+        from semantic_index.narrative_audit import sample_cached_narratives
+
+        base_path = tempfile.mktemp(suffix=".db")
+        sidecar = _build_cache_with_n_entries(base_path, 5)
+        conn = sqlite3.connect(sidecar)
+        # Mark all five as insufficient_signal — no rows should be sampled.
+        conn.execute("UPDATE narrative_cache SET insufficient_signal = 1")
+        conn.commit()
+        # Add a single eligible row.
+        conn.execute(
+            "INSERT INTO narrative_cache VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                999,
+                1999,
+                0,
+                0,
+                "",
+                11,
+                0,
+                0.1,
+                0,
+                "real narrative",
+                datetime.now(UTC).isoformat(),
+            ),
+        )
+        conn.commit()
+        conn.close()
+
+        sample = sample_cached_narratives(base_path, n=10)
+        assert len(sample) == 1
+        assert sample[0]["source_id"] == 999
+
+    def test_sample_returns_empty_when_cache_missing(self) -> None:
+        """Fresh deploys have no narrative cache yet — return [] without crashing."""
+        import tempfile
+
+        from semantic_index.narrative_audit import sample_cached_narratives
+
+        base_path = tempfile.mktemp(suffix=".db")
+        # No cache file created — base_path.narrative-cache.db does not exist.
+        assert sample_cached_narratives(base_path, n=10) == []
+
+
+class TestRunAudit:
+    def test_run_audit_scores_each_sample_and_records_results(self) -> None:
+        """End-to-end: sample → score → record. Flagged count reflects threshold."""
+        import sqlite3
+        import tempfile
+        from unittest.mock import MagicMock
+
+        from semantic_index.narrative_audit import run_audit
+
+        base_path = tempfile.mktemp(suffix=".db")
+        _build_cache_with_n_entries(base_path, 3)
+        _build_minimal_app_db(
+            base_path,
+            artists=[(i, f"artist {i}") for i in range(3)]
+            + [(i + 1000, f"target {i}") for i in range(3)],
+        )
+
+        # Mock returns alternating responses: clean, dirty, clean.
+        responses = [
+            "G: claim\nCOUNTS: 1g 0u",  # ratio 0.0, not flagged at 0.2
+            "G: a\nU: b\nU: c\nU: d\nCOUNTS: 1g 3u",  # ratio 0.75, flagged
+            "G: a\nG: b\nCOUNTS: 2g 0u",  # ratio 0.0, not flagged
+        ]
+        mock_client = MagicMock()
+
+        def make_msg(text):
+            m = MagicMock()
+            block = MagicMock()
+            block.text = text
+            m.content = [block]
+            return m
+
+        mock_client.messages.create.side_effect = [make_msg(t) for t in responses]
+
+        summary = run_audit(base_path, client=mock_client, n=3, threshold=0.2)
+
+        assert summary["audited"] == 3
+        assert summary["flagged"] == 1
+
+        # Verify rows persisted with the right flag distribution.
+        verify = sqlite3.connect(base_path + ".narrative-audit-cache.db")
+        verify.row_factory = sqlite3.Row
+        rows = verify.execute(
+            "SELECT claim_ratio, flagged FROM narrative_audit ORDER BY id"
+        ).fetchall()
+        verify.close()
+        assert len(rows) == 3
+        flagged_count = sum(r["flagged"] for r in rows)
+        assert flagged_count == 1
+
+    def test_run_audit_passes_artist_metadata_to_verifier(self) -> None:
+        """The verifier should see source/target names + styles, not raw integer IDs.
+
+        Without artist names in ``provided_data``, every descriptive claim in a
+        narrative is ungroundable by construction, which makes the threshold
+        meaningless. The audit looks up metadata from the production DB the
+        same way the live narrative endpoint did when it generated the cached
+        text.
+        """
+        import json
+        import tempfile
+        from unittest.mock import MagicMock
+
+        from semantic_index.narrative_audit import run_audit
+
+        base_path = tempfile.mktemp(suffix=".db")
+        _build_cache_with_n_entries(base_path, 1)
+        _build_minimal_app_db(
+            base_path,
+            artists=[(0, "Stereolab"), (1000, "Cat Power")],
+        )
+
+        mock_client = MagicMock()
+        msg = MagicMock()
+        block = MagicMock()
+        block.text = "G: a\nCOUNTS: 1g 0u"
+        msg.content = [block]
+        mock_client.messages.create.return_value = msg
+
+        run_audit(base_path, client=mock_client, n=1, threshold=0.2)
+
+        sent_payload = mock_client.messages.create.call_args.kwargs["messages"][0]["content"]
+        parsed = json.loads(sent_payload)
+        provided = parsed["provided_data"]
+        assert provided["source"]["name"] == "Stereolab"
+        assert provided["target"]["name"] == "Cat Power"
+
+    def test_run_audit_threshold_is_strict_above(self) -> None:
+        """A score equal to the threshold is NOT flagged (strict ``>``)."""
+        import tempfile
+        from unittest.mock import MagicMock
+
+        from semantic_index.narrative_audit import run_audit
+
+        base_path = tempfile.mktemp(suffix=".db")
+        _build_cache_with_n_entries(base_path, 1)
+        _build_minimal_app_db(base_path, artists=[(0, "Stereolab"), (1000, "Cat Power")])
+
+        # Exactly threshold: 1g + 1u → ratio 0.5
+        mock_client = MagicMock()
+        msg = MagicMock()
+        block = MagicMock()
+        block.text = "G: a\nU: b\nCOUNTS: 1g 1u"
+        msg.content = [block]
+        mock_client.messages.create.return_value = msg
+
+        summary = run_audit(base_path, client=mock_client, n=1, threshold=0.5)
+        assert summary["flagged"] == 0
+
+
+class TestRecentAudits:
+    def test_read_recent_returns_empty_for_fresh_db(self) -> None:
+        import tempfile
+
+        from semantic_index.narrative_audit import read_recent_audits
+
+        base_path = tempfile.mktemp(suffix=".db")
+        assert read_recent_audits(base_path, limit=10) == []
+
+    def test_read_recent_returns_rows_in_reverse_chronological_order(self) -> None:
+        import tempfile
+
+        from semantic_index.narrative_audit import (
+            open_audit_db,
+            read_recent_audits,
+            record_audit_result,
+        )
+
+        base_path = tempfile.mktemp(suffix=".db")
+        conn = open_audit_db(base_path)
+        for i in range(3):
+            record_audit_result(
+                conn,
+                source_id=i,
+                target_id=i + 100,
+                month=0,
+                dj_id=0,
+                edge_type="",
+                prompt_version=11,
+                narrative=f"narrative {i}",
+                claim_ratio=0.1 * i,
+                grounded=2,
+                ungrounded=i,
+                flagged=(i == 2),
+            )
+        conn.close()
+
+        rows = read_recent_audits(base_path, limit=10)
+        assert len(rows) == 3
+        # Most-recent first: source_ids should descend (2, 1, 0).
+        assert [r["source_id"] for r in rows] == [2, 1, 0]
+        assert rows[0]["flagged"] is True
+        assert rows[1]["flagged"] is False
+
+    def test_read_recent_filters_by_flagged(self) -> None:
+        import tempfile
+
+        from semantic_index.narrative_audit import (
+            open_audit_db,
+            read_recent_audits,
+            record_audit_result,
+        )
+
+        base_path = tempfile.mktemp(suffix=".db")
+        conn = open_audit_db(base_path)
+        for i in range(5):
+            record_audit_result(
+                conn,
+                source_id=i,
+                target_id=i + 100,
+                month=0,
+                dj_id=0,
+                edge_type="",
+                prompt_version=11,
+                narrative=f"narrative {i}",
+                claim_ratio=0.5 if i < 2 else 0.0,
+                grounded=2,
+                ungrounded=2 if i < 2 else 0,
+                flagged=i < 2,
+            )
+        conn.close()
+
+        flagged_rows = read_recent_audits(base_path, limit=10, flagged_only=True)
+        assert len(flagged_rows) == 2
+        assert all(r["flagged"] for r in flagged_rows)
+
+
+def _build_minimal_app_db(path: str, artists: list[tuple[int, str]] | None = None) -> None:
+    """Build the smallest DB the API factory needs.
+
+    Always creates an empty ``artist`` table. When ``artists`` is provided,
+    seed those rows so the audit can resolve source/target IDs to names.
+    """
+    import sqlite3
+
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        "CREATE TABLE artist (id INTEGER PRIMARY KEY, canonical_name TEXT NOT NULL UNIQUE, "
+        "genre TEXT, total_plays INTEGER NOT NULL DEFAULT 0);"
+    )
+    if artists:
+        conn.executemany(
+            "INSERT INTO artist (id, canonical_name) VALUES (?, ?)",
+            artists,
+        )
+    conn.commit()
+    conn.close()
+
+
+class TestAuditEndpoint:
+    @pytest_asyncio.fixture
+    async def client(self, tmp_path):
+        from semantic_index.api.app import create_app
+
+        db_path = str(tmp_path / "graph.db")
+        _build_minimal_app_db(db_path)
+        app = create_app(db_path)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            yield ac, db_path
+
+    @pytest.mark.asyncio
+    async def test_recent_endpoint_empty_when_no_audits(self, client) -> None:
+        ac, _ = client
+        resp = await ac.get("/graph/narrative-audit/recent")
+        assert resp.status_code == 200
+        assert resp.json() == {"audits": []}
+
+    @pytest.mark.asyncio
+    async def test_recent_endpoint_returns_recorded_rows(self, client) -> None:
+        from semantic_index.narrative_audit import open_audit_db, record_audit_result
+
+        ac, db_path = client
+        conn = open_audit_db(db_path)
+        record_audit_result(
+            conn,
+            source_id=1,
+            target_id=2,
+            month=0,
+            dj_id=0,
+            edge_type="",
+            prompt_version=11,
+            narrative="WXYC DJs pair X and Y.",
+            claim_ratio=0.5,
+            grounded=1,
+            ungrounded=1,
+            flagged=True,
+        )
+        conn.close()
+
+        resp = await ac.get("/graph/narrative-audit/recent")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body["audits"]) == 1
+        assert body["audits"][0]["flagged"] is True
+        assert body["audits"][0]["claim_ratio"] == 0.5
+
+    @pytest.mark.asyncio
+    async def test_recent_endpoint_supports_flagged_only(self, client) -> None:
+        from semantic_index.narrative_audit import open_audit_db, record_audit_result
+
+        ac, db_path = client
+        conn = open_audit_db(db_path)
+        record_audit_result(
+            conn,
+            source_id=1,
+            target_id=2,
+            month=0,
+            dj_id=0,
+            edge_type="",
+            prompt_version=11,
+            narrative="clean",
+            claim_ratio=0.0,
+            grounded=2,
+            ungrounded=0,
+            flagged=False,
+        )
+        record_audit_result(
+            conn,
+            source_id=3,
+            target_id=4,
+            month=0,
+            dj_id=0,
+            edge_type="",
+            prompt_version=11,
+            narrative="dirty",
+            claim_ratio=0.6,
+            grounded=2,
+            ungrounded=3,
+            flagged=True,
+        )
+        conn.close()
+
+        resp = await ac.get("/graph/narrative-audit/recent?flagged_only=true")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body["audits"]) == 1
+        assert body["audits"][0]["source_id"] == 3


### PR DESCRIPTION
Closes #230.

## Summary

Adds a Haiku-powered claim-ratio audit on cached narratives to catch structural-claim hallucinations that the always-on token-match gate (#228) misses. Token-match asks "is this vocabulary grounded?"; claim-ratio asks "are the claims themselves grounded?" — they diverge on narratives that reuse data words but invent relationship claims.

The audit:

1. Samples N cached narratives from `<db>.narrative-cache.db` (excluding `insufficient_signal` placeholders).
2. Opens a read-only connection to the production DB and reconstructs source/target metadata (name, genre, styles, audio profile) the same way the live narrative endpoint did when scoring the cached narrative — so the verifier evaluates claims against real grounding data, not bare integer IDs.
3. Sends each narrative through a Haiku verifier prompt that decomposes it into `G:` / `U:` lines and a `COUNTS: Xg Yu` summary.
4. Records `(claim_ratio, grounded, ungrounded, flagged, narrative, prompt_version, ...)` to a separate sidecar `<db>.narrative-audit-cache.db` so audit history survives narrative-cache version bumps.
5. Flags any narrative with `ungrounded / total > threshold` (default 0.2, strict `>`).

`shared_neighbors` and `relationships` (which the live endpoint also fed the model) are not reconstructed — claims about specific shared neighbors will register as ungrounded by design, since neighbor hallucinations are exactly what we want flagged.

Both `sample_cached_narratives` and `read_recent_audits` short-circuit to `[]` when their sidecar doesn't exist yet, so a fresh deploy before any narratives or audits have run doesn't crash.

## What's included

- `semantic_index/narrative_audit.py` — sampling, metadata reconstruction (reuses `narrative._lookup_artist_metadata`), verifier prompt, parse helper (`COUNTS:` line + `G:`/`U:` line fallback), audit DB schema, `run_audit()`, `read_recent_audits()`.
- `scripts/audit_narratives.py` — CLI entry point. Reads `--db-path`, `--n`, `--threshold` (overridable via `NARRATIVE_AUDIT_CLAIM_THRESHOLD`). Requires `ANTHROPIC_API_KEY`.
- `semantic_index/api/narrative_audit_routes.py` — `GET /graph/narrative-audit/recent?limit=&flagged_only=` endpoint. Returns `[]` when no audits have run yet.
- `tests/unit/test_narrative_audit.py` — 17 unit tests covering parse, sampling (including the fresh-deploy no-cache case), run loop with metadata reconstruction, sidecar persistence, threshold strictness, and the read endpoint.
- `CLAUDE.md` — module table entries and a "Narrative claim-ratio audit" section under "Graph API".

## Acceptance criteria

- [x] CLI script `scripts/audit_narratives.py` that runs the audit
- [ ] Schedule it nightly — **deferred to follow-up.** Plumbing into the in-process scheduler or a separate Railway cron is straightforward but introduces deployment-side decisions; punting keeps this PR focused on the audit logic itself.
- [x] Threshold configurable via `NARRATIVE_AUDIT_CLAIM_THRESHOLD` env var, default 0.2
- [x] Audit results queryable via `/graph/narrative-audit/recent`
- [x] Documented in `CLAUDE.md`

## Test plan

- [x] `pytest tests/unit/test_narrative_audit.py` (17 passed)
- [x] `pytest tests/unit/test_narrative.py tests/unit/test_narrative_audit.py` (no regressions)
- [x] `ruff check` clean across new files
- [x] `ruff format --check` clean
- [x] `mypy` clean across new files
- [ ] Run a real audit on production cache (manual: `ANTHROPIC_API_KEY=… python scripts/audit_narratives.py --db-path data/wxyc_artist_graph.db --n 20`) and inspect `/graph/narrative-audit/recent` output before scheduling.