### PR TITLE
Rescale acoustic_similarity above 0.97 saturation floor

### DIFF
--- a/semantic_index/api/routes.py
+++ b/semantic_index/api/routes.py
@@ -86,6 +86,13 @@ class EdgeSchema:
     affinity_type_name: str | None = None
 
 
+# Cosine similarity over per-artist audio feature centroids saturates: stored
+# values cluster in [0.97, 1.0] (production avg 0.977). Production uses an
+# inclusion threshold of 0.98; older data starts at 0.97. Below this floor the
+# acoustic dimension is treated as zero contribution to affinity.
+ACOUSTIC_SATURATION_FLOOR = 0.97
+
+
 EDGE_REGISTRY: dict[EdgeType, EdgeSchema] = {
     EdgeType.SHARED_STYLE: EdgeSchema(
         "shared_style",
@@ -131,7 +138,14 @@ EDGE_REGISTRY: dict[EdgeType, EdgeSchema] = {
         "acoustic_similarity",
         "similarity",
         ["similarity"],
-        affinity_score_expr="similarity",
+        # Without rescaling, per-set max-normalization gives every audio-covered
+        # neighbor a near-uniform contribution and the dimension behaves as a
+        # flat coverage bonus rather than a similarity signal. Map the saturated
+        # band into [0, 1] so contribution reflects distance above the floor.
+        affinity_score_expr=(
+            f"MAX(0, (similarity - {ACOUSTIC_SATURATION_FLOOR})"
+            f" / (1 - {ACOUSTIC_SATURATION_FLOOR}))"
+        ),
         affinity_weight=2.0,
     ),
 }

--- a/tests/unit/test_api_routes.py
+++ b/tests/unit/test_api_routes.py
@@ -435,6 +435,69 @@ class TestAffinityNeighbors:
         assert resp.status_code == 404
 
 
+class TestAffinityAcousticRescale:
+    """Acoustic similarity values cluster in 0.97-1.0; without rescaling, every
+    neighbor with audio coverage gets a near-identical contribution and the
+    dimension behaves as a flat coverage bonus rather than a similarity signal.
+
+    These tests pin the rescaled behavior: contributions should reflect distance
+    above the saturation floor (≈0.97), so a marginal neighbor (sim=0.972)
+    contributes much less than a top neighbor (sim=0.99).
+    """
+
+    @pytest_asyncio.fixture
+    async def acoustic_client(self) -> AsyncClient:
+        from tests.conftest import make_artist_stats
+
+        path = tempfile.mktemp(suffix=".db")
+        stats = {
+            "TestSource": make_artist_stats("TestSource", total_plays=10),
+            "TopMatch": make_artist_stats("TopMatch", total_plays=10),
+            "MidMatch": make_artist_stats("MidMatch", total_plays=10),
+            "MarginalMatch": make_artist_stats("MarginalMatch", total_plays=10),
+        }
+        export_sqlite(path, artist_stats=stats, pmi_edges=[], xref_edges=[], min_count=1)
+        conn = sqlite3.connect(path)
+        conn.executescript(
+            "CREATE TABLE IF NOT EXISTS acoustic_similarity ("
+            " artist_a_id INTEGER NOT NULL, artist_b_id INTEGER NOT NULL,"
+            " similarity REAL NOT NULL, PRIMARY KEY (artist_a_id, artist_b_id))"
+        )
+        ids = {r[1]: r[0] for r in conn.execute("SELECT id, canonical_name FROM artist")}
+        src = ids["TestSource"]
+        for name, sim in (("TopMatch", 0.99), ("MidMatch", 0.985), ("MarginalMatch", 0.972)):
+            a, b = sorted([src, ids[name]])
+            conn.execute("INSERT INTO acoustic_similarity VALUES (?, ?, ?)", (a, b, sim))
+        conn.commit()
+        conn.close()
+        app = create_app(path)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            yield ac, ids
+
+    @pytest.mark.asyncio
+    async def test_marginal_acoustic_neighbor_contributes_much_less_than_top(
+        self, acoustic_client: tuple[AsyncClient, dict[str, int]]
+    ) -> None:
+        client, ids = acoustic_client
+        resp = await client.get(
+            f"/graph/artists/{ids['TestSource']}/neighbors",
+            params={"type": "affinity", "limit": 10},
+        )
+        assert resp.status_code == 200
+        weights = {n["artist"]["canonical_name"]: n["weight"] for n in resp.json()["neighbors"]}
+        assert set(weights) == {"TopMatch", "MidMatch", "MarginalMatch"}
+        # The dimension should discriminate: marginal must lag well behind top.
+        # Pre-rescale: all three weights cluster at ~1.96. Post-rescale: top ≈ 2.0,
+        # marginal should drop to ≤ 50% of top because (0.972-0.97)/(0.99-0.97) ≈ 0.1.
+        assert weights["MarginalMatch"] < weights["TopMatch"] * 0.5, (
+            f"Acoustic similarity is saturated — marginal weight {weights['MarginalMatch']} "
+            f"is too close to top weight {weights['TopMatch']}; expected the rescaled dimension "
+            f"to spread contributions by distance above the 0.97 saturation floor."
+        )
+        # Order is still preserved: top > mid > marginal.
+        assert weights["TopMatch"] > weights["MidMatch"] > weights["MarginalMatch"]
+
+
 class TestBatchNeighbors:
     @pytest.mark.asyncio
     async def test_batch_returns_results_per_artist(


### PR DESCRIPTION
## Summary

- Cosine similarity over per-artist 59-dim feature centroids saturates at 0.97–1.0 (avg 0.977 across 2.8M edges). After per-set max-normalization, every audio-covered neighbor was getting ~+1.96 from the dimension regardless of how acoustically similar they actually were — a flat coverage bonus, not a similarity signal. This biased affinity toward well-documented IDM-adjacent artists at the expense of WXYC-defining picks (Fursaxa, Carl Stone, Tangerine Dream, Growing) that lack AcousticBrainz coverage.
- Fix: rescale inside \`affinity_score_expr\` — \`MAX(0, (similarity - 0.97) / 0.03)\`. Maps the saturated band into [0, 1] so contribution reflects distance above the floor. Single edit covers both single and batch affinity codepaths since they share \`EDGE_REGISTRY\`. Preserves the underlying table for \`/explain\` and \`/narrative\` (which query raw edges directly).

Closes #276

## Empirical effect on prod DB (Autechre top-15 affinity)

| | Before | After |
|---|---|---|
| Tangerine Dream (3 plays, PMI 5.02) | dropped | **#12** |
| Fursaxa (3 plays, PMI 4.94) | dropped | **#13** |
| Mount Kimbie (2 plays, PMI 3.08) | #7 | dropped |
| Giuseppe Ielasi (2 plays, PMI 4.79) | #9 | dropped |
| Kid 606 (2 plays, PMI 4.30) | #11 | #15 |
| Aphex Twin | #1 | #1 unchanged |
| Acoustic-contributing in top-15 | 9 | 5 |

Aphex Twin remains #1 (DJ-driven). The IDM consensus (Pan Sonic, Matmos, Boards of Canada, Squarepusher) is still represented but no longer crowds out distinctive picks.

## Test plan

- [x] New \`TestAffinityAcousticRescale\` pins desired behavior: three acoustic-only neighbors at sim 0.99 / 0.985 / 0.972 must produce meaningfully spread weights; marginal must be < 50% of top. Confirmed failing pre-fix (1.964 vs 2.0), passing post-fix.
- [x] Full \`tests/unit/test_api_routes.py\` (51 tests) passes — no regressions to existing affinity behavior.
- [x] ruff check + ruff format clean (pre-commit hooks pass).
- [x] mypy clean.
- [x] Manual sanity check on prod DB confirms Autechre's neighborhood shifts as expected.

## Out of scope

Other enrichment dimensions and the broader DJ-vs-enrichment weight balance (the generate-vs-mirror tradeoff that could be exposed via the heat slider) are not addressed here — they depend on having a working acoustic dimension first.