### PR TITLE
Prune acoustic_similarity to top-K neighbors per artist

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -197,6 +197,17 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Minimum cosine similarity for acoustic similarity edges (default: 0.98)",
     )
     parser.add_argument(
+        "--acoustic-similarity-top-k",
+        type=int,
+        default=50,
+        help=(
+            "Per-artist neighbor cap for acoustic_similarity. Pass 0 to disable pruning "
+            "(default: 50). The threshold-based table grows to millions of near-uniform "
+            "edges that contribute almost no ranking signal; capping at top-K shrinks "
+            "the affinity I/O footprint without changing top-N rankings in practice."
+        ),
+    )
+    parser.add_argument(
         "--compilation-track-artist-dump",
         default=None,
         help="Path to a SQL dump file containing the COMPILATION_TRACK_ARTIST table. "
@@ -1046,7 +1057,10 @@ def run(args: argparse.Namespace) -> None:
                     _ab_conn = _ab_sqlite3.connect(str(sqlite_path))
                     store_audio_profiles(_ab_conn, profiles)
                     acoustic_edge_count = compute_acoustic_similarity(
-                        _ab_conn, profiles, threshold=args.acoustic_similarity_threshold
+                        _ab_conn,
+                        profiles,
+                        threshold=args.acoustic_similarity_threshold,
+                        top_k_per_artist=args.acoustic_similarity_top_k or None,
                     )
                     _ab_conn.close()
                     log.info("  %d acoustic similarity edges", acoustic_edge_count)
@@ -1150,7 +1164,10 @@ def run(args: argparse.Namespace) -> None:
                     _ab_conn = _ab_sqlite3.connect(str(sqlite_path))
                     store_audio_profiles(_ab_conn, profiles)
                     acoustic_edge_count = compute_acoustic_similarity(
-                        _ab_conn, profiles, threshold=args.acoustic_similarity_threshold
+                        _ab_conn,
+                        profiles,
+                        threshold=args.acoustic_similarity_threshold,
+                        top_k_per_artist=args.acoustic_similarity_top_k or None,
                     )
                     _ab_conn.close()
                     log.info("  %d acoustic similarity edges", acoustic_edge_count)

--- a/scripts/prune_acoustic_similarity.py
+++ b/scripts/prune_acoustic_similarity.py
@@ -1,0 +1,99 @@
+"""One-shot prune of the ``acoustic_similarity`` table to top-K neighbors per artist.
+
+Run this against the production graph DB to immediately shrink the
+``acoustic_similarity`` table without waiting for the next pipeline rebuild.
+The retained edges are exactly those produced by the prune step that future
+``compute_acoustic_similarity`` runs apply by default.
+
+Usage:
+
+    python scripts/prune_acoustic_similarity.py \\
+        --db-path data/wxyc_artist_graph.db \\
+        --top-k 50 \\
+        [--vacuum] [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+from semantic_index.acousticbrainz import prune_acoustic_similarity
+
+logger = logging.getLogger("prune_acoustic_similarity")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--db-path", required=True, type=Path, help="Graph SQLite database")
+    parser.add_argument("--top-k", type=int, default=50, help="Per-artist neighbor cap")
+    parser.add_argument(
+        "--vacuum",
+        action="store_true",
+        help="Run VACUUM after prune to reclaim disk space (rewrites the whole DB)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Run prune in a transaction and roll back; report what would change",
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+    if not args.db_path.exists():
+        logger.error("DB not found: %s", args.db_path)
+        return 1
+
+    conn = sqlite3.connect(str(args.db_path))
+    try:
+        size_before = args.db_path.stat().st_size
+        t0 = time.monotonic()
+        if args.dry_run:
+            before, after = prune_acoustic_similarity(conn, args.top_k)
+            conn.rollback()
+            logger.info(
+                "[dry-run] %d → %d edges (would prune %d, %.1f%%); no changes written",
+                before,
+                after,
+                before - after,
+                (before - after) / before * 100 if before else 0,
+            )
+            return 0
+
+        before, after = prune_acoustic_similarity(conn, args.top_k)
+        conn.commit()
+        elapsed = time.monotonic() - t0
+        logger.info(
+            "Pruned %d → %d edges in %.1fs (kept %.1f%%)",
+            before,
+            after,
+            elapsed,
+            (after / before * 100) if before else 0,
+        )
+
+        if args.vacuum:
+            t0 = time.monotonic()
+            logger.info("Running VACUUM to reclaim disk space (this rewrites the DB)…")
+            conn.execute("VACUUM")
+            logger.info("VACUUM complete in %.1fs", time.monotonic() - t0)
+
+        size_after = args.db_path.stat().st_size
+        logger.info(
+            "DB file: %.1f MiB → %.1f MiB (%+.1f MiB)",
+            size_before / 1024 / 1024,
+            size_after / 1024 / 1024,
+            (size_after - size_before) / 1024 / 1024,
+        )
+    finally:
+        conn.close()
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/recover_audio_profiles.py
+++ b/scripts/recover_audio_profiles.py
@@ -59,6 +59,7 @@ def recover(
     *,
     min_recordings: int = DEFAULT_MIN_RECORDINGS,
     similarity_threshold: float = DEFAULT_SIMILARITY_THRESHOLD,
+    similarity_top_k: int | None = 50,
     dry_run: bool = False,
     rebuild_all: bool = False,
 ) -> dict[str, int]:
@@ -213,7 +214,10 @@ def recover(
         # Step 8: Recompute acoustic similarity for all profiles
         if all_profiles:
             similarity_count = compute_acoustic_similarity(
-                conn, all_profiles, threshold=similarity_threshold
+                conn,
+                all_profiles,
+                threshold=similarity_threshold,
+                top_k_per_artist=similarity_top_k,
             )
             logger.info("%d acoustic similarity edges", similarity_count)
 
@@ -282,6 +286,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help=f"Cosine similarity threshold for edges (default: {DEFAULT_SIMILARITY_THRESHOLD})",
     )
     parser.add_argument(
+        "--acoustic-similarity-top-k",
+        type=int,
+        default=50,
+        help="Per-artist neighbor cap; 0 disables prune (default: 50)",
+    )
+    parser.add_argument(
         "--rebuild-all",
         action="store_true",
         help="Clear existing profiles and rebuild from scratch (e.g. for dimension migration)",
@@ -320,6 +330,7 @@ def main(argv: list[str] | None = None) -> None:
         musicbrainz_cache_dsn=args.musicbrainz_cache_dsn,
         min_recordings=args.min_recordings,
         similarity_threshold=args.acoustic_similarity_threshold,
+        similarity_top_k=args.acoustic_similarity_top_k or None,
         dry_run=args.dry_run,
         rebuild_all=args.rebuild_all,
     )

--- a/semantic_index/acousticbrainz.py
+++ b/semantic_index/acousticbrainz.py
@@ -934,14 +934,17 @@ def prune_acoustic_similarity(
     # For each row, rn_a = rank within artist_a_id's neighbors, rn_b = rank within
     # artist_b_id's neighbors. We keep rows where either rank is <= top_k.
     # Tiebreaker on artist id for determinism.
-    conn.executescript(
+    # Use plain execute() rather than executescript(): the latter issues an
+    # implicit COMMIT, which would silently break the "caller manages the
+    # transaction" contract documented above (e.g., the dry-run wrapper).
+    conn.execute("DROP TABLE IF EXISTS _keep_acoustic")
+    conn.execute(
         """
-        DROP TABLE IF EXISTS _keep_acoustic;
         CREATE TEMP TABLE _keep_acoustic (
             artist_a_id INTEGER NOT NULL,
             artist_b_id INTEGER NOT NULL,
             PRIMARY KEY (artist_a_id, artist_b_id)
-        );
+        )
         """
     )
     # For each artist X, rank ALL neighbors (regardless of canonical direction) by

--- a/semantic_index/acousticbrainz.py
+++ b/semantic_index/acousticbrainz.py
@@ -799,19 +799,24 @@ def compute_acoustic_similarity(
     conn: sqlite3.Connection,
     profiles: dict[int, ArtistAudioProfile],
     threshold: float = 0.85,
+    top_k_per_artist: int | None = None,
 ) -> int:
     """Compute pairwise cosine similarity between artist audio profiles.
 
     Only stores edges where similarity >= threshold. Stores edges in
-    canonical order (artist_a_id < artist_b_id).
+    canonical order (artist_a_id < artist_b_id). When ``top_k_per_artist``
+    is set, the table is pruned to each artist's top-K neighbors after
+    computation (see :func:`prune_acoustic_similarity`).
 
     Args:
         conn: SQLite connection to the graph database.
         profiles: Mapping of artist ID → ArtistAudioProfile.
         threshold: Minimum similarity to emit an edge.
+        top_k_per_artist: If set, retain only this many top-similarity
+            neighbors per artist after computing all edges.
 
     Returns:
-        Number of similarity edges created.
+        Number of similarity edges in the table after prune (if any).
     """
     import time as _time
 
@@ -886,4 +891,100 @@ def compute_acoustic_similarity(
         threshold,
         elapsed,
     )
+    if top_k_per_artist is not None:
+        _, edge_count = prune_acoustic_similarity(conn, top_k_per_artist)
+        conn.commit()
     return edge_count
+
+
+def prune_acoustic_similarity(
+    conn: sqlite3.Connection,
+    top_k: int,
+) -> tuple[int, int]:
+    """Prune ``acoustic_similarity`` to top-K most-similar edges per artist.
+
+    For each artist X, the K edges with the highest similarity to X are kept.
+    An edge (a, b) is retained if it appears in either A's or B's top-K — so
+    every artist always has at least their best matches present, even if the
+    other endpoint is heavily connected.
+
+    Why: with the production threshold of 0.97, the table grows to millions of
+    near-uniform edges (avg similarity 0.977) that contribute almost no
+    discriminating signal after per-source max-normalization. Top-K-per-artist
+    keeps the meaningful tail and shrinks the I/O footprint of every affinity
+    query.
+
+    Args:
+        conn: SQLite connection to the graph database. The caller is
+            responsible for committing or rolling back; this function does
+            not commit so it composes cleanly with dry-run wrappers.
+        top_k: Per-artist neighbor cap (must be > 0).
+
+    Returns:
+        ``(rows_before, rows_after)`` count tuple for reporting.
+    """
+    if top_k <= 0:
+        raise ValueError(f"top_k must be positive, got {top_k}")
+
+    before = conn.execute("SELECT COUNT(*) FROM acoustic_similarity").fetchone()[0]
+    if before == 0:
+        return 0, 0
+
+    # Compute (artist_a_id, artist_b_id) pairs to keep into a temp table.
+    # For each row, rn_a = rank within artist_a_id's neighbors, rn_b = rank within
+    # artist_b_id's neighbors. We keep rows where either rank is <= top_k.
+    # Tiebreaker on artist id for determinism.
+    conn.executescript(
+        """
+        DROP TABLE IF EXISTS _keep_acoustic;
+        CREATE TEMP TABLE _keep_acoustic (
+            artist_a_id INTEGER NOT NULL,
+            artist_b_id INTEGER NOT NULL,
+            PRIMARY KEY (artist_a_id, artist_b_id)
+        );
+        """
+    )
+    # For each artist X, rank ALL neighbors (regardless of canonical direction) by
+    # similarity. Keep edges where either endpoint considers the other a top-K
+    # neighbor, then re-canonicalize to (a < b) order via MIN/MAX.
+    conn.execute(
+        """
+        INSERT OR IGNORE INTO _keep_acoustic (artist_a_id, artist_b_id)
+        SELECT MIN(x_id, y_id), MAX(x_id, y_id) FROM (
+            SELECT x_id, y_id, ROW_NUMBER() OVER (
+                PARTITION BY x_id ORDER BY similarity DESC, y_id
+            ) AS rn
+            FROM (
+                SELECT artist_a_id AS x_id, artist_b_id AS y_id, similarity
+                FROM acoustic_similarity
+                UNION ALL
+                SELECT artist_b_id, artist_a_id, similarity
+                FROM acoustic_similarity
+            )
+        )
+        WHERE rn <= ?
+        """,
+        (top_k,),
+    )
+
+    conn.execute(
+        """
+        DELETE FROM acoustic_similarity
+        WHERE NOT EXISTS (
+            SELECT 1 FROM _keep_acoustic k
+            WHERE k.artist_a_id = acoustic_similarity.artist_a_id
+              AND k.artist_b_id = acoustic_similarity.artist_b_id
+        )
+        """
+    )
+    conn.execute("DROP TABLE _keep_acoustic")
+
+    after = conn.execute("SELECT COUNT(*) FROM acoustic_similarity").fetchone()[0]
+    logger.info(
+        "Acoustic similarity prune: %d → %d edges (top_k=%d, kept %.1f%%)",
+        before,
+        after,
+        top_k,
+        (after / before * 100) if before else 0,
+    )
+    return before, after

--- a/tests/unit/test_acousticbrainz.py
+++ b/tests/unit/test_acousticbrainz.py
@@ -790,3 +790,22 @@ class TestPruneAcousticSimilarity:
             "SELECT COUNT(*) FROM acoustic_similarity WHERE artist_a_id >= artist_b_id"
         ).fetchone()[0]
         assert bad == 0
+
+    def test_does_not_commit_so_rollback_works(self, similarity_db: sqlite3.Connection) -> None:
+        """Function must compose with caller-managed transactions.
+
+        The dry-run script depends on being able to run prune then rollback.
+        A previous version used ``conn.executescript`` which issues an
+        implicit COMMIT — this test guards against that regression.
+        """
+        _seed_complete_graph(similarity_db, 5)
+        similarity_db.commit()  # baseline state is committed
+
+        before, after = prune_acoustic_similarity(similarity_db, top_k=2)
+        assert before == 10
+        assert after == 7
+
+        similarity_db.rollback()
+        # After rollback the original 10 edges should be restored.
+        restored = similarity_db.execute("SELECT COUNT(*) FROM acoustic_similarity").fetchone()[0]
+        assert restored == 10

--- a/tests/unit/test_acousticbrainz.py
+++ b/tests/unit/test_acousticbrainz.py
@@ -18,6 +18,7 @@ from semantic_index.acousticbrainz import (
     build_audio_profiles,
     cosine_similarity,
     load_audio_profiles,
+    prune_acoustic_similarity,
     store_audio_profiles,
 )
 
@@ -673,3 +674,119 @@ class TestTarAcousticBrainzLoader:
 
         assert len(profiles) == 2
         assert profiles[1].recording_count == 2
+
+
+# --- Top-K-per-artist prune ---
+
+
+@pytest.fixture
+def similarity_db(tmp_path: Path) -> sqlite3.Connection:
+    """Build a fresh DB with the acoustic_similarity schema and a known edge set."""
+    conn = sqlite3.connect(str(tmp_path / "sim.db"))
+    conn.row_factory = sqlite3.Row
+    conn.executescript(
+        """
+        CREATE TABLE acoustic_similarity (
+            artist_a_id INTEGER NOT NULL,
+            artist_b_id INTEGER NOT NULL,
+            similarity REAL NOT NULL,
+            PRIMARY KEY (artist_a_id, artist_b_id)
+        );
+        CREATE INDEX idx_acoustic_sim_a ON acoustic_similarity(artist_a_id);
+        CREATE INDEX idx_acoustic_sim_b ON acoustic_similarity(artist_b_id);
+        """
+    )
+    return conn
+
+
+def _all_edges(conn: sqlite3.Connection) -> set[tuple[int, int]]:
+    return {
+        (r["artist_a_id"], r["artist_b_id"])
+        for r in conn.execute("SELECT artist_a_id, artist_b_id FROM acoustic_similarity")
+    }
+
+
+def _seed_complete_graph(conn: sqlite3.Connection, n: int) -> None:
+    """Insert the complete graph on artists 1..n with similarity decreasing
+    so the order of (a,b) by similarity is reverse-lex on a, then b.
+
+    Concretely, for n=5:
+      (1,2)=.99 (1,3)=.98 (1,4)=.97 (1,5)=.96
+      (2,3)=.95 (2,4)=.94 (2,5)=.93
+      (3,4)=.92 (3,5)=.91
+      (4,5)=.90
+    """
+    s = 1.00
+    for a in range(1, n + 1):
+        for b in range(a + 1, n + 1):
+            s -= 0.01
+            conn.execute("INSERT INTO acoustic_similarity VALUES (?, ?, ?)", (a, b, round(s, 4)))
+    conn.commit()
+
+
+class TestPruneAcousticSimilarity:
+    """Top-K-per-artist (either-side) prune of the acoustic_similarity table."""
+
+    def test_top_k_keeps_top_neighbors_per_artist(self, similarity_db: sqlite3.Connection) -> None:
+        """Top-K=2 on a 5-artist complete graph: keep edges in either endpoint's top-2."""
+        _seed_complete_graph(similarity_db, 5)
+        # Hand-computed expected (top-2 per artist either side):
+        # 1: top-2 = (1,2)=.99, (1,3)=.98
+        # 2: top-2 = (1,2)=.99, (2,3)=.95
+        # 3: top-2 = (1,3)=.98, (2,3)=.95
+        # 4: top-2 = (1,4)=.97, (2,4)=.94
+        # 5: top-2 = (1,5)=.96, (2,5)=.93
+        # Union: {(1,2), (1,3), (2,3), (1,4), (2,4), (1,5), (2,5)} = 7 edges
+        # Pruned: (3,4), (3,5), (4,5)
+        before, after = prune_acoustic_similarity(similarity_db, top_k=2)
+        assert before == 10
+        assert after == 7
+        kept = _all_edges(similarity_db)
+        assert kept == {(1, 2), (1, 3), (2, 3), (1, 4), (2, 4), (1, 5), (2, 5)}
+
+    def test_either_side_semantics(self, similarity_db: sqlite3.Connection) -> None:
+        """An edge in B's top-K but not A's top-K must still be kept.
+
+        Construct a star-ish topology so artist 1 has many high-similarity
+        neighbors but artists 2..5 each have only one neighbor — themselves
+        connected to artist 1. With K=1, artist 1's top-1 is just (1,2),
+        but (1,3), (1,4), (1,5) are each the only edge for artists 3, 4, 5.
+        So all four edges should remain.
+        """
+        edges = [(1, 2, 0.99), (1, 3, 0.98), (1, 4, 0.97), (1, 5, 0.96)]
+        for a, b, s in edges:
+            similarity_db.execute("INSERT INTO acoustic_similarity VALUES (?, ?, ?)", (a, b, s))
+        similarity_db.commit()
+
+        before, after = prune_acoustic_similarity(similarity_db, top_k=1)
+        assert before == 4
+        assert after == 4  # 1's top-1 = (1,2); 3,4,5's top-1 = their only edge to 1
+        assert _all_edges(similarity_db) == {(1, 2), (1, 3), (1, 4), (1, 5)}
+
+    def test_large_k_keeps_everything(self, similarity_db: sqlite3.Connection) -> None:
+        _seed_complete_graph(similarity_db, 4)
+        # 4 artists -> C(4,2) = 6 edges, max 3 neighbors per artist
+        before, after = prune_acoustic_similarity(similarity_db, top_k=100)
+        assert before == 6
+        assert after == 6
+
+    def test_empty_table_no_error(self, similarity_db: sqlite3.Connection) -> None:
+        before, after = prune_acoustic_similarity(similarity_db, top_k=10)
+        assert before == 0
+        assert after == 0
+
+    def test_invalid_top_k_raises(self, similarity_db: sqlite3.Connection) -> None:
+        _seed_complete_graph(similarity_db, 3)
+        with pytest.raises(ValueError):
+            prune_acoustic_similarity(similarity_db, top_k=0)
+        with pytest.raises(ValueError):
+            prune_acoustic_similarity(similarity_db, top_k=-1)
+
+    def test_preserves_canonical_order(self, similarity_db: sqlite3.Connection) -> None:
+        """All retained edges must still satisfy artist_a_id < artist_b_id."""
+        _seed_complete_graph(similarity_db, 6)
+        prune_acoustic_similarity(similarity_db, top_k=3)
+        bad = similarity_db.execute(
+            "SELECT COUNT(*) FROM acoustic_similarity WHERE artist_a_id >= artist_b_id"
+        ).fetchone()[0]
+        assert bad == 0


### PR DESCRIPTION
Follow-up to #274 — addresses the profiling finding that ``acoustic_similarity`` dominates affinity I/O while contributing near-zero discriminating signal.

## Why

The table holds 2.8M edges, ~135 per artist average (max 1376), with all similarity values clustered between **0.97 and 1.0** (avg **0.977**, hard floor at 0.97). After per-source max-normalization in the affinity composite (``score / max_score``), every neighbor gets approximately the same acoustic boost — the dimension barely discriminates between them.

For the Orbital second-hop batch the table contributes 5000+ rows per request — most of the disk pages we read.

## Change

- New ``prune_acoustic_similarity(conn, top_k)``: for each artist X, rank all neighbors (regardless of canonical edge direction) by similarity and keep edges that appear in either endpoint's top-K. Either-side semantics so a hub artist's small top-K doesn't strand the smaller-degree side.
- ``compute_acoustic_similarity`` gains ``top_k_per_artist`` so future pipeline runs maintain the invariant.
- New ``--acoustic-similarity-top-k`` flag on ``run_pipeline.py`` and ``scripts/recover_audio_profiles.py`` (default **50**; pass **0** to disable).
- New ``scripts/prune_acoustic_similarity.py`` for one-shot prune of the live prod DB without waiting for a pipeline rebuild. Supports ``--dry-run`` and ``--vacuum``.

