### PR TITLE
Open API SQLite connections with mmap, larger cache, and read-only mode

### DIFF
--- a/semantic_index/api/database.py
+++ b/semantic_index/api/database.py
@@ -7,13 +7,32 @@ from contextlib import contextmanager
 
 from fastapi import Request
 
+_MMAP_BYTES = 1 << 30  # 1 GiB — covers the full graph database
+_CACHE_PAGES = -65536  # negative → KiB; 65536 = 64 MiB per connection
+
 
 @contextmanager
 def _open_db(db_path: str):
-    """Open a read-only SQLite connection, ensuring creation and close happen in the same thread."""
-    conn = sqlite3.connect(db_path, check_same_thread=False)
+    """Open a read-only SQLite connection, ensuring creation and close happen in the same thread.
+
+    Tuning rationale:
+    - ``mode=ro`` URI: true read-only open at the OS level. Lets SQLite skip
+      lock files and lets the OS keep file pages clean.
+    - ``mmap_size``: maps the database file. Mapped pages live in the OS page
+      cache and survive the connection close, so subsequent requests reuse
+      pages without disk I/O. Critical on memory-constrained hosts where the
+      per-connection page cache is too small to matter.
+    - ``cache_size``: bumps the per-connection page cache from 2 MiB to 64 MiB
+      so a single request that hits multiple edge tables reuses pages instead
+      of evicting them mid-query.
+    - ``query_only``: belt-and-suspenders — even with ``mode=ro``, this
+      guarantees no accidental writes from a misbehaving query.
+    """
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, check_same_thread=False)
     conn.row_factory = sqlite3.Row
-    conn.execute("PRAGMA query_only=ON")
+    conn.execute(f"PRAGMA mmap_size = {_MMAP_BYTES}")
+    conn.execute(f"PRAGMA cache_size = {_CACHE_PAGES}")
+    conn.execute("PRAGMA query_only = ON")
     try:
         yield conn
     finally:


### PR DESCRIPTION
## Why

After #270 and #271 collapsed the affinity batch to ~10 SQL queries, prod still showed a 1-21s spread for the Orbital affinity second-hop (4.58s in the screenshot the user just sent). Locally on the same DB and the same artist set the call takes ~7ms. The entire gap is cold-page disk I/O on EBS.

The connection setup in \`_open_db\` was the obvious culprit:

\`\`\`python
conn = sqlite3.connect(db_path, check_same_thread=False)
conn.row_factory = sqlite3.Row
conn.execute("PRAGMA query_only=ON")
\`\`\`

Default page cache is 2 MiB per connection, no mmap, not opened read-only. Each request opens fresh, fills 2 MiB, then closes — the OS page cache is the only thing protecting us against re-reading the same index pages on the next request, and on a memory-constrained host it can't.

## Change

Three pragmas in \`_open_db\`:

| Change | Effect |
|---|---|
| \`mode=ro\` URI | Matches what \`/health\` already uses. Lets SQLite skip lock files; lets the kernel keep file pages clean (eligible for fast eviction without writeback). |
| \`PRAGMA mmap_size = 1 GiB\` | Maps the 504 MiB graph DB. Mapped pages live in the OS page cache and survive connection close, so subsequent requests reuse them. Hint only — kernel only pages in what's accessed, safe on small instances. |
| \`PRAGMA cache_size = -65536\` (64 MiB) | A single affinity request fans out across 8 edge tables; 2 MiB isn't enough to hold the working set, so we were thrashing within a request. |

## Numbers

Local microbench is unchanged (warm cache fits in RAM either way). This is a prod-only win — the right test is to re-run the Orbital affinity URL after deploy and compare to the 4.58s baseline.

## Open question I noticed while profiling

The dominant I/O cost in affinity is \`acoustic_similarity\`: 2.8M rows total, ~135 edges per artist average (max 1376 — for Orbital's neighbor set, 5000 rows for 10 sources). But all similarity scores cluster between **0.97 and 1.0 (avg 0.977)**. After per-source max-normalization the dimension barely discriminates between neighbors. We're paying ~80% of the I/O cost for a near-uniform contribution. A pipeline-level fix (threshold-based pruning or top-K per artist) would shrink the table and the affinity query proportionally; left for a follow-up.

## Test plan

- [x] All API tests still pass (\`pytest tests/unit/test_api_routes.py tests/unit/test_api_faceted.py tests/unit/test_api.py tests/unit/test_api_discovery.py\` → 85 passed)
- [x] \`ruff check\`, \`ruff format --check\`, \`mypy\` — clean
- [ ] After deploy: re-time \`https://explore.wxyc.org/?artist=Orbital&edge=affinity&heat=1\`. Expect cold to drop from 4.58s into the 1s range; warm to stay near 700ms.