### PR TITLE
[E2 step 0d 3/3] semantic-index feature-flag documentation + grep-assert (cross-cache-identity)

### DIFF
--- a/.github/workflows/cross-cache-identity-flags.yml
+++ b/.github/workflows/cross-cache-identity-flags.yml
@@ -1,0 +1,30 @@
+name: Cross-cache-identity flag-doc consistency
+
+# Asserts that the semantic-index-owned cross-cache-identity feature flags
+# listed in CLAUDE.md match the §4.2 locked inventory. Runs on every PR
+# touching CLAUDE.md, the script, or this workflow — the existing ci.yml
+# ignores `**/*.md` paths, so a dedicated workflow is needed to guard
+# CLAUDE.md drift specifically.
+#
+# Plan reference: WXYC/wiki plans/library-hook-canonicalization-plan.md §4.2.
+
+on:
+  pull_request:
+    paths:
+      - 'CLAUDE.md'
+      - 'scripts/check_cross_cache_identity_flags.sh'
+      - '.github/workflows/cross-cache-identity-flags.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'CLAUDE.md'
+      - 'scripts/check_cross_cache_identity_flags.sh'
+      - '.github/workflows/cross-cache-identity-flags.yml'
+
+jobs:
+  check:
+    name: Flag-doc consistency
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: bash scripts/check_cross_cache_identity_flags.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -473,6 +473,16 @@ The SQLite database and sidecar caches live in the bind-mounted `/data` director
 - `DATABASE_URL_BACKEND` — Backend-Service PostgreSQL DSN for nightly sync (required when `SYNC_ENABLED=true`; uses the RDS private endpoint since EC2 and RDS share a VPC)
 - `SYNC_MIN_COUNT` — minimum co-occurrence count for DJ transition edges (default: `2`)
 
+**Cross-cache-identity feature flags.** Per-cache toggles for which `wxyc_library` hook table the resolver reads (legacy schema vs. new normalized schema). All default `false`. The **canonical inventory** (with naming-convention rationale and approval gates) lives in `WXYC/Backend-Service/CLAUDE.md` "Cross-cache-identity feature flags (canonical inventory)". When a flag is renamed or its default changes, both the canonical Backend section AND this list must update in the same PR; CI on this repo grep-asserts the names listed here match the §4.2 inventory.
+
+| Flag | Scope | Default | Set true when |
+|---|---|---|---|
+| `SI_USE_NEW_HOOK_DISCOGS` | per-cache (Docker discogs, port 5433) | `false` | LML cuts over for that cache + 7 days clean |
+| `SI_USE_NEW_HOOK_MUSICBRAINZ` | per-cache | `false` | LML cuts over for that cache + 7 days clean |
+| `SI_USE_NEW_HOOK_WIKIDATA` | per-cache | `false` | LML cuts over for that cache + 7 days clean |
+
+Production location: EC2 systemd unit env file (`.env.semantic-index`). Updater is Jake via SSH + edit env file + container restart. Plan reference: `WXYC/wiki/plans/library-hook-canonicalization-plan.md` §4.2.
+
 **GitHub Actions secrets** (shared with Backend-Service, same GitHub org):
 - `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, `AWS_ECR_URI`
 - `EC2_HOST`, `EC2_USER`, `EC2_SSH_KEY`

--- a/scripts/check_cross_cache_identity_flags.sh
+++ b/scripts/check_cross_cache_identity_flags.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Asserts that the semantic-index-owned cross-cache-identity feature flags
+# listed in CLAUDE.md match the §4.2 locked inventory.
+#
+# Tier 1 (this PR, BS#667): doc-vs-expected-list.
+# Tier 2 (E1 hook-loader PR for SI consumers): adds a check that flag names
+# referenced in code match the doc.
+#
+# Plan reference: WXYC/wiki plans/library-hook-canonicalization-plan.md §4.2.
+# Canonical: WXYC/Backend-Service/CLAUDE.md "Cross-cache-identity feature flags (canonical inventory)".
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CLAUDE_MD="$REPO_ROOT/CLAUDE.md"
+
+if [[ ! -f "$CLAUDE_MD" ]]; then
+  echo "FAIL: $CLAUDE_MD not found." >&2
+  exit 1
+fi
+
+# Locked SI-owned flag names per §4.2.
+expected=(
+  "SI_USE_NEW_HOOK_DISCOGS"
+  "SI_USE_NEW_HOOK_MUSICBRAINZ"
+  "SI_USE_NEW_HOOK_WIKIDATA"
+)
+
+# Extract SI_USE_NEW_HOOK_* names from CLAUDE.md (any occurrence; the doc has
+# only one canonical mention of each). Backtick-quoted in the table.
+documented=$(
+  grep -oE '`(SI_USE_NEW_HOOK_[A-Z_]+)`' "$CLAUDE_MD" | tr -d '`' | sort -u
+)
+
+if [[ -z "$documented" ]]; then
+  echo "FAIL: no SI_USE_NEW_HOOK_* flags found in CLAUDE.md." >&2
+  exit 1
+fi
+
+expected_sorted=$(printf '%s\n' "${expected[@]}" | sort -u)
+
+missing=$(comm -23 <(printf '%s\n' "$expected_sorted") <(printf '%s\n' "$documented"))
+extra=$(comm -13 <(printf '%s\n' "$expected_sorted") <(printf '%s\n' "$documented"))
+
+failed=0
+if [[ -n "$missing" ]]; then
+  echo "FAIL: §4.2 SI-owned flags missing from CLAUDE.md:" >&2
+  echo "$missing" | sed 's/^/  - /' >&2
+  failed=1
+fi
+if [[ -n "$extra" ]]; then
+  echo "FAIL: CLAUDE.md lists SI_USE_NEW_HOOK_* flags not in §4.2:" >&2
+  echo "$extra" | sed 's/^/  - /' >&2
+  echo "  If a new SI cross-cache-identity flag is being introduced, update §4.2 first." >&2
+  failed=1
+fi
+
+if [[ "$failed" -ne 0 ]]; then
+  echo "" >&2
+  echo "Canonical inventory: WXYC/Backend-Service/CLAUDE.md 'Cross-cache-identity feature flags (canonical inventory)'." >&2
+  exit 1
+fi
+
+count=$(printf '%s\n' "$expected_sorted" | wc -l | tr -d ' ')
+echo "PASS: $count semantic-index-owned cross-cache-identity flag(s) consistent with §4.2."