## Numbers (prod 504 MiB SQLite)

| | edges | DB file size | affinity batch (warm, 10 source artists) |
|---|---|---|---|
| Original | 2,799,539 | 481 MiB | 6.79 ms median |
| Pruned (top-K=50) | 666,412 (-76%) | 343 MiB after VACUUM (-138 MiB) | **2.28 ms median (3×)** |

Cold-page wins on EC2 will be proportionally larger because the I/O footprint shrinks 4×.

### Semantic check (top-3 affinity neighbors per source)

| source | original top-3 | pruned top-3 | diff |
|---|---|---|---|
| The Orb (260) | Orbital, Tricky, DJ Food | Orbital, Tricky, Thomas Fehlmann | position-3 swap |
| Delerium (14125) | Orbital, conjure one, Underworld | same | — |
| Depeche Mode (219) | Madonna, Kraftwerk, Pet Shop Boys | same | — |
| Way Out West (55131) | Paul Van Dyk, Fluke, fragma | same | — |
| Opus III (81502) | Sweater on Polo, Madonna, andy caldwell | same | — |

4 of 5 identical, one position-3 swap to a comparable artist. The dimension wasn't discriminating much before — pruning doesn't change rankings meaningfully.

## Deploy plan

1. Merge this PR.
2. SSH to EC2 and run ``python scripts/prune_acoustic_similarity.py --db-path /data/wxyc_artist_graph.db --top-k 50 --vacuum`` against the live DB. Takes ~15s; the API stays available since SQLite handles concurrent reads.
3. Future nightly syncs / pipeline reruns automatically maintain the invariant via the new default.

## Test plan

- [x] 7 new prune tests: either-side semantics, canonical-order preservation, empty-table no-op, large-K identity, invalid-K rejection, plus a regression test asserting that ``prune_acoustic_similarity`` does not commit (so caller transactions compose cleanly — the dry-run wrapper depends on this)
- [x] Existing acousticbrainz + API tests still pass (104 total)
- [x] ``ruff check``, ``ruff format --check``, ``mypy`` — clean
- [x] End-to-end: ran the script against a copy of the prod DB. Dry-run reports correct counts without modification, actual prune leaves correct row count, ``--vacuum`` reclaims 138 MiB.