### PR TITLE
Add narrative eval-set tooling

### DIFF
--- a/scripts/eval/README.md
+++ b/scripts/eval/README.md
@@ -1,0 +1,118 @@
+# Narrative Eval Set
+
+Tooling for building a labeled corpus of WXYC narrative-endpoint outputs. The eval set is the yardstick that lets every downstream narrative-enrichment epic (review descriptors, embeddings, constraint ontology) claim a real lift in narrative wrongness rather than only nudging proxy scores like token-match or claim-ratio.
+
+See `docs/narrative-enrichment-whitepaper.md` Section 11.3 for the motivation: existing scoring methods measure *grounding fidelity* (how closely a narrative hews to the literal data fields), not *truthiness*. Section 7.3's control-group inversion isn't a calibration bug — it's the methods doing what they were designed to do, which is the wrong thing. A human-labeled set lets us measure what we actually care about.
+
+## Pipeline
+
+```
+sample_pairs.py        -> output/eval/eval_pairs.jsonl        (stratified candidates)
+generate_narratives.py -> output/eval/eval_narratives.jsonl   (production narratives)
+build_wrong_set.py     -> output/eval/eval_wrong.jsonl        (data-shuffle gold positives)
+export_labeling.py     -> output/eval/labeling.csv + .jsonl   (labeler-ready sheet)
+```
+
+The backscoring pass (`backscore.py`, planned) is not in the MVP — it's gated on the labeling round itself, since until we have human labels there is nothing to backscore against. Field-corruption and pretraining-bait wrong-set constructions are also deferred; they're a smaller increment than data-shuffle and can be added once labeling proves the rubric is consistent.
+
+## Stratification
+
+Pairs are stratified across 16 cells:
+
+- **fame**: HIGH (`total_plays > 800`) | LOW (100..400 inclusive)
+- **richness**: RICH (≥3 styles AND audio profile) | THIN (≤2 styles OR no audio)
+- **genre**: CROSS (different genre) | SAME (same genre)
+- **edge**: DIRECT (`dj_transition.raw_count >= 2`) | INDIRECT (no edge, AA-sum ≥ 0.8)
+
+The whitepaper's Section 6.2 used a 2×2×2 matrix (fame × richness × genre). We added the edge axis because a narrative for a directly-transitioning pair has access to a `relationships.djTransition` field while an indirect pair does not — the prompt shape is meaningfully different and any wrongness analysis should be able to distinguish the two.
+
+The fame band's mid-range (`401..800`) is intentionally excluded so the HIGH/LOW distinction stays sharp. Mid-band artists are common (~half the catalog) but they obscure whether fame is actually the operative variable.
+
+## Per-cell capacity
+
+The four LOW-INDIRECT cells starve at sample time — LOW-fame artists (100-400 plays) typically don't have the rich shared-neighbor structure to clear the AA-sum threshold of 0.8. Several LOW-DIRECT cells also produce `insufficient_signal` canned narratives because their direct edges are not backed by enough shared-neighbor structure to clear the same threshold. Both behaviors mirror what the production endpoint does, so the eval set faithfully represents user-visible reality.
+
+The current corpus has 252 production narratives spread across all 16 cells (HIGH cells average ~16 each, LOW cells more variable, with ~80 `insufficient_signal` canned placeholders concentrated in LOW-DIRECT). The cell counts are uneven because the corpus accumulated across two sampler runs (the second after the self-loop bug fix); rather than re-trim, we kept the full pool because more labelable data is good. Plus 30 deliberately-wrong rows from `build_wrong_set.py`, total 282 labelable rows.
+
+## Running it
+
+```bash
+# 1. Sample pairs across the matrix.
+python -m scripts.eval.sample_pairs \
+    --db-path data/wxyc_artist_graph.db \
+    --out output/eval/eval_pairs.jsonl \
+    --per-cell 12
+
+# 2. Generate narratives via the production endpoint (cache populates as a side
+#    effect — same path users hit). Requires ANTHROPIC_API_KEY.
+ANTHROPIC_API_KEY=sk-... python -m scripts.eval.generate_narratives \
+    --db-path data/wxyc_artist_graph.db \
+    --pairs output/eval/eval_pairs.jsonl \
+    --out output/eval/eval_narratives.jsonl
+
+# 3. Build deliberately-wrong narratives (data-shuffle: real names + mismatched
+#    metadata). These are gold positives — every row is wrong by construction.
+ANTHROPIC_API_KEY=sk-... python -m scripts.eval.build_wrong_set \
+    --db-path data/wxyc_artist_graph.db \
+    --narratives output/eval/eval_narratives.jsonl \
+    --out output/eval/eval_wrong.jsonl \
+    --n 30
+
+# 4. Export a labeling sheet (CSV for Sheets + JSONL for downstream analysis).
+python -m scripts.eval.export_labeling \
+    --db-path data/wxyc_artist_graph.db \
+    --narratives output/eval/eval_narratives.jsonl \
+    --wrong output/eval/eval_wrong.jsonl \
+    --csv-out output/eval/labeling.csv \
+    --jsonl-out output/eval/labeling.jsonl
+```
+
+Re-runs are safe: `generate_narratives.py` supports `--skip-cached`, and the underlying narrative cache uses prompt-version-keyed entries so old rows from earlier prompts stay on disk but don't interfere.
+
+## Labeling
+
+The CSV is sized for Google Sheets. Columns:
+
+- `row_id` — stable identifier; preserves identity across reshuffles or label-merge passes.
+- `cell_id`, `pair`, `narrative` — the row a labeler reads.
+- `source_data`, `target_data`, `shared_neighbors` — the input the model saw.
+- `raw_count` / `aa_sum` / `insufficient_signal` / `token_match_score` — diagnostic context (don't use to set the label, but useful for spot-checking edge cases).
+- `severity`, `failure_mode`, `notes` — empty; the labeler fills these.
+
+Rubric and worked examples: `docs/eval-set-rubric.md`. Labelers should read it once before starting and refer back when in doubt.
+
+For multi-labeler runs:
+
+1. Calibration round — every labeler labels the same first 20 rows. Compare results, refine rubric examples for any rows where labelers disagreed.
+2. Bulk pass — partition the remaining rows. Optionally by genre wheelhouse if labelers have specialized expertise.
+3. Self-IRR — re-label a 10% subset a week later (single-labeler quality check).
+
+After labels merge back into a single CSV, a follow-up script (`merge_labels.py`, not yet built) will join them onto the JSONL backing file by `row_id`, producing the labeled eval set proper.
+
+## What this enables
+
+Once the eval set has human labels:
+
+1. **Backscore prior interventions.** Replay all six prompt variants from Section 6.4 of the whitepaper plus the v1/v2 scoring methods against the labeled set. Report precision/recall/F1 per failure mode. This is the first apples-to-apples table showing which interventions reduce wrongness vs. only reducing proxy scores.
+2. **Measure new interventions.** Review-corpus integration, skip-gram embeddings, the constraint ontology — each claims a hallucination reduction in the whitepaper. The eval set converts those claims into measurable lifts.
+3. **Detect drift.** Re-run the production prompt against the eval pairs periodically and compare. If a prompt change quietly raises wrongness on a stable input set, we see it before listeners do.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `scripts/eval/sample_pairs.py` | Stratified candidate-pair sampler. |
+| `scripts/eval/generate_narratives.py` | Drives the production `/narrative` endpoint via TestClient. |
+| `scripts/eval/build_wrong_set.py` | Generates data-shuffle gold positives (real names + mismatched metadata). |
+| `scripts/eval/export_labeling.py` | Joins narratives with input data; emits CSV + JSONL. Hides `construction_method` and `expected_label` from the CSV so the labeler doesn't see the answer. |
+| `scripts/eval/merge_labels.py` | Joins a filled-in labeler CSV back onto `labeling.jsonl` by `row_id`. Validates against the rubric vocabulary; supports per-labeler outputs for IRR work. |
+| `scripts/eval/backscore.py` | Two subcommands: `score` runs token-match v1 and claim-ratio v1 against every eval-set row (real metadata, not the model's prompt input — mirrors what a labeler judges); `metrics` reports precision/recall/F1 of each scorer once labels exist. |
+| `tests/unit/test_eval_sample_pairs.py` | Sampler unit tests (cell classification, edge enumeration, self-loop exclusion). |
+| `tests/unit/test_eval_merge_labels.py` | Label-merge validation (vocabulary, severity-without-mode error, unknown row_id rejection). |
+| `docs/eval-set-rubric.md` | Labeling rubric: severity, failure modes, worked examples. |
+| `output/eval/eval_pairs.jsonl` | Sampled candidate pairs. |
+| `output/eval/eval_narratives.jsonl` | Generated production narratives + endpoint scoring metadata. |
+| `output/eval/eval_wrong.jsonl` | Data-shuffle wrong narratives, each annotated with `construction_method` and `expected_label`. |
+| `output/eval/labeling.csv` | Labeler-ready sheet (production + wrong rows interleaved, answer key hidden). |
+| `output/eval/labeling.jsonl` | Same data, JSON form, with input data + answer-key fields preserved. |
+| `output/eval/eval_scored.jsonl` | Per-row token-match v1 + claim-ratio v1 scores (built by `backscore.py score`). |

--- a/scripts/eval/__init__.py
+++ b/scripts/eval/__init__.py
@@ -1,0 +1,13 @@
+"""Tooling for the narrative eval set.
+
+The eval set is a labeled corpus of narratives — production-shape outputs paired
+with the structured input data the model saw — used to measure whether scoring
+methods, prompt changes, or downstream enrichment epics actually reduce
+narrative wrongness rather than just nudging proxy metrics.
+
+Pipeline:
+  sample_pairs   → eval_pairs.jsonl    (stratified candidate pairs)
+  generate       → eval_narratives.jsonl (production narratives via TestClient)
+  build_wrong    → eval_wrong.jsonl    (deliberately-wrong constructions)
+  export         → labeling.csv / .jsonl (combined sheet for human labelers)
+"""

--- a/scripts/eval/backscore.py
+++ b/scripts/eval/backscore.py
@@ -1,0 +1,297 @@
+"""Backscore the eval set with the production scoring methods.
+
+For every row in ``labeling.jsonl`` (production + deliberately-wrong rows),
+compute:
+
+  - ``token_match_v1`` — the unmatched-content-words ratio against the
+    *real* metadata of the named artists (always; even wrong rows get
+    re-scored against real data so the result reflects what the labeler is
+    judging, not what the model was prompted with).
+  - ``claim_ratio_v1`` — Haiku-driven claim decomposition (grounded vs
+    ungrounded) against the same real metadata. Mirrors the live
+    ``narrative_audit`` pipeline; same prompt, same parser.
+
+Output is ``eval_scored.jsonl`` — one row per labeling row with both scores
+attached. Once human labels merge in (via ``merge_labels.py``), a follow-up
+function (``compute_metrics``) computes precision / recall / F1 of each
+scorer treated as a binary classifier of ``severity == 'severe'``.
+
+Usage:
+    ANTHROPIC_API_KEY=sk-... python -m scripts.eval.backscore \
+        --db-path data/wxyc_artist_graph.db \
+        --labeling-jsonl output/eval/labeling.jsonl \
+        --out output/eval/eval_scored.jsonl \
+        [--limit 0] [--skip-cached] [--threshold 0.5]
+
+When ``--skip-cached`` is set and ``--out`` already exists, rows already in
+the output (matched by ``row_id``) are skipped — useful for resumable runs
+on a large corpus.
+
+Once labels exist, generate the metrics report:
+    python -m scripts.eval.backscore metrics \
+        --scored output/eval/eval_scored.jsonl \
+        --labeled output/eval/labeling_labeled.jake.jsonl
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def _open_ro_db(path: str) -> sqlite3.Connection:
+    conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _load_labeling(path: Path) -> list[dict]:
+    rows: list[dict] = []
+    with path.open() as fh:
+        for line in fh:
+            line = line.strip()
+            if line:
+                rows.append(json.loads(line))
+    return rows
+
+
+def _load_existing_row_ids(path: Path) -> set[str]:
+    if not path.exists():
+        return set()
+    out: set[str] = set()
+    with path.open() as fh:
+        for line in fh:
+            try:
+                r = json.loads(line)
+                out.add(r["row_id"])
+            except (json.JSONDecodeError, KeyError):
+                continue
+    return out
+
+
+def _build_score_input(db: sqlite3.Connection, row: dict) -> dict:
+    """The scorer's ``provided_data`` — the real metadata of the named artists.
+
+    For production rows this matches what the model was given. For wrong rows
+    (data_shuffle), the model was given DIFFERENT metadata; we re-score
+    against the REAL metadata of the named artists, which is what the
+    labeler sees and judges. This is intentional — the score should mirror
+    the labeler's judgment, not the model's input.
+    """
+    from semantic_index.api.narrative import _lookup_artist_metadata
+
+    source_meta = _lookup_artist_metadata(
+        db, row["source_id"], row["source_name"], row["source_genre"], row["source_plays"]
+    )
+    target_meta = _lookup_artist_metadata(
+        db, row["target_id"], row["target_name"], row["target_genre"], row["target_plays"]
+    )
+    return {"source": source_meta, "target": target_meta}
+
+
+def _score_one(client, db: sqlite3.Connection, row: dict) -> dict:
+    """Compute token-match v1 and claim-ratio v1 for a single eval-set row."""
+    from semantic_index.api.narrative import _token_match_score
+    from semantic_index.narrative_audit import _CLAIM_DECOMPOSE_PROMPT, parse_claim_counts
+
+    input_data = _build_score_input(db, row)
+    narrative = row.get("narrative") or ""
+    token_score = _token_match_score(narrative, input_data) if narrative else 0.0
+
+    if not narrative:
+        return {
+            "token_match_v1": 0.0,
+            "claim_ratio_v1": 0.0,
+            "claim_grounded": 0,
+            "claim_ungrounded": 0,
+        }
+
+    verify_payload = json.dumps(
+        {"narrative": narrative, "provided_data": input_data},
+        separators=(",", ":"),
+    )
+    response = client.messages.create(
+        model="claude-haiku-4-5-20251001",
+        max_tokens=400,
+        system=_CLAIM_DECOMPOSE_PROMPT,
+        messages=[{"role": "user", "content": verify_payload}],
+    )
+    grounded, ungrounded = parse_claim_counts(response.content[0].text)
+    total = grounded + ungrounded
+    ratio = (ungrounded / total) if total else 0.0
+
+    return {
+        "token_match_v1": round(token_score, 4),
+        "claim_ratio_v1": round(ratio, 4),
+        "claim_grounded": grounded,
+        "claim_ungrounded": ungrounded,
+    }
+
+
+def cmd_score(args: argparse.Namespace) -> int:
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    if not api_key:
+        logger.error("ANTHROPIC_API_KEY is required")
+        return 1
+    import anthropic
+
+    client = anthropic.Anthropic(api_key=api_key)
+    db = _open_ro_db(args.db_path)
+    rows = _load_labeling(Path(args.labeling_jsonl))
+
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    already = _load_existing_row_ids(out_path) if args.skip_cached else set()
+    if already:
+        logger.info("Skipping %d rows already in %s", len(already), out_path)
+
+    todo = [r for r in rows if r["row_id"] not in already]
+    if args.limit > 0:
+        todo = todo[: args.limit]
+
+    logger.info("Scoring %d rows -> %s", len(todo), out_path)
+    written = errors = 0
+    with out_path.open("a") as fh:
+        for i, row in enumerate(todo, 1):
+            t0 = time.time()
+            try:
+                scores = _score_one(client, db, row)
+            except Exception:  # noqa: BLE001
+                logger.exception("Scoring failed for %s", row.get("row_id"))
+                errors += 1
+                continue
+            elapsed_ms = int((time.time() - t0) * 1000)
+
+            out_row = {
+                "row_id": row["row_id"],
+                "cell_id": row.get("cell_id"),
+                "construction_method": row.get("construction_method", "production"),
+                "narrative": row.get("narrative"),
+                "scores": scores,
+                "scored_at_ms": elapsed_ms,
+            }
+            fh.write(json.dumps(out_row, separators=(",", ":")) + "\n")
+            fh.flush()
+            written += 1
+            if i % 20 == 0 or i == len(todo):
+                logger.info(
+                    "%d/%d scored (errors=%d, last token=%.3f claim=%.3f, %dms)",
+                    i, len(todo), errors,
+                    scores["token_match_v1"], scores["claim_ratio_v1"], elapsed_ms,
+                )
+
+    logger.info("Done: wrote %d, errors=%d", written, errors)
+    return 0 if errors == 0 else 1
+
+
+def cmd_metrics(args: argparse.Namespace) -> int:
+    """Compute precision/recall/F1 for each scorer treated as a binary classifier.
+
+    Positive class = ``severity in {severe, minor}`` (any wrongness). Threshold
+    crossings on the scorer's value mark predicted positives. For each method
+    we report:
+      - precision (predicted_positive AND label_positive) / predicted_positive
+      - recall    (predicted_positive AND label_positive) / label_positive
+      - F1
+      - per-failure_mode breakdown of recall (which categories does each
+        scorer catch?)
+    """
+    scored = {r["row_id"]: r for r in _load_labeling(Path(args.scored))}
+    labeled = _load_labeling(Path(args.labeled))
+
+    by_method: dict[str, dict[str, list[float]]] = {
+        "token_match_v1": {"pos_scores": [], "neg_scores": []},
+        "claim_ratio_v1": {"pos_scores": [], "neg_scores": []},
+    }
+    by_mode_recall: dict[str, dict[str, list[bool]]] = {
+        "token_match_v1": {},
+        "claim_ratio_v1": {},
+    }
+
+    n_labeled = n_pos = 0
+    for row in labeled:
+        rid = row["row_id"]
+        if rid not in scored:
+            continue
+        label = row.get("label") or {}
+        severity = label.get("severity")
+        if not severity:
+            continue
+        n_labeled += 1
+        is_positive = severity in {"severe", "minor"}
+        if is_positive:
+            n_pos += 1
+        scores = scored[rid]["scores"]
+        for method in ("token_match_v1", "claim_ratio_v1"):
+            score = scores[method]
+            (by_method[method]["pos_scores"] if is_positive else by_method[method]["neg_scores"]).append(score)
+
+        if is_positive:
+            mode = label.get("failure_mode") or "unspecified"
+            for method in ("token_match_v1", "claim_ratio_v1"):
+                hit = scores[method] > args.threshold
+                by_mode_recall[method].setdefault(mode, []).append(hit)
+
+    print(f"Labeled rows: {n_labeled} (positive: {n_pos}, negative: {n_labeled - n_pos})")
+    print(f"Threshold for binary classification: {args.threshold}")
+    print()
+
+    for method in ("token_match_v1", "claim_ratio_v1"):
+        pos = by_method[method]["pos_scores"]
+        neg = by_method[method]["neg_scores"]
+        tp = sum(1 for s in pos if s > args.threshold)
+        fn = len(pos) - tp
+        fp = sum(1 for s in neg if s > args.threshold)
+        tn = len(neg) - fp
+        precision = tp / (tp + fp) if (tp + fp) else 0.0
+        recall = tp / (tp + fn) if (tp + fn) else 0.0
+        f1 = (2 * precision * recall / (precision + recall)) if (precision + recall) else 0.0
+        mean_pos = sum(pos) / len(pos) if pos else 0.0
+        mean_neg = sum(neg) / len(neg) if neg else 0.0
+        print(f"=== {method} ===")
+        print(f"  mean(positive)={mean_pos:.3f}  mean(negative)={mean_neg:.3f}")
+        print(f"  TP={tp} FP={fp} TN={tn} FN={fn}")
+        print(f"  precision={precision:.3f}  recall={recall:.3f}  F1={f1:.3f}")
+        if by_mode_recall[method]:
+            print("  recall by failure_mode:")
+            for mode, hits in sorted(by_mode_recall[method].items()):
+                r = sum(hits) / len(hits) if hits else 0.0
+                print(f"    {mode:30} n={len(hits):3} recall={r:.3f}")
+        print()
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    score = sub.add_parser("score", help="Compute scores for the eval-set rows.")
+    score.add_argument("--db-path", default="data/wxyc_artist_graph.db")
+    score.add_argument("--labeling-jsonl", required=True)
+    score.add_argument("--out", required=True)
+    score.add_argument("--limit", type=int, default=0)
+    score.add_argument("--skip-cached", action="store_true")
+    score.set_defaults(func=cmd_score)
+
+    metrics = sub.add_parser("metrics", help="Compute precision/recall/F1 against labels.")
+    metrics.add_argument("--scored", required=True)
+    metrics.add_argument("--labeled", required=True)
+    metrics.add_argument("--threshold", type=float, default=0.5,
+                         help="Score above which a row is predicted positive (default 0.5)")
+    metrics.set_defaults(func=cmd_metrics)
+
+    args = ap.parse_args(argv)
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/eval/build_wrong_set.py
+++ b/scripts/eval/build_wrong_set.py
@@ -1,0 +1,244 @@
+"""Build deliberately-wrong narratives for detector calibration.
+
+The 153 production narratives in ``eval_narratives.jsonl`` are wrongness-by-luck:
+some will be wrong, some not, in proportions reflecting the live system. They
+test labeler IRR and represent natural distribution. Detector calibration
+needs *gold positives* — rows where wrongness is known by construction.
+
+This script generates the data-shuffle variant only:
+
+  1. Pick an existing production pair (A, B) — the names that appear in the
+     narrative.
+  2. Pick a *different* random pair (C, D) — the metadata source.
+  3. Build a prompt that names A and B but supplies C's metadata as ``source``
+     and D's metadata as ``target``.
+  4. Call Claude Haiku directly (not via the endpoint, so the production
+     ``narrative-cache.db`` stays clean). The model produces a narrative that
+     names A and B but describes C and D's musical attributes. Wrong by
+     construction — failure_mode=subject_hallucination.
+
+Field-corruption and pretraining-bait constructions are not implemented here.
+
+Usage:
+    ANTHROPIC_API_KEY=sk-... python -m scripts.eval.build_wrong_set \
+        --db-path data/wxyc_artist_graph.db \
+        --narratives output/eval/eval_narratives.jsonl \
+        --out output/eval/eval_wrong.jsonl \
+        [--n 30] [--seed 7]
+
+Output JSONL row mirrors the production-narrative shape so ``export_labeling``
+treats both pools identically. The labeler always sees the *real* metadata for
+the artists named in the narrative — that's how they detect the wrongness.
+Extra fields:
+    construction_method: "data_shuffle"
+    metadata_source: {source_id: int, target_id: int}  # the C/D pair we shuffled in
+    expected_label: {severity: "severe", failure_mode: "subject_hallucination"}
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import random
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def _open_ro_db(path: str) -> sqlite3.Connection:
+    conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _load_eligible_pairs(narratives_path: Path) -> list[dict]:
+    """Return only generative narrative rows (skip canned insufficient_signal placeholders).
+
+    Insufficient-signal rows can't meaningfully be data-shuffled — the canned
+    text doesn't make claims about the music, just acknowledges low signal.
+    """
+    out: list[dict] = []
+    with narratives_path.open() as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            r = json.loads(line)
+            if r.get("insufficient_signal"):
+                continue
+            if not r.get("narrative"):
+                continue
+            out.append(r)
+    return out
+
+
+def _build_user_message(source_name: str, target_name: str, source_meta: dict, target_meta: dict) -> str:
+    """Construct the user-message JSON the model sees.
+
+    Identical shape to ``narrative._build_prompt`` but no relationships /
+    facets / shared_neighbors fields — those would carry leakage from the real
+    pair, defeating the shuffle. The minimal shape is enough to elicit a
+    descriptive narrative the model will ground in the (mismatched) metadata.
+    """
+    source_view = dict(source_meta)
+    source_view["name"] = source_name
+    target_view = dict(target_meta)
+    target_view["name"] = target_name
+    payload = {"source": source_view, "target": target_view}
+    return json.dumps(payload, separators=(",", ":"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--db-path", default="data/wxyc_artist_graph.db")
+    ap.add_argument("--narratives", required=True)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--n", type=int, default=30, help="Number of shuffled narratives to generate")
+    ap.add_argument("--seed", type=int, default=7)
+    ap.add_argument("--sleep", type=float, default=0.0)
+    args = ap.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    if not api_key:
+        logger.error("ANTHROPIC_API_KEY is required")
+        return 1
+
+    # Lazy imports.
+    import anthropic
+
+    from semantic_index.api.narrative import (
+        _SYSTEM_PROMPT,
+        _lookup_artist_metadata,
+    )
+
+    db = _open_ro_db(args.db_path)
+    eligible = _load_eligible_pairs(Path(args.narratives))
+    if len(eligible) < 2:
+        logger.error("Need at least 2 generative narratives in --narratives; got %d", len(eligible))
+        return 1
+    logger.info("Eligible production pairs: %d", len(eligible))
+
+    rng = random.Random(args.seed)
+    # Sample names_pair (A, B) and metadata_pair (C, D) such that the
+    # underlying ARTIST IDs do not overlap. Same-id overlap would partially
+    # leak the right metadata into the shuffled prompt and weaken the gold-
+    # positive guarantee.
+    pairs_for_names = rng.sample(eligible, min(args.n, len(eligible)))
+
+    client = anthropic.Anthropic(api_key=api_key)
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    written = 0
+    with out_path.open("w") as fh:
+        for i, name_row in enumerate(pairs_for_names, 1):
+            # Find a metadata-source pair with no id overlap.
+            tries = 0
+            meta_row = None
+            while tries < 50:
+                cand = rng.choice(eligible)
+                if cand["source_id"] not in (name_row["source_id"], name_row["target_id"]) and cand["target_id"] not in (name_row["source_id"], name_row["target_id"]):
+                    meta_row = cand
+                    break
+                tries += 1
+            if meta_row is None:
+                logger.warning("Skipping %d: couldn't find non-overlapping metadata pair", i)
+                continue
+
+            source_meta = _lookup_artist_metadata(
+                db,
+                meta_row["source_id"],
+                meta_row["source_name"],
+                meta_row["source_genre"],
+                meta_row["source_plays"],
+            )
+            target_meta = _lookup_artist_metadata(
+                db,
+                meta_row["target_id"],
+                meta_row["target_name"],
+                meta_row["target_genre"],
+                meta_row["target_plays"],
+            )
+            user_message = _build_user_message(
+                name_row["source_name"], name_row["target_name"],
+                source_meta, target_meta,
+            )
+
+            t0 = time.time()
+            try:
+                response = client.messages.create(
+                    model="claude-haiku-4-5-20251001",
+                    max_tokens=150,
+                    system=_SYSTEM_PROMPT,
+                    messages=[{"role": "user", "content": user_message}],
+                )
+                narrative = response.content[0].text
+            except Exception as exc:  # noqa: BLE001 -- exit cleanly on API failure
+                logger.exception("Anthropic call failed for %s / %s", name_row["source_name"], name_row["target_name"])
+                continue
+            elapsed_ms = int((time.time() - t0) * 1000)
+
+            row = {
+                # Keep the SAME shape as eval_narratives.jsonl so export_labeling
+                # treats both pools identically. source_id/target_id point to the
+                # NAMED artists, so the labeler sees the named artists' REAL
+                # metadata when reading the row.
+                "cell_id": "WRONG-DATA-SHUFFLE",
+                "fame": name_row["fame"],
+                "richness": name_row["richness"],
+                "genre": name_row["genre"],
+                "edge": name_row["edge"],
+                "source_id": name_row["source_id"],
+                "target_id": name_row["target_id"],
+                "source_name": name_row["source_name"],
+                "target_name": name_row["target_name"],
+                "source_genre": name_row["source_genre"],
+                "target_genre": name_row["target_genre"],
+                "source_plays": name_row["source_plays"],
+                "target_plays": name_row["target_plays"],
+                "narrative": narrative,
+                "cached": False,
+                "insufficient_signal": False,
+                "token_match_score": 0.0,  # not computed for these
+                "low_grounding": False,
+                "http_status": 200,
+                "latency_ms": elapsed_ms,
+                "construction_method": "data_shuffle",
+                "metadata_source": {
+                    "source_id": meta_row["source_id"],
+                    "target_id": meta_row["target_id"],
+                    "source_name": meta_row["source_name"],
+                    "target_name": meta_row["target_name"],
+                },
+                "expected_label": {
+                    "severity": "severe",
+                    "failure_mode": "subject_hallucination",
+                },
+            }
+            fh.write(json.dumps(row, separators=(",", ":")) + "\n")
+            fh.flush()
+            written += 1
+            logger.info(
+                "%d/%d: named=%s/%s metadata=%s/%s elapsed=%dms",
+                i, len(pairs_for_names),
+                name_row["source_name"], name_row["target_name"],
+                meta_row["source_name"], meta_row["target_name"],
+                elapsed_ms,
+            )
+
+            if args.sleep > 0 and i < len(pairs_for_names):
+                time.sleep(args.sleep)
+
+    logger.info("Wrote %d data-shuffle rows -> %s", written, out_path)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/eval/export_labeling.py
+++ b/scripts/eval/export_labeling.py
@@ -1,0 +1,181 @@
+"""Export the narrative eval set as a labeling sheet (CSV + JSONL backing).
+
+Joins ``eval_narratives.jsonl`` with the per-artist input data the production
+narrative endpoint actually saw (looked up live from the SQLite graph DB), then
+emits one row per narrative with empty label columns for human entry.
+
+The CSV is laid out for Google Sheets — narratives, source/target data, and
+shared neighbors live in adjacent columns so a labeler can read the narrative
+and verify against the data without scrolling. The JSONL preserves the same
+data plus a stable ``row_id`` and ``cell_id``, so post-labeling analysis can
+stratify by matrix cell.
+
+Usage:
+    python -m scripts.eval.export_labeling \
+        --db-path data/wxyc_artist_graph.db \
+        --narratives output/eval/eval_narratives.jsonl \
+        --csv-out output/eval/labeling.csv \
+        --jsonl-out output/eval/labeling.jsonl \
+        [--seed 7]
+
+Order is randomized with the provided seed so a labeler doesn't see all
+HIGH-RICH rows clustered. ``row_id`` lets you re-join labels to the original
+narrative regardless of row order.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import logging
+import random
+import sqlite3
+import sys
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def _open_ro_db(path: str) -> sqlite3.Connection:
+    conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _format_artist_data(meta: dict) -> str:
+    """Render a per-artist metadata dict as a readable multi-line string for the sheet."""
+    parts: list[str] = []
+    parts.append(f"name: {meta.get('name')}")
+    parts.append(f"plays: {meta.get('total_plays')}")
+    if (g := meta.get("genre")) is not None:
+        parts.append(f"genre: {g}")
+    if styles := meta.get("styles"):
+        parts.append(f"styles: {', '.join(styles)}")
+    if audio := meta.get("audio"):
+        for k, v in audio.items():
+            parts.append(f"audio.{k}: {v}")
+    return "\n".join(parts)
+
+
+def _format_shared_neighbors(neighbors: list[dict]) -> str:
+    if not neighbors:
+        return ""
+    return ", ".join(f"{n['name']} (aa {n['aa_score']:.2f})" for n in neighbors)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--db-path", default="data/wxyc_artist_graph.db")
+    ap.add_argument("--narratives", required=True, help="Input eval_narratives.jsonl")
+    ap.add_argument(
+        "--wrong",
+        default=None,
+        help="Optional eval_wrong.jsonl. When provided, deliberately-wrong rows "
+        "are interleaved with the production rows. Construction-method markers "
+        "and expected-label fields stay in the JSONL backing but are NOT shown "
+        "in the labeler-facing CSV (so the labeler doesn't see the answer).",
+    )
+    ap.add_argument("--csv-out", required=True)
+    ap.add_argument("--jsonl-out", required=True)
+    ap.add_argument("--seed", type=int, default=7)
+    args = ap.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+    # Import here so --help works without the API extras.
+    from semantic_index.api.narrative import (
+        _lookup_artist_metadata,
+        _rank_shared_neighbors_by_aa,
+    )
+
+    db = _open_ro_db(args.db_path)
+
+    rows_in: list[dict] = []
+    with Path(args.narratives).open() as fh:
+        for line in fh:
+            line = line.strip()
+            if line:
+                rows_in.append(json.loads(line))
+
+    if args.wrong:
+        with Path(args.wrong).open() as fh:
+            for line in fh:
+                line = line.strip()
+                if line:
+                    rows_in.append(json.loads(line))
+        logger.info("Merged %s wrong rows in addition to production rows", args.wrong)
+
+    rng = random.Random(args.seed)
+    rng.shuffle(rows_in)
+
+    csv_path = Path(args.csv_out)
+    jsonl_path = Path(args.jsonl_out)
+    csv_path.parent.mkdir(parents=True, exist_ok=True)
+    jsonl_path.parent.mkdir(parents=True, exist_ok=True)
+
+    csv_columns = [
+        "row_id",
+        "cell_id",
+        "pair",
+        "narrative",
+        "source_data",
+        "target_data",
+        "shared_neighbors",
+        "raw_count",
+        "aa_sum",
+        "insufficient_signal",
+        "token_match_score",
+        "severity",        # blank — labeler fills (severe / minor / not_wrong)
+        "failure_mode",    # blank — labeler fills (subject_hallucination / ...)
+        "notes",           # blank — labeler freeform
+    ]
+
+    written = 0
+    with csv_path.open("w", newline="") as csv_fh, jsonl_path.open("w") as jl_fh:
+        writer = csv.DictWriter(csv_fh, fieldnames=csv_columns, quoting=csv.QUOTE_ALL)
+        writer.writeheader()
+
+        for i, r in enumerate(rows_in):
+            row_id = f"R{i + 1:04d}"
+            source_meta = _lookup_artist_metadata(
+                db, r["source_id"], r["source_name"], r["source_genre"], r["source_plays"]
+            )
+            target_meta = _lookup_artist_metadata(
+                db, r["target_id"], r["target_name"], r["target_genre"], r["target_plays"]
+            )
+            neighbors = _rank_shared_neighbors_by_aa(db, r["source_id"], r["target_id"])[:5]
+
+            csv_row = {
+                "row_id": row_id,
+                "cell_id": r["cell_id"],
+                "pair": f"{r['source_name']} <-> {r['target_name']}",
+                "narrative": r.get("narrative") or "",
+                "source_data": _format_artist_data(source_meta),
+                "target_data": _format_artist_data(target_meta),
+                "shared_neighbors": _format_shared_neighbors(neighbors),
+                "raw_count": r.get("raw_count", "") if r.get("raw_count") is not None else "",
+                "aa_sum": r.get("aa_sum", ""),
+                "insufficient_signal": "yes" if r.get("insufficient_signal") else "",
+                "token_match_score": f"{r.get('token_match_score', 0.0):.3f}",
+                "severity": "",
+                "failure_mode": "",
+                "notes": "",
+            }
+            writer.writerow(csv_row)
+
+            jl_row = dict(r)
+            jl_row["row_id"] = row_id
+            jl_row["source_data"] = source_meta
+            jl_row["target_data"] = target_meta
+            jl_row["shared_neighbors"] = neighbors
+            jl_fh.write(json.dumps(jl_row, separators=(",", ":")) + "\n")
+
+            written += 1
+
+    logger.info("Wrote %d rows -> %s + %s", written, csv_path, jsonl_path)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/eval/generate_narratives.py
+++ b/scripts/eval/generate_narratives.py
@@ -1,0 +1,169 @@
+"""Generate production narratives for sampled pairs.
+
+Drives the live ``/graph/artists/{id}/explain/{id}/narrative`` endpoint via
+FastAPI's ``TestClient`` so prompt assembly, AA-gating, anonymization, scoring,
+and the regen loop are exercised exactly as users see them. The narrative
+sidecar cache populates as a side effect.
+
+Output is a JSONL file pairing each input row from ``sample_pairs.py`` with the
+endpoint's response, suitable for downstream eval-set construction.
+
+Usage:
+    ANTHROPIC_API_KEY=sk-... python -m scripts.eval.generate_narratives \
+        --db-path data/wxyc_artist_graph.db \
+        --pairs output/eval/eval_pairs.jsonl \
+        --out output/eval/eval_narratives.jsonl \
+        [--limit 5] [--skip-cached]
+
+Output JSONL row: input row keys (cell_id, source_id, ...) plus:
+    {
+      "narrative": "...",
+      "cached": false,
+      "insufficient_signal": false,
+      "token_match_score": 0.21,
+      "low_grounding": false,
+      "http_status": 200
+    }
+
+When the API returns a non-2xx, ``narrative`` is null and ``error`` carries the
+detail.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+import time
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def _load_pairs(path: Path) -> list[dict]:
+    rows: list[dict] = []
+    with path.open() as fh:
+        for line in fh:
+            line = line.strip()
+            if line:
+                rows.append(json.loads(line))
+    return rows
+
+
+def _load_cached_keys(out_path: Path) -> set[tuple[int, int]]:
+    """Return set of (source_id, target_id) pairs already written to ``out_path``."""
+    if not out_path.exists():
+        return set()
+    keys: set[tuple[int, int]] = set()
+    with out_path.open() as fh:
+        for line in fh:
+            try:
+                row = json.loads(line)
+                keys.add((int(row["source_id"]), int(row["target_id"])))
+            except (json.JSONDecodeError, KeyError, ValueError):
+                continue
+    return keys
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--db-path", default="data/wxyc_artist_graph.db")
+    ap.add_argument("--pairs", required=True, help="Pair list JSONL from sample_pairs.py")
+    ap.add_argument("--out", required=True, help="Output JSONL path")
+    ap.add_argument("--limit", type=int, default=0, help="Max requests (0 = all)")
+    ap.add_argument(
+        "--skip-cached",
+        action="store_true",
+        help="Skip pairs whose (source_id, target_id) already appear in --out",
+    )
+    ap.add_argument("--sleep", type=float, default=0.0, help="Sleep between requests (seconds)")
+    args = ap.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    if not api_key:
+        logger.error("ANTHROPIC_API_KEY is required")
+        return 1
+
+    # Lazy imports so the script's --help works without the optional API extras.
+    from fastapi.testclient import TestClient
+
+    from semantic_index.api.app import create_app
+
+    app = create_app(args.db_path, anthropic_api_key=api_key)
+    client = TestClient(app)
+
+    pairs = _load_pairs(Path(args.pairs))
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    already = _load_cached_keys(out_path) if args.skip_cached else set()
+    if already:
+        logger.info("Skipping %d pairs already in %s", len(already), out_path)
+
+    todo = [
+        p for p in pairs
+        if (int(p["source_id"]), int(p["target_id"])) not in already
+        and (int(p["target_id"]), int(p["source_id"])) not in already
+    ]
+    if args.limit > 0:
+        todo = todo[: args.limit]
+
+    logger.info("Generating %d narratives -> %s", len(todo), out_path)
+    written = 0
+    insufficient = 0
+    cached = 0
+    errors = 0
+
+    with out_path.open("a") as fh:
+        for i, p in enumerate(todo, 1):
+            url = f"/graph/artists/{p['source_id']}/explain/{p['target_id']}/narrative"
+            t0 = time.time()
+            response = client.get(url)
+            elapsed = time.time() - t0
+
+            row = dict(p)
+            row["http_status"] = response.status_code
+            row["latency_ms"] = int(elapsed * 1000)
+
+            if response.status_code == 200:
+                body = response.json()
+                row["narrative"] = body.get("narrative")
+                row["cached"] = body.get("cached", False)
+                row["insufficient_signal"] = body.get("insufficient_signal", False)
+                row["token_match_score"] = body.get("token_match_score", 0.0)
+                row["low_grounding"] = body.get("low_grounding", False)
+                if row["insufficient_signal"]:
+                    insufficient += 1
+                if row["cached"]:
+                    cached += 1
+            else:
+                row["narrative"] = None
+                row["error"] = response.text[:500]
+                errors += 1
+
+            fh.write(json.dumps(row, separators=(",", ":")) + "\n")
+            fh.flush()
+            written += 1
+
+            if i % 10 == 0 or i == len(todo):
+                logger.info(
+                    "%d/%d done (cached=%d insufficient=%d errors=%d, last=%dms)",
+                    i, len(todo), cached, insufficient, errors, row["latency_ms"],
+                )
+
+            if args.sleep > 0 and i < len(todo):
+                time.sleep(args.sleep)
+
+    logger.info(
+        "Wrote %d narratives (cached=%d insufficient=%d errors=%d) -> %s",
+        written, cached, insufficient, errors, out_path,
+    )
+    return 0 if errors == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/eval/merge_labels.py
+++ b/scripts/eval/merge_labels.py
@@ -1,0 +1,163 @@
+"""Merge a filled-in labeler CSV back onto the labeling JSONL backing.
+
+A labeler downloads ``labeling.csv`` from Sheets (or any other tool that round-
+trips CSV with the same columns), fills the ``severity`` / ``failure_mode`` /
+``notes`` columns, and uploads the result. This script joins those filled
+labels onto the JSONL backing file by ``row_id``, producing a single
+``labeling_labeled.jsonl`` ready for downstream analysis (eval-set training,
+backscore precision/recall, etc.).
+
+Validates that:
+- Every ``row_id`` in the CSV matches exactly one row in the JSONL.
+- ``severity`` is one of the rubric's three values when filled.
+- ``failure_mode`` is one of the rubric's five values when filled.
+
+Multiple labelers can run this script with different CSV inputs; each output
+JSONL is keyed by ``labeler_id`` (passed via ``--labeler``) so a follow-up
+script can compute IRR.
+
+Usage:
+    python -m scripts.eval.merge_labels \
+        --labeling-jsonl output/eval/labeling.jsonl \
+        --labels-csv path/to/labeler-jake.csv \
+        --labeler jake \
+        --out output/eval/labeling_labeled.jake.jsonl
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import logging
+import sys
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+VALID_SEVERITY = {"severe", "minor", "not_wrong"}
+VALID_FAILURE_MODE = {
+    "subject_hallucination",
+    "neighbor_characterization",
+    "dj_intent",
+    "data_noise",
+    "other",
+}
+
+
+def _load_jsonl(path: Path) -> dict[str, dict]:
+    """Return ``{row_id: row}`` dict from a JSONL file. Raises on duplicate row_id."""
+    rows: dict[str, dict] = {}
+    with path.open() as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            r = json.loads(line)
+            row_id = r["row_id"]
+            if row_id in rows:
+                raise ValueError(f"Duplicate row_id in {path}: {row_id}")
+            rows[row_id] = r
+    return rows
+
+
+def _normalize_label(value: str | None) -> str:
+    """Lowercase + strip + map common variants to canonical rubric values."""
+    if value is None:
+        return ""
+    v = value.strip().lower()
+    # tolerate dashes / spaces in failure mode codes
+    return v.replace(" ", "_").replace("-", "_")
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--labeling-jsonl", required=True)
+    ap.add_argument("--labels-csv", required=True)
+    ap.add_argument("--labeler", required=True, help="Identifier for this labeler (e.g. 'jake')")
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+    backing = _load_jsonl(Path(args.labeling_jsonl))
+    logger.info("Backing JSONL: %d rows", len(backing))
+
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    written = unlabeled = errors = 0
+    seen_ids: set[str] = set()
+    severity_counts: dict[str, int] = {}
+    mode_counts: dict[str, int] = {}
+
+    with Path(args.labels_csv).open() as csv_fh, out_path.open("w") as jl_fh:
+        rdr = csv.DictReader(csv_fh)
+        for csv_row in rdr:
+            row_id = csv_row.get("row_id", "").strip()
+            if not row_id:
+                continue
+            if row_id not in backing:
+                logger.warning("CSV row_id %s not in backing JSONL", row_id)
+                errors += 1
+                continue
+            if row_id in seen_ids:
+                logger.warning("CSV row_id %s appears twice in labels CSV", row_id)
+                errors += 1
+                continue
+            seen_ids.add(row_id)
+
+            severity = _normalize_label(csv_row.get("severity"))
+            failure_mode = _normalize_label(csv_row.get("failure_mode"))
+
+            if not severity:
+                unlabeled += 1
+                continue
+
+            if severity not in VALID_SEVERITY:
+                logger.warning("row %s: invalid severity %r", row_id, severity)
+                errors += 1
+                continue
+            if severity != "not_wrong":
+                if not failure_mode:
+                    logger.warning("row %s: severity=%s but failure_mode blank", row_id, severity)
+                    errors += 1
+                    continue
+                if failure_mode not in VALID_FAILURE_MODE:
+                    logger.warning("row %s: invalid failure_mode %r", row_id, failure_mode)
+                    errors += 1
+                    continue
+            else:
+                # "not_wrong" rows shouldn't carry a failure_mode; clear if set.
+                failure_mode = ""
+
+            severity_counts[severity] = severity_counts.get(severity, 0) + 1
+            if failure_mode:
+                mode_counts[failure_mode] = mode_counts.get(failure_mode, 0) + 1
+
+            out_row = dict(backing[row_id])
+            out_row["label"] = {
+                "labeler": args.labeler,
+                "severity": severity,
+                "failure_mode": failure_mode,
+                "notes": csv_row.get("notes", "").strip(),
+            }
+            jl_fh.write(json.dumps(out_row, separators=(",", ":")) + "\n")
+            written += 1
+
+    missing_from_csv = set(backing) - seen_ids
+    logger.info(
+        "Wrote %d labeled rows -> %s (%d unlabeled in CSV, %d not in CSV at all, %d errors)",
+        written,
+        out_path,
+        unlabeled,
+        len(missing_from_csv),
+        errors,
+    )
+    logger.info("Severity counts: %s", severity_counts)
+    logger.info("Failure mode counts: %s", mode_counts)
+    return 0 if errors == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/eval/sample_pairs.py
+++ b/scripts/eval/sample_pairs.py
@@ -1,0 +1,462 @@
+"""Sample pairs stratified across the narrative risk matrix.
+
+Cells are defined by four binary axes:
+
+  - fame:     HIGH (total_plays > 800) | LOW (100 <= total_plays <= 400)
+  - richness: RICH (>=3 styles AND audio_profile) | THIN (<=2 styles OR no audio)
+  - genre:    CROSS (different genre) | SAME (same genre)
+  - edge:     DIRECT (dj_transition raw_count >= 2)
+              | INDIRECT (no edge, but AA-sum across shared neighbors >= 0.8)
+
+That is 16 cells. For each cell, draw N pairs that satisfy the predicates and
+emit them as JSONL.
+
+The AA-sum threshold for INDIRECT pairs matches ``_DEFAULT_MIN_AA_SCORE`` in
+``semantic_index/api/narrative.py`` so the live narrative endpoint will accept
+the pair rather than returning the canned "insufficient signal" reply. DIRECT
+pairs require ``raw_count >= 2`` for symmetry with the pipeline's ``min_count``
+default.
+
+Usage:
+    python -m scripts.eval.sample_pairs \
+        --db-path data/wxyc_artist_graph.db \
+        --out output/eval/eval_pairs.jsonl \
+        --per-cell 12 \
+        [--seed 7]
+
+Output JSONL row:
+    {
+      "cell_id": "HIGH-RICH-CROSS-DIRECT",
+      "fame": "HIGH", "richness": "RICH", "genre": "CROSS", "edge": "DIRECT",
+      "source_id": 12345, "target_id": 67890,
+      "source_name": "...", "target_name": "...",
+      "source_genre": "Rock", "target_genre": "Jazz",
+      "source_plays": 1240, "target_plays": 905,
+      "raw_count": 4,                     # DIRECT only
+      "aa_sum": 1.41                      # INDIRECT only
+    }
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import math
+import random
+import sqlite3
+import sys
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from itertools import product
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+FAME_HIGH_MIN = 800  # strict-greater in the AA prompt; we want to mirror that
+FAME_LOW_MIN = 100
+FAME_LOW_MAX = 400
+MIN_AA_SUM = 0.8
+DIRECT_MIN_RAW_COUNT = 2
+RICH_MIN_STYLES = 3
+
+CELL_AXES = ("fame", "richness", "genre", "edge")
+
+
+@dataclass(frozen=True)
+class ArtistProfile:
+    id: int
+    name: str
+    genre: str
+    total_plays: int
+    style_count: int
+    has_audio: bool
+
+    @property
+    def fame(self) -> str | None:
+        if self.total_plays > FAME_HIGH_MIN:
+            return "HIGH"
+        if FAME_LOW_MIN <= self.total_plays <= FAME_LOW_MAX:
+            return "LOW"
+        return None  # mid-band — not eligible for either fame cell
+
+    @property
+    def richness(self) -> str:
+        return "RICH" if (self.style_count >= RICH_MIN_STYLES and self.has_audio) else "THIN"
+
+
+@dataclass
+class CellSpec:
+    fame: str
+    richness: str
+    genre: str
+    edge: str
+
+    @property
+    def cell_id(self) -> str:
+        return f"{self.fame}-{self.richness}-{self.genre}-{self.edge}"
+
+
+@dataclass
+class PairRecord:
+    cell: CellSpec
+    a: ArtistProfile
+    b: ArtistProfile
+    raw_count: int | None = None
+    aa_sum: float | None = None
+    aa_neighbors: list[tuple[str, float]] = field(default_factory=list)
+
+    def to_jsonl(self) -> str:
+        row = {
+            "cell_id": self.cell.cell_id,
+            "fame": self.cell.fame,
+            "richness": self.cell.richness,
+            "genre": self.cell.genre,
+            "edge": self.cell.edge,
+            "source_id": self.a.id,
+            "target_id": self.b.id,
+            "source_name": self.a.name,
+            "target_name": self.b.name,
+            "source_genre": self.a.genre,
+            "target_genre": self.b.genre,
+            "source_plays": self.a.total_plays,
+            "target_plays": self.b.total_plays,
+        }
+        if self.raw_count is not None:
+            row["raw_count"] = self.raw_count
+        if self.aa_sum is not None:
+            row["aa_sum"] = round(self.aa_sum, 3)
+        return json.dumps(row, separators=(",", ":"))
+
+
+def open_db(path: str) -> sqlite3.Connection:
+    conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def load_eligible_artists(db: sqlite3.Connection) -> list[ArtistProfile]:
+    """Return all artists meeting *either* fame band, with richness annotated.
+
+    Compilation/VA names are excluded explicitly; the broader resolver handles
+    these upstream but the SQLite ``artist`` table can still surface them.
+    """
+    rows = db.execute(
+        """
+        SELECT a.id, a.canonical_name, a.genre, a.total_plays,
+            (SELECT COUNT(*) FROM artist_style s WHERE s.artist_id = a.id) AS style_count,
+            EXISTS(SELECT 1 FROM audio_profile ap WHERE ap.artist_id = a.id) AS has_audio
+        FROM artist a
+        WHERE a.genre IS NOT NULL
+          AND (a.total_plays > ?
+               OR (a.total_plays BETWEEN ? AND ?))
+          AND a.canonical_name NOT LIKE 'Various%'
+          AND a.canonical_name NOT LIKE 'V/A%'
+          AND a.canonical_name NOT LIKE '%Soundtrack%'
+          AND lower(a.canonical_name) != 'unknown'
+        """,
+        (FAME_HIGH_MIN, FAME_LOW_MIN, FAME_LOW_MAX),
+    ).fetchall()
+    return [
+        ArtistProfile(
+            id=r["id"],
+            name=r["canonical_name"],
+            genre=r["genre"],
+            total_plays=r["total_plays"],
+            style_count=r["style_count"],
+            has_audio=bool(r["has_audio"]),
+        )
+        for r in rows
+    ]
+
+
+def index_by_fame_richness(
+    artists: Iterable[ArtistProfile],
+) -> dict[tuple[str, str], list[ArtistProfile]]:
+    out: dict[tuple[str, str], list[ArtistProfile]] = {}
+    for a in artists:
+        if a.fame is None:
+            continue
+        out.setdefault((a.fame, a.richness), []).append(a)
+    return out
+
+
+def compute_degrees(db: sqlite3.Connection) -> dict[int, int]:
+    """Return artist_id -> distinct dj_transition partner count."""
+    rows = db.execute(
+        """
+        WITH all_edges AS (
+            SELECT source_id AS a, target_id AS b FROM dj_transition
+            UNION ALL
+            SELECT target_id AS a, source_id AS b FROM dj_transition
+        )
+        SELECT a, COUNT(DISTINCT b) AS deg FROM all_edges GROUP BY a
+        """
+    ).fetchall()
+    return {r["a"]: r["deg"] for r in rows}
+
+
+def get_direct_edge_raw_count(db: sqlite3.Connection, a_id: int, b_id: int) -> int | None:
+    """Return raw_count if a direct dj_transition exists in either direction, else None."""
+    row = db.execute(
+        "SELECT raw_count FROM dj_transition "
+        "WHERE (source_id = ? AND target_id = ?) OR (source_id = ? AND target_id = ?) "
+        "ORDER BY raw_count DESC LIMIT 1",
+        (a_id, b_id, b_id, a_id),
+    ).fetchone()
+    return int(row["raw_count"]) if row else None
+
+
+def compute_aa_sum(
+    db: sqlite3.Connection,
+    a_id: int,
+    b_id: int,
+    degrees: dict[int, int],
+) -> tuple[float, list[tuple[str, float]]]:
+    """Return (sum, [(neighbor_name, aa_score), ...]) sorted by score desc."""
+    rows = db.execute(
+        """
+        WITH a_n AS (
+            SELECT CASE WHEN source_id = :a THEN target_id ELSE source_id END AS nid
+            FROM dj_transition WHERE (source_id = :a OR target_id = :a) AND source_id != target_id
+        ),
+        b_n AS (
+            SELECT CASE WHEN source_id = :b THEN target_id ELSE source_id END AS nid
+            FROM dj_transition WHERE (source_id = :b OR target_id = :b) AND source_id != target_id
+        )
+        SELECT DISTINCT ar.id, ar.canonical_name
+        FROM a_n
+        JOIN b_n ON a_n.nid = b_n.nid
+        JOIN artist ar ON ar.id = a_n.nid
+        WHERE ar.id NOT IN (:a, :b)
+          AND ar.canonical_name NOT LIKE 'Various%'
+          AND ar.canonical_name NOT LIKE 'V/A%'
+        """,
+        {"a": a_id, "b": b_id},
+    ).fetchall()
+    scored: list[tuple[str, float]] = []
+    for r in rows:
+        deg = degrees.get(r["id"], 0)
+        if deg < 2:
+            continue
+        scored.append((r["canonical_name"], 1.0 / math.log(deg)))
+    scored.sort(key=lambda x: x[1], reverse=True)
+    return sum(s for _, s in scored), scored
+
+
+def matches_genre_axis(a: ArtistProfile, b: ArtistProfile, axis: str) -> bool:
+    if axis == "SAME":
+        return a.genre == b.genre
+    return a.genre != b.genre
+
+
+def sample_direct_cell(
+    db: sqlite3.Connection,
+    cell: CellSpec,
+    pool: list[ArtistProfile],
+    target: int,
+    rng: random.Random,
+    *,
+    used_pair_keys: set[frozenset[int]],
+) -> list[PairRecord]:
+    """Driven from the ``dj_transition`` table: enumerate edges over the pool.
+
+    Random sampling pair-wise from a 3000-artist pool wastes attempts on the
+    >99% of pairs that lack a direct edge. Starting from the edges and
+    filtering by (fame, richness, genre) reaches the target much faster.
+    """
+    pool_index = {a.id: a for a in pool}
+    rows = db.execute(
+        f"""
+        SELECT source_id, target_id, raw_count FROM dj_transition
+        WHERE raw_count >= {DIRECT_MIN_RAW_COUNT}
+          AND source_id != target_id
+          AND source_id IN ({",".join("?" * len(pool_index))})
+          AND target_id IN ({",".join("?" * len(pool_index))})
+        """,  # noqa: S608  -- pool ids are int from our SELECT, not user input
+        list(pool_index.keys()) + list(pool_index.keys()),
+    ).fetchall()
+
+    candidates: list[PairRecord] = []
+    seen: set[frozenset[int]] = set()
+    for r in rows:
+        a, b = pool_index[r["source_id"]], pool_index[r["target_id"]]
+        key = frozenset({a.id, b.id})
+        if key in seen or key in used_pair_keys:
+            continue
+        if not matches_genre_axis(a, b, cell.genre):
+            continue
+        seen.add(key)
+        candidates.append(PairRecord(cell=cell, a=a, b=b, raw_count=int(r["raw_count"])))
+
+    rng.shuffle(candidates)
+    out = candidates[:target]
+    for p in out:
+        used_pair_keys.add(frozenset({p.a.id, p.b.id}))
+    return out
+
+
+def sample_indirect_cell(
+    db: sqlite3.Connection,
+    cell: CellSpec,
+    pool: list[ArtistProfile],
+    degrees: dict[int, int],
+    target: int,
+    rng: random.Random,
+    *,
+    max_attempts: int,
+    used_pair_keys: set[frozenset[int]],
+) -> list[PairRecord]:
+    """Indirect pairs: no direct edge, but AA-sum across shared neighbors >= threshold.
+
+    Strategy: pick a seed artist, query for partners that share at least one
+    transition neighbor with the seed (a 1-SQL-query lookup), filter to the
+    pool and to no-direct-edge, then run the AA-sum test on the candidates.
+    Far cheaper than blind pair-wise random sampling.
+    """
+    pool_ids = {a.id for a in pool}
+    pool_by_id = {a.id: a for a in pool}
+    out: list[PairRecord] = []
+    seen_in_cell: set[frozenset[int]] = set()
+    attempts = 0
+    seed_pool = list(pool)
+    rng.shuffle(seed_pool)
+
+    for seed in seed_pool:
+        if len(out) >= target or attempts >= max_attempts:
+            break
+
+        partner_ids = db.execute(
+            """
+            WITH seed_n AS (
+                SELECT CASE WHEN source_id = :s THEN target_id ELSE source_id END AS nid
+                FROM dj_transition
+                WHERE (source_id = :s OR target_id = :s) AND source_id != target_id
+            ),
+            two_hop AS (
+                SELECT DISTINCT
+                    CASE WHEN dj_transition.source_id = seed_n.nid
+                         THEN dj_transition.target_id ELSE dj_transition.source_id END AS pid
+                FROM seed_n
+                JOIN dj_transition
+                  ON dj_transition.source_id = seed_n.nid
+                  OR dj_transition.target_id = seed_n.nid
+            )
+            SELECT pid FROM two_hop WHERE pid != :s
+            """,
+            {"s": seed.id},
+        ).fetchall()
+
+        partner_candidates = [pool_by_id[r["pid"]] for r in partner_ids if r["pid"] in pool_ids]
+        rng.shuffle(partner_candidates)
+
+        for partner in partner_candidates:
+            if len(out) >= target or attempts >= max_attempts:
+                break
+            attempts += 1
+            key = frozenset({seed.id, partner.id})
+            if key in seen_in_cell or key in used_pair_keys:
+                continue
+            seen_in_cell.add(key)
+
+            if not matches_genre_axis(seed, partner, cell.genre):
+                continue
+            if get_direct_edge_raw_count(db, seed.id, partner.id) is not None:
+                continue
+            aa_sum, neighbors = compute_aa_sum(db, seed.id, partner.id, degrees)
+            if aa_sum < MIN_AA_SUM:
+                continue
+            out.append(
+                PairRecord(
+                    cell=cell, a=seed, b=partner,
+                    aa_sum=aa_sum, aa_neighbors=neighbors[:5],
+                )
+            )
+            used_pair_keys.add(key)
+    return out
+
+
+def sample_cell(
+    db: sqlite3.Connection,
+    cell: CellSpec,
+    pool: list[ArtistProfile],
+    degrees: dict[int, int],
+    target: int,
+    rng: random.Random,
+    *,
+    max_attempts: int,
+    used_pair_keys: set[frozenset[int]],
+) -> list[PairRecord]:
+    """Dispatch to the appropriate per-edge-type sampler."""
+    if cell.edge == "DIRECT":
+        return sample_direct_cell(
+            db, cell, pool, target, rng, used_pair_keys=used_pair_keys,
+        )
+    return sample_indirect_cell(
+        db, cell, pool, degrees, target, rng,
+        max_attempts=max_attempts, used_pair_keys=used_pair_keys,
+    )
+
+
+def build_cells() -> list[CellSpec]:
+    return [
+        CellSpec(fame=f, richness=r, genre=g, edge=e)
+        for f, r, g, e in product(("HIGH", "LOW"), ("RICH", "THIN"), ("CROSS", "SAME"), ("DIRECT", "INDIRECT"))
+    ]
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--db-path", default="data/wxyc_artist_graph.db")
+    ap.add_argument("--out", required=True, help="Output JSONL path")
+    ap.add_argument("--per-cell", type=int, default=12, help="Pairs per cell (default 12).")
+    ap.add_argument("--max-attempts-per-cell", type=int, default=2000)
+    ap.add_argument("--seed", type=int, default=7)
+    args = ap.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+    db = open_db(args.db_path)
+    artists = load_eligible_artists(db)
+    degrees = compute_degrees(db)
+    pools = index_by_fame_richness(artists)
+    logger.info(
+        "Pools: %s",
+        {f"{k[0]}/{k[1]}": len(v) for k, v in sorted(pools.items())},
+    )
+
+    rng = random.Random(args.seed)
+    used: set[frozenset[int]] = set()
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    written = 0
+    counts: dict[str, int] = {}
+    with out_path.open("w") as fh:
+        for cell in build_cells():
+            pool_key = (cell.fame, cell.richness)
+            pool = pools.get(pool_key, [])
+            if len(pool) < 2:
+                logger.warning("Pool %s empty/small (%d) — skipping cell %s", pool_key, len(pool), cell.cell_id)
+                continue
+            pairs = sample_cell(
+                db,
+                cell,
+                pool,
+                degrees,
+                target=args.per_cell,
+                rng=rng,
+                max_attempts=args.max_attempts_per_cell,
+                used_pair_keys=used,
+            )
+            for p in pairs:
+                fh.write(p.to_jsonl() + "\n")
+                written += 1
+            counts[cell.cell_id] = len(pairs)
+            logger.info("Cell %s: %d pairs", cell.cell_id, len(pairs))
+
+    logger.info("Wrote %d pairs across %d cells -> %s", written, len(counts), out_path)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_eval_merge_labels.py
+++ b/tests/unit/test_eval_merge_labels.py
@@ -1,0 +1,237 @@
+"""Unit tests for the label merge utility."""
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+
+from scripts.eval.merge_labels import (
+    VALID_FAILURE_MODE,
+    VALID_SEVERITY,
+    _normalize_label,
+    main,
+)
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> None:
+    with path.open("w") as fh:
+        for r in rows:
+            fh.write(json.dumps(r) + "\n")
+
+
+def _write_csv(path: Path, rows: list[dict]) -> None:
+    if not rows:
+        path.write_text("")
+        return
+    cols = list(rows[0].keys())
+    with path.open("w", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=cols)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+class TestNormalizeLabel:
+    def test_lowercases_and_trims(self):
+        assert _normalize_label("  Severe ") == "severe"
+        assert _normalize_label("Subject Hallucination") == "subject_hallucination"
+        assert _normalize_label("dj-intent") == "dj_intent"
+
+    def test_blank_and_none(self):
+        assert _normalize_label(None) == ""
+        assert _normalize_label("") == ""
+        assert _normalize_label("   ") == ""
+
+
+class TestMergeHappyPath:
+    def test_merges_well_formed_csv(self, tmp_path):
+        backing = tmp_path / "labeling.jsonl"
+        _write_jsonl(
+            backing,
+            [
+                {"row_id": "R0001", "narrative": "n1"},
+                {"row_id": "R0002", "narrative": "n2"},
+            ],
+        )
+        labels = tmp_path / "labels.csv"
+        _write_csv(
+            labels,
+            [
+                {
+                    "row_id": "R0001",
+                    "severity": "severe",
+                    "failure_mode": "subject_hallucination",
+                    "notes": "wrong artist",
+                },
+                {"row_id": "R0002", "severity": "not_wrong", "failure_mode": "", "notes": ""},
+            ],
+        )
+        out = tmp_path / "merged.jsonl"
+        rc = main(
+            [
+                "--labeling-jsonl",
+                str(backing),
+                "--labels-csv",
+                str(labels),
+                "--labeler",
+                "jake",
+                "--out",
+                str(out),
+            ]
+        )
+        assert rc == 0
+        rows = _read_jsonl(out)
+        assert len(rows) == 2
+        assert rows[0]["label"] == {
+            "labeler": "jake",
+            "severity": "severe",
+            "failure_mode": "subject_hallucination",
+            "notes": "wrong artist",
+        }
+        assert rows[1]["label"]["severity"] == "not_wrong"
+        assert rows[1]["label"]["failure_mode"] == ""
+
+
+class TestValidation:
+    def test_invalid_severity_errors_but_skips_row(self, tmp_path):
+        backing = tmp_path / "labeling.jsonl"
+        _write_jsonl(backing, [{"row_id": "R0001", "narrative": "n1"}])
+        labels = tmp_path / "labels.csv"
+        _write_csv(
+            labels,
+            [
+                {"row_id": "R0001", "severity": "BOGUS", "failure_mode": "", "notes": ""},
+            ],
+        )
+        out = tmp_path / "merged.jsonl"
+        rc = main(
+            [
+                "--labeling-jsonl",
+                str(backing),
+                "--labels-csv",
+                str(labels),
+                "--labeler",
+                "jake",
+                "--out",
+                str(out),
+            ]
+        )
+        assert rc == 1
+        # Output exists but is empty (the bad row was rejected)
+        assert _read_jsonl(out) == []
+
+    def test_severe_without_failure_mode_errors(self, tmp_path):
+        backing = tmp_path / "labeling.jsonl"
+        _write_jsonl(backing, [{"row_id": "R0001", "narrative": "n1"}])
+        labels = tmp_path / "labels.csv"
+        _write_csv(
+            labels,
+            [
+                {"row_id": "R0001", "severity": "severe", "failure_mode": "", "notes": ""},
+            ],
+        )
+        out = tmp_path / "merged.jsonl"
+        rc = main(
+            [
+                "--labeling-jsonl",
+                str(backing),
+                "--labels-csv",
+                str(labels),
+                "--labeler",
+                "jake",
+                "--out",
+                str(out),
+            ]
+        )
+        assert rc == 1
+
+    def test_unknown_row_id_errors(self, tmp_path):
+        backing = tmp_path / "labeling.jsonl"
+        _write_jsonl(backing, [{"row_id": "R0001", "narrative": "n1"}])
+        labels = tmp_path / "labels.csv"
+        _write_csv(
+            labels,
+            [
+                {
+                    "row_id": "R9999",
+                    "severity": "severe",
+                    "failure_mode": "subject_hallucination",
+                    "notes": "",
+                },
+            ],
+        )
+        out = tmp_path / "merged.jsonl"
+        rc = main(
+            [
+                "--labeling-jsonl",
+                str(backing),
+                "--labels-csv",
+                str(labels),
+                "--labeler",
+                "jake",
+                "--out",
+                str(out),
+            ]
+        )
+        assert rc == 1
+
+    def test_blank_severity_marks_unlabeled_not_error(self, tmp_path):
+        backing = tmp_path / "labeling.jsonl"
+        _write_jsonl(
+            backing,
+            [
+                {"row_id": "R0001", "narrative": "n1"},
+                {"row_id": "R0002", "narrative": "n2"},
+            ],
+        )
+        labels = tmp_path / "labels.csv"
+        _write_csv(
+            labels,
+            [
+                {
+                    "row_id": "R0001",
+                    "severity": "severe",
+                    "failure_mode": "subject_hallucination",
+                    "notes": "",
+                },
+                {"row_id": "R0002", "severity": "", "failure_mode": "", "notes": ""},
+            ],
+        )
+        out = tmp_path / "merged.jsonl"
+        rc = main(
+            [
+                "--labeling-jsonl",
+                str(backing),
+                "--labels-csv",
+                str(labels),
+                "--labeler",
+                "jake",
+                "--out",
+                str(out),
+            ]
+        )
+        assert rc == 0
+        # Only labeled row written
+        rows = _read_jsonl(out)
+        assert len(rows) == 1
+        assert rows[0]["row_id"] == "R0001"
+
+
+class TestRubricCoverage:
+    """Sanity: the label vocab in the script matches the rubric in docs/."""
+
+    def test_severity_vocab(self):
+        assert VALID_SEVERITY == {"severe", "minor", "not_wrong"}
+
+    def test_failure_mode_vocab(self):
+        assert VALID_FAILURE_MODE == {
+            "subject_hallucination",
+            "neighbor_characterization",
+            "dj_intent",
+            "data_noise",
+            "other",
+        }

--- a/tests/unit/test_eval_sample_pairs.py
+++ b/tests/unit/test_eval_sample_pairs.py
@@ -1,0 +1,263 @@
+"""Unit tests for the eval-set pair sampler's classification logic."""
+
+from __future__ import annotations
+
+import math
+import sqlite3
+
+import pytest
+
+from scripts.eval.sample_pairs import (
+    DIRECT_MIN_RAW_COUNT,
+    MIN_AA_SUM,
+    ArtistProfile,
+    CellSpec,
+    PairRecord,
+    build_cells,
+    compute_aa_sum,
+    compute_degrees,
+    get_direct_edge_raw_count,
+    index_by_fame_richness,
+    matches_genre_axis,
+    sample_cell,
+)
+
+
+def _profile(
+    *,
+    aid: int = 1,
+    name: str = "Test Artist",
+    genre: str = "Rock",
+    plays: int = 500,
+    style_count: int = 0,
+    has_audio: bool = False,
+) -> ArtistProfile:
+    return ArtistProfile(
+        id=aid,
+        name=name,
+        genre=genre,
+        total_plays=plays,
+        style_count=style_count,
+        has_audio=has_audio,
+    )
+
+
+class TestArtistProfileFame:
+    def test_high_fame_strict_above_threshold(self):
+        assert _profile(plays=801).fame == "HIGH"
+        assert _profile(plays=800).fame is None  # boundary excluded
+
+    def test_low_fame_inclusive_band(self):
+        assert _profile(plays=100).fame == "LOW"
+        assert _profile(plays=400).fame == "LOW"
+        assert _profile(plays=99).fame is None
+        assert _profile(plays=401).fame is None
+
+    def test_mid_band_excluded(self):
+        assert _profile(plays=600).fame is None
+
+
+class TestArtistProfileRichness:
+    def test_rich_requires_styles_and_audio(self):
+        assert _profile(style_count=3, has_audio=True).richness == "RICH"
+        assert _profile(style_count=10, has_audio=True).richness == "RICH"
+
+    def test_thin_when_styles_below_threshold(self):
+        assert _profile(style_count=2, has_audio=True).richness == "THIN"
+
+    def test_thin_when_no_audio(self):
+        assert _profile(style_count=10, has_audio=False).richness == "THIN"
+
+
+class TestGenreAxis:
+    def test_same_axis_matches_equal_genres(self):
+        a = _profile(aid=1, genre="Rock")
+        b = _profile(aid=2, genre="Rock")
+        assert matches_genre_axis(a, b, "SAME") is True
+        assert matches_genre_axis(a, b, "CROSS") is False
+
+    def test_cross_axis_matches_different_genres(self):
+        a = _profile(aid=1, genre="Rock")
+        b = _profile(aid=2, genre="Jazz")
+        assert matches_genre_axis(a, b, "CROSS") is True
+        assert matches_genre_axis(a, b, "SAME") is False
+
+
+class TestIndexByFameRichness:
+    def test_buckets_artists_excluding_mid_band(self):
+        artists = [
+            _profile(aid=1, plays=900, style_count=3, has_audio=True),
+            _profile(aid=2, plays=200, style_count=1, has_audio=False),
+            _profile(aid=3, plays=600, style_count=5, has_audio=True),  # mid-band, excluded
+            _profile(aid=4, plays=950, style_count=0, has_audio=False),
+        ]
+        idx = index_by_fame_richness(artists)
+        assert ("HIGH", "RICH") in idx and len(idx[("HIGH", "RICH")]) == 1
+        assert ("HIGH", "THIN") in idx and len(idx[("HIGH", "THIN")]) == 1
+        assert ("LOW", "THIN") in idx and len(idx[("LOW", "THIN")]) == 1
+        assert ("LOW", "RICH") not in idx  # no LOW+RICH artist in fixture
+        # mid-band artist absent from every bucket
+        flat = [a.id for v in idx.values() for a in v]
+        assert 3 not in flat
+
+
+class TestBuildCells:
+    def test_emits_sixteen_cells(self):
+        cells = build_cells()
+        assert len(cells) == 16
+        ids = [c.cell_id for c in cells]
+        assert len(set(ids)) == 16
+        for cid in ids:
+            parts = cid.split("-")
+            assert parts[0] in {"HIGH", "LOW"}
+            assert parts[1] in {"RICH", "THIN"}
+            assert parts[2] in {"CROSS", "SAME"}
+            assert parts[3] in {"DIRECT", "INDIRECT"}
+
+
+@pytest.fixture
+def in_memory_db() -> sqlite3.Connection:
+    """Tiny graph: A↔B↔C, where A↔B has raw_count 5 (DIRECT-eligible)."""
+    db = sqlite3.connect(":memory:")
+    db.row_factory = sqlite3.Row
+    db.executescript(
+        """
+        CREATE TABLE artist (
+            id INTEGER PRIMARY KEY, canonical_name TEXT, genre TEXT,
+            total_plays INTEGER NOT NULL DEFAULT 0
+        );
+        CREATE TABLE dj_transition (
+            source_id INTEGER, target_id INTEGER, raw_count INTEGER, pmi REAL,
+            PRIMARY KEY (source_id, target_id)
+        );
+        INSERT INTO artist VALUES
+          (1, 'A', 'Rock', 1000),
+          (2, 'B', 'Rock', 900),
+          (3, 'C', 'Jazz', 850),
+          (4, 'Hub', 'Rock', 500),
+          (5, 'SelfLooper', 'Rock', 950);
+        -- A-B direct edge, raw_count 5
+        INSERT INTO dj_transition VALUES (1, 2, 5, 1.0);
+        -- A-Hub, B-Hub, C-Hub: A and B share neighbor C via Hub
+        INSERT INTO dj_transition VALUES (1, 4, 2, 0.5);
+        INSERT INTO dj_transition VALUES (2, 4, 2, 0.5);
+        INSERT INTO dj_transition VALUES (3, 4, 2, 0.5);
+        -- SelfLooper -> SelfLooper: a DJ played the same artist back-to-back.
+        -- This is real in production data; the sampler must NOT emit it as a pair.
+        INSERT INTO dj_transition VALUES (5, 5, 4, 2.0);
+        """
+    )
+    return db
+
+
+class TestDirectEdgeLookup:
+    def test_finds_edge_either_direction(self, in_memory_db):
+        assert get_direct_edge_raw_count(in_memory_db, 1, 2) == 5
+        assert get_direct_edge_raw_count(in_memory_db, 2, 1) == 5
+
+    def test_returns_none_when_no_edge(self, in_memory_db):
+        # A↔C: no direct edge in fixture
+        assert get_direct_edge_raw_count(in_memory_db, 1, 3) is None
+
+
+class TestComputeDegrees:
+    def test_includes_both_directions(self, in_memory_db):
+        deg = compute_degrees(in_memory_db)
+        # Hub (id=4) has 3 distinct partners
+        assert deg[4] == 3
+        # A (id=1) has 2 partners (B, Hub)
+        assert deg[1] == 2
+
+
+class TestComputeAaSum:
+    def test_returns_zero_when_no_shared_neighbors(self, in_memory_db):
+        # B (id=2) and C (id=3) share Hub (id=4), so this would NOT be zero.
+        # Instead test a pair that genuinely shares nothing — there isn't one
+        # in the small fixture, so we verify the Hub contribution shape.
+        degrees = compute_degrees(in_memory_db)
+        aa_sum, neighbors = compute_aa_sum(in_memory_db, 1, 3, degrees)
+        # Only Hub is shared (degree 3), so aa = 1/log(3)
+        assert pytest.approx(aa_sum, rel=1e-6) == 1.0 / math.log(3)
+        assert neighbors == [("Hub", pytest.approx(1.0 / math.log(3), rel=1e-6))]
+
+
+class TestPairRecordSerialization:
+    def test_direct_record_includes_raw_count(self):
+        rec = PairRecord(
+            cell=CellSpec("HIGH", "RICH", "CROSS", "DIRECT"),
+            a=_profile(aid=1, name="A", plays=1000),
+            b=_profile(aid=2, name="B", plays=900, genre="Jazz"),
+            raw_count=4,
+        )
+        row = rec.to_jsonl()
+        assert '"cell_id":"HIGH-RICH-CROSS-DIRECT"' in row
+        assert '"raw_count":4' in row
+        assert "aa_sum" not in row
+
+    def test_indirect_record_includes_aa_sum(self):
+        rec = PairRecord(
+            cell=CellSpec("LOW", "THIN", "SAME", "INDIRECT"),
+            a=_profile(aid=1, name="A", plays=200),
+            b=_profile(aid=2, name="B", plays=300),
+            aa_sum=1.234,
+        )
+        row = rec.to_jsonl()
+        assert '"aa_sum":1.234' in row
+        assert "raw_count" not in row
+
+
+class TestSampleCellRespectsAxes:
+    def test_direct_cell_only_emits_pairs_with_min_raw_count(self, in_memory_db):
+        artists = [
+            _profile(aid=1, name="A", genre="Rock", plays=1000),
+            _profile(aid=2, name="B", genre="Rock", plays=900),
+        ]
+        cell = CellSpec("HIGH", "THIN", "SAME", "DIRECT")
+        import random as _random
+
+        rng = _random.Random(0)
+        used: set[frozenset[int]] = set()
+        degrees = compute_degrees(in_memory_db)
+        pairs = sample_cell(
+            in_memory_db,
+            cell,
+            artists,
+            degrees,
+            target=5,
+            rng=rng,
+            max_attempts=200,
+            used_pair_keys=used,
+        )
+        # The single eligible A-B pair should be emitted exactly once.
+        assert len(pairs) == 1
+        assert pairs[0].raw_count is not None
+        assert pairs[0].raw_count >= DIRECT_MIN_RAW_COUNT
+        assert MIN_AA_SUM > 0  # constant exists; sanity
+
+    def test_direct_cell_excludes_self_loops(self, in_memory_db):
+        """A DJ playing one artist back-to-back creates a self-loop in
+        dj_transition. The sampler must filter these — a pair where
+        source_id == target_id can't be narrated coherently and pollutes
+        the eval-set's relationship-vs-attribute distinction."""
+        artists = [
+            _profile(aid=5, name="SelfLooper", genre="Rock", plays=950),
+        ]
+        cell = CellSpec("HIGH", "THIN", "SAME", "DIRECT")
+        import random as _random
+
+        rng = _random.Random(0)
+        used: set[frozenset[int]] = set()
+        degrees = compute_degrees(in_memory_db)
+        pairs = sample_cell(
+            in_memory_db,
+            cell,
+            artists,
+            degrees,
+            target=5,
+            rng=rng,
+            max_attempts=200,
+            used_pair_keys=used,
+        )
+        assert pairs == []
+        # And should not be re-emitted on a fresh call from the same fixture.
+        assert all(p.a.id != p.b.id for p in pairs)


### PR DESCRIPTION
## Summary

Part 1 of #280 (the eval-set substrate epic). Adds `scripts/eval/` — a self-contained tooling package that builds a labeled corpus of narrative-endpoint outputs. Companion docs (rubric + baseline findings) ship in PR #2 (link added below when filed).

## What's in this PR

Pure tooling: 8 new scripts under `scripts/eval/`, 2 unit-test files, 1 package README. **Zero edits to existing code paths** — purely additive.

| File | Lines | Purpose |
|---|---|---|
| `sample_pairs.py` | 462 | 16-cell stratified sampler (fame x richness x genre x edge), self-loop-safe |
| `generate_narratives.py` | 169 | Drives `/narrative` endpoint via `TestClient` |
| `build_wrong_set.py` | 244 | Data-shuffle gold positives via direct Haiku call |
| `export_labeling.py` | 181 | Joins narratives with input data; emits CSV + JSONL |
| `merge_labels.py` | 163 | Validates filled labeler CSV; per-labeler outputs |
| `backscore.py` | 297 | `score` + `metrics` subcommands |
| `tests/unit/test_eval_sample_pairs.py` | 263 | 18 sampler tests incl. self-loop regression |
| `tests/unit/test_eval_merge_labels.py` | 237 | 9 label-merge validation tests |
| `scripts/eval/README.md` | 118 | End-to-end workflow doc |
| `scripts/eval/__init__.py` | 13 | Package init |

Total: 2147 lines. Most volume is per-script docstrings; the largest single file (`sample_pairs.py`) is a stratified sampler with detailed comments per axis.

## Why two PRs

The eval-set work as a whole comes to ~2344 lines. Splitting keeps each PR under your usual review threshold:
- This PR: scripts + tests + scripts-package README (2147 lines)
- Follow-up PR: `docs/eval-set-rubric.md` + `docs/eval-set-baseline-findings.md` (197 lines, no code)

The docs PR is stacked on this one. Once this lands, the docs PR rebases onto main and shrinks to a clean two-file diff.

## Why this work

`docs/narrative-enrichment-whitepaper.md` §7.5 argues qualitatively that `token_match_v1` and `claim_ratio_v1` measure grounding fidelity, not truthiness. Without a labeled corpus we can't measure whether prompt mitigations actually reduce wrongness, the constraint ontology has no yardstick, and Phase 2 / Phase 3 can't compare head-to-head on impact. This is the substrate that makes those measurements possible.

## Test plan

- [x] `pytest tests/unit/test_eval_sample_pairs.py tests/unit/test_eval_merge_labels.py` (27 passed)
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `mypy semantic_index/` clean
- [x] Smoke-tested `sample_pairs.py` against the production `data/wxyc_artist_graph.db` (165 candidate pairs across 16 cells)
- [x] Smoke-tested `generate_narratives.py` end-to-end (252 narratives generated, ~/bin/zsh.30 of Haiku)
- [x] Smoke-tested `build_wrong_set.py` (30 data-shuffle rows)
- [x] Smoke-tested `backscore.py score` end-to-end (282 rows scored, ~/bin/zsh.30 of Haiku)
- [x] Smoke-tested `backscore.py metrics` against a 20-row self-labeled subset

Output artifacts (`output/eval/*.jsonl`, `output/eval/*.csv`) are gitignored and not part of the diff. They're regenerated by running the pipeline.

## Related

- Closes nothing on its own; #280 is closed by the docs PR.
- Parent: #280
- Follow-ups: #277 (field-corruption wrong-set), #278 (pretraining-bait wrong-set)
- Whitepaper sections used: §6.2 (risk matrix), §6.3 (failure modes), §7.5 (grounding-vs-truthiness gap), §8 (constraint ontology motivation)