### PR DESCRIPTION
## Summary

semantic-index half of WXYC/Backend-Service#667 (E2 step 0d, part 3 of 3). Adds the 3 SI-owned per-cache `SI_USE_NEW_HOOK_*` flags from §4.2's locked inventory to CLAUDE.md and a CI grep-assert.

## Changes

- `CLAUDE.md` — new "Cross-cache-identity feature flags" subsection in the Deployment / Configuration block. Lists `SI_USE_NEW_HOOK_DISCOGS`, `SI_USE_NEW_HOOK_MUSICBRAINZ`, `SI_USE_NEW_HOOK_WIKIDATA` with default `false` and approval gate "LML cuts over for that cache + 7 days clean". Cross-references the canonical inventory in WXYC/Backend-Service/CLAUDE.md.
- `scripts/check_cross_cache_identity_flags.sh` — tier-1 grep-assert (doc-vs-§4.2-locked-list).
- `.github/workflows/cross-cache-identity-flags.yml` — dedicated workflow. Necessary because the existing `ci.yml` ignores `**/*.md` paths.

## .env.example divergence (calling out)

The BS#667 issue body groups semantic-index with Backend and LML as repos that "amend `.env.example`", but semantic-index does not have a checked-in `.env.example` — only the EC2-side `.env.semantic-index` documented in CLAUDE.md. Documenting in CLAUDE.md is consistent with the issue body's CLAUDE.md-Configuration treatment of repos without `.env.example`.

## Test plan

- [x] `bash scripts/check_cross_cache_identity_flags.sh` PASS locally (3 SI-owned flags consistent with §4.2).
- [x] Pre-commit hooks (ruff check, ruff format --check, mypy) all pass.
- [ ] Cross-cache-identity flag-doc consistency CI green on push.

## Plan reference

`WXYC/wiki/plans/library-hook-canonicalization-plan.md` §4.2.

## Related

- Parent issue: WXYC/Backend-Service#667 (closes when parts 1/3 + 2/3 + 3/3 all merge)
- Canonical inventory PR (1/3): WXYC/Backend-Service#740
- LML PR (2/3): WXYC/library-metadata-lookup#253
- Epic parent: WXYC/Backend-Service#663 (E2)