### PR TITLE
Polish labeling UI: sticky layout, friendly labels, tooltips

### DIFF
--- a/semantic_index/labeling_app/row_source.py
+++ b/semantic_index/labeling_app/row_source.py
@@ -60,7 +60,7 @@ class RowSource:
                 {
                     "row_id": r["row_id"],
                     "cell_id": r.get("cell_id", ""),
-                    "pair": f"{r.get('source_name', '?')} <-> {r.get('target_name', '?')}",
+                    "pair": f"{r.get('source_name', '?')} ↔ {r.get('target_name', '?')}",
                     "insufficient_signal": bool(r.get("insufficient_signal")),
                 }
             )
@@ -74,5 +74,5 @@ class RowSource:
 
 def _redact(row: dict) -> dict:
     return {k: v for k, v in row.items() if k not in REDACTED_FIELDS} | {
-        "pair": f"{row.get('source_name', '?')} <-> {row.get('target_name', '?')}",
+        "pair": f"{row.get('source_name', '?')} ↔ {row.get('target_name', '?')}",
     }

--- a/semantic_index/labeling_app/static/index.html
+++ b/semantic_index/labeling_app/static/index.html
@@ -24,10 +24,10 @@
 
     <article id="row-card" hidden>
       <header class="row-header">
-        <div>
+        <div class="row-meta">
           <span id="row-id" class="row-id"></span>
           <span id="row-cell" class="cell"></span>
-          <span id="row-insufficient" class="badge" hidden>insufficient signal</span>
+          <span id="row-insufficient" class="badge" hidden title="The model declined to write a confident narrative — there wasn't enough musical signal to ground claims. These rows usually don't carry severe errors.">low signal</span>
         </div>
         <div id="progress" class="progress"></div>
       </header>
@@ -37,47 +37,76 @@
       <section class="narrative-block">
         <h3>Narrative</h3>
         <p id="row-narrative"></p>
-        <div class="meta">
-          token-match: <span id="row-token-match"></span>
-        </div>
       </section>
 
       <section class="data-grid">
-        <div>
-          <h3>Source</h3>
-          <pre id="row-source-data"></pre>
+        <div class="data-card">
+          <h3>Source artist</h3>
+          <dl id="row-source-data"></dl>
         </div>
-        <div>
-          <h3>Target</h3>
-          <pre id="row-target-data"></pre>
+        <div class="data-card">
+          <h3>Target artist</h3>
+          <dl id="row-target-data"></dl>
         </div>
       </section>
 
-      <section>
-        <h3>Shared neighbors</h3>
+      <section class="neighbors-block">
+        <h3>Shared neighbors <span class="hint" title="Other artists that DJs played alongside both of these. Higher score = stronger shared context.">?</span></h3>
         <ul id="row-neighbors"></ul>
       </section>
 
       <form id="label-form" autocomplete="off">
         <fieldset>
-          <legend>Severity</legend>
-          <label><input type="radio" name="severity" value="severe" /> severe</label>
-          <label><input type="radio" name="severity" value="minor" /> minor</label>
-          <label><input type="radio" name="severity" value="not_wrong" /> not_wrong</label>
+          <legend>How wrong is the narrative?</legend>
+          <label title="A wrong claim that would mislead a listener — wrong artist identity, fabricated collaboration, made-up genre, etc.">
+            <input type="radio" name="severity" value="severe" />
+            <strong>Severe</strong>
+            <span class="hint-text">would mislead a listener</span>
+          </label>
+          <label title="Slightly off but mostly correct — overstates a connection, vague in a way that's not strictly wrong, etc.">
+            <input type="radio" name="severity" value="minor" />
+            <strong>Minor</strong>
+            <span class="hint-text">a little off, mostly fine</span>
+          </label>
+          <label title="No problem with any claim. An 'insufficient signal' canned response counts as fine.">
+            <input type="radio" name="severity" value="not_wrong" />
+            <strong>Looks fine</strong>
+            <span class="hint-text">no problem</span>
+          </label>
         </fieldset>
 
         <fieldset id="fm-fieldset">
-          <legend>Failure mode</legend>
-          <label><input type="radio" name="failure_mode" value="subject_hallucination" /> subject_hallucination</label>
-          <label><input type="radio" name="failure_mode" value="neighbor_characterization" /> neighbor_characterization</label>
-          <label><input type="radio" name="failure_mode" value="dj_intent" /> dj_intent</label>
-          <label><input type="radio" name="failure_mode" value="data_noise" /> data_noise</label>
-          <label><input type="radio" name="failure_mode" value="other" /> other</label>
+          <legend>What kind of mistake?</legend>
+          <label title="The narrative makes claims about a DIFFERENT artist than the one named — usually because the model confused them with a similarly-named musician.">
+            <input type="radio" name="failure_mode" value="subject_hallucination" />
+            <strong>Wrong artist</strong>
+            <span class="hint-text">confused with someone else</span>
+          </label>
+          <label title="A claim about a third artist mentioned in the narrative is wrong — wrong genre, made-up collaboration, etc.">
+            <input type="radio" name="failure_mode" value="neighbor_characterization" />
+            <strong>Wrong about a third party</strong>
+            <span class="hint-text">misdescribes a mentioned artist</span>
+          </label>
+          <label title="The narrative claims a DJ played them together for a reason that the data doesn't support.">
+            <input type="radio" name="failure_mode" value="dj_intent" />
+            <strong>Misread DJ intent</strong>
+            <span class="hint-text">invents the WHY</span>
+          </label>
+          <label title="The narrative is faithful to its inputs, but the inputs themselves were misleading — e.g. an outlier Discogs style for an indie band.">
+            <input type="radio" name="failure_mode" value="data_noise" />
+            <strong>Misled by bad input</strong>
+            <span class="hint-text">faithful to noisy data</span>
+          </label>
+          <label title="Something else is wrong. Use the notes field to explain.">
+            <input type="radio" name="failure_mode" value="other" />
+            <strong>Other</strong>
+            <span class="hint-text">explain in notes</span>
+          </label>
         </fieldset>
 
         <label class="notes">
-          Notes
-          <textarea name="notes" rows="3" placeholder="Optional. Concrete: which claim is wrong, which neighbor was hallucinated, etc."></textarea>
+          Notes <span class="muted">(optional)</span>
+          <textarea name="notes" rows="3" placeholder="Be concrete: which claim is wrong, which neighbor was hallucinated, etc."></textarea>
         </label>
 
         <div class="actions">
@@ -86,6 +115,10 @@
           <button type="button" id="next-button" title="Tab or j">↓ next</button>
           <span id="save-status" class="muted"></span>
         </div>
+
+        <p class="kbd-hint muted">
+          Hotkeys: <kbd>j</kbd>/<kbd>k</kbd> next/prev row · <kbd>1</kbd>/<kbd>2</kbd>/<kbd>3</kbd> severe/minor/fine · <kbd>⌘↵</kbd> save and advance
+        </p>
       </form>
     </article>
   </section>

--- a/semantic_index/labeling_app/static/labeling.css
+++ b/semantic_index/labeling_app/static/labeling.css
@@ -1,13 +1,20 @@
+/* Layout: header + sidebar are sticky, the page itself scrolls. No internal
+   iframe-style scrollers on the right pane. */
 * { box-sizing: border-box; }
-html, body { margin: 0; padding: 0; height: 100%; }
+html { height: 100%; }
 body {
-  font: 14px/1.45 -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, sans-serif;
+  margin: 0;
+  font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, sans-serif;
   color: #1a1a1a;
   background: #fafafa;
+  min-height: 100vh;
 }
 .muted { color: #888; font-weight: normal; }
 
 header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -27,24 +34,30 @@ header h1 { font-size: 1rem; margin: 0; font-weight: 600; }
   border-radius: 3px;
   cursor: pointer;
   text-decoration: none;
+  font: inherit;
   font-size: 0.8rem;
 }
 #who button:hover, #who a:hover { background: #333; }
 
 main {
   display: grid;
-  grid-template-columns: 280px 1fr;
-  height: calc(100vh - 44px);
+  grid-template-columns: 280px minmax(0, 1fr);
+  align-items: start;
 }
 
 #row-list {
+  position: sticky;
+  /* Header is ~47px tall (0.6rem padding + 1rem h1 + 0.6rem padding + border).
+     Use a slightly conservative top so the sidebar starts cleanly under it. */
+  top: 47px;
+  height: calc(100vh - 47px);
   border-right: 1px solid #ddd;
   background: #fff;
   overflow-y: auto;
 }
 #row-list .row-link {
   display: block;
-  padding: 0.5rem 0.75rem;
+  padding: 0.55rem 0.85rem;
   border-bottom: 1px solid #eee;
   cursor: pointer;
   font-size: 0.85rem;
@@ -52,130 +65,216 @@ main {
 }
 #row-list .row-link:hover { background: #f4f4f4; }
 #row-list .row-link.active { background: #e0eaff; }
-#row-list .row-link .rid { font-family: ui-monospace, monospace; color: #666; }
-#row-list .row-link .pair { display: block; margin-top: 0.15rem; }
-#row-list .row-link .cell { font-size: 0.7rem; color: #999; }
-#row-list .row-link.labeled { opacity: 0.55; }
-#row-list .row-link.labeled .pair::before { content: "✓ "; color: #2a7a2a; }
+#row-list .row-link .rid { font-family: ui-monospace, monospace; color: #888; font-size: 0.75rem; }
+#row-list .row-link .pair { display: block; margin-top: 0.15rem; color: #1a1a1a; }
+#row-list .row-link .cell { font-size: 0.7rem; color: #aaa; margin-left: 0.4rem; }
+#row-list .row-link.labeled { opacity: 0.6; }
+#row-list .row-link.labeled .pair::before { content: "✓ "; color: #2a7a2a; font-weight: 600; }
 
-#row-detail { padding: 1rem 1.5rem; overflow-y: auto; }
-#row-empty { color: #999; font-style: italic; }
+#row-detail {
+  padding: 1.5rem 2rem;
+  max-width: 960px;
+}
+#row-empty { color: #999; font-style: italic; padding-top: 2rem; }
 
 .row-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.4rem;
 }
-.row-id { font-family: ui-monospace, monospace; color: #666; font-size: 0.85rem; }
-.cell { font-size: 0.75rem; color: #999; margin-left: 0.5rem; }
+.row-meta { display: flex; align-items: center; gap: 0.5rem; }
+.row-id { font-family: ui-monospace, monospace; color: #888; font-size: 0.85rem; }
+.cell { font-size: 0.75rem; color: #aaa; }
 .badge {
   display: inline-block;
-  padding: 0.1rem 0.4rem;
-  border-radius: 3px;
+  padding: 0.12rem 0.5rem;
+  border-radius: 999px;
   font-size: 0.7rem;
   background: #fff4d6;
   color: #7a5a00;
   border: 1px solid #e8d68a;
-  margin-left: 0.5rem;
+  cursor: help;
 }
 .progress { font-size: 0.8rem; color: #666; }
 
-#row-pair { font-size: 1.4rem; margin: 0.25rem 0 1rem; }
+#row-pair {
+  font-size: 1.6rem;
+  margin: 0.25rem 0 1.25rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
 
 .narrative-block {
   background: #fff;
   border: 1px solid #ddd;
-  border-radius: 4px;
-  padding: 0.75rem 1rem;
-  margin-bottom: 1rem;
+  border-radius: 6px;
+  padding: 1rem 1.25rem;
+  margin-bottom: 1.25rem;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.02);
 }
-.narrative-block h3 { margin: 0 0 0.4rem; font-size: 0.8rem; color: #666; text-transform: uppercase; }
+.narrative-block h3,
+.data-card h3,
+.neighbors-block h3 {
+  margin: 0 0 0.5rem;
+  font-size: 0.7rem;
+  color: #888;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-weight: 600;
+}
 .narrative-block p {
   margin: 0;
   font-size: 1.05rem;
-  line-height: 1.5;
+  line-height: 1.55;
 }
-.narrative-block .meta { margin-top: 0.5rem; font-size: 0.75rem; color: #888; }
 
 .data-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 1rem;
-  margin-bottom: 1rem;
+  margin-bottom: 1.25rem;
 }
-.data-grid h3 { margin: 0 0 0.3rem; font-size: 0.8rem; color: #666; text-transform: uppercase; }
-.data-grid pre {
+.data-card {
   background: #fff;
   border: 1px solid #ddd;
-  border-radius: 4px;
-  padding: 0.6rem 0.8rem;
-  font-size: 0.8rem;
-  white-space: pre-wrap;
-  margin: 0;
-  max-height: 280px;
-  overflow-y: auto;
+  border-radius: 6px;
+  padding: 0.85rem 1rem;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.02);
 }
+.data-card dl {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  column-gap: 1rem;
+  row-gap: 0.4rem;
+  margin: 0;
+  font-size: 0.9rem;
+}
+.data-card dt {
+  color: #888;
+  font-weight: 500;
+  font-size: 0.85rem;
+}
+.data-card dd {
+  margin: 0;
+  color: #1a1a1a;
+}
+.data-card .empty { color: #aaa; font-style: italic; }
 
+.neighbors-block { margin-bottom: 1.25rem; }
+.neighbors-block .hint {
+  display: inline-block;
+  width: 1.1em;
+  height: 1.1em;
+  line-height: 1em;
+  text-align: center;
+  border: 1px solid #bbb;
+  border-radius: 50%;
+  font-size: 0.7rem;
+  color: #666;
+  cursor: help;
+  margin-left: 0.25rem;
+  vertical-align: 1px;
+  text-transform: none;
+  letter-spacing: 0;
+}
 #row-neighbors {
   list-style: none;
   padding: 0;
-  margin: 0 0 1rem;
+  margin: 0;
   font-size: 0.85rem;
 }
 #row-neighbors li {
   display: inline-block;
   background: #fff;
   border: 1px solid #ddd;
-  padding: 0.2rem 0.5rem;
+  padding: 0.25rem 0.6rem;
   margin: 0 0.4rem 0.4rem 0;
-  border-radius: 3px;
+  border-radius: 999px;
+  font-size: 0.8rem;
 }
+#row-neighbors li .score { color: #888; margin-left: 0.4rem; font-size: 0.75rem; }
+#row-neighbors li.empty { background: transparent; border: none; color: #aaa; font-style: italic; padding-left: 0; }
 
 #label-form {
   background: #fff;
   border: 1px solid #ddd;
-  border-radius: 4px;
-  padding: 0.75rem 1rem;
+  border-radius: 6px;
+  padding: 1rem 1.25rem;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.02);
 }
 #label-form fieldset {
   border: none;
   padding: 0;
-  margin: 0 0 0.6rem;
+  margin: 0 0 1rem;
   display: flex;
-  align-items: center;
   flex-wrap: wrap;
-  gap: 0.6rem;
+  gap: 0.5rem;
+  align-items: stretch;
 }
 #label-form legend {
+  display: block;
+  width: 100%;
   font-size: 0.75rem;
   color: #666;
   text-transform: uppercase;
-  margin-right: 0.4rem;
-  padding: 0;
-  display: inline-block;
+  letter-spacing: 0.05em;
+  font-weight: 600;
+  padding: 0 0 0.5rem;
 }
 #label-form fieldset label {
   display: inline-flex;
   align-items: center;
-  gap: 0.25rem;
+  gap: 0.4rem;
   cursor: pointer;
-  padding: 0.2rem 0.5rem;
-  border: 1px solid transparent;
-  border-radius: 3px;
+  padding: 0.45rem 0.7rem;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  background: #fafafa;
+  flex: 0 1 auto;
 }
-#label-form fieldset label:hover { background: #f4f4f4; }
+#label-form fieldset label:hover { background: #f4f4f4; border-color: #bbb; }
+#label-form fieldset label:has(input:checked) {
+  background: #e0eaff;
+  border-color: #6b8be0;
+}
+#label-form fieldset label strong { font-weight: 600; }
+#label-form fieldset label .hint-text {
+  color: #888;
+  font-size: 0.75rem;
+  font-weight: 400;
+}
 
-#label-form .notes { display: block; margin: 0.6rem 0; font-size: 0.75rem; color: #666; text-transform: uppercase; }
+#fm-fieldset.disabled { opacity: 0.35; pointer-events: none; }
+
+#label-form .notes {
+  display: block;
+  margin: 0.6rem 0;
+  font-size: 0.75rem;
+  color: #666;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-weight: 600;
+}
+#label-form .notes .muted {
+  text-transform: none;
+  letter-spacing: 0;
+  font-weight: normal;
+  margin-left: 0.3rem;
+}
 #label-form textarea {
   display: block;
   width: 100%;
-  margin-top: 0.3rem;
-  padding: 0.4rem 0.6rem;
+  margin-top: 0.4rem;
+  padding: 0.5rem 0.7rem;
   font: inherit;
+  font-size: 0.9rem;
   border: 1px solid #ccc;
-  border-radius: 3px;
+  border-radius: 4px;
   text-transform: none;
+  letter-spacing: 0;
+  color: #1a1a1a;
+  resize: vertical;
 }
 
 #label-form .actions {
@@ -188,19 +287,30 @@ main {
   background: #1a1a1a;
   color: #fff;
   border: none;
-  padding: 0.4rem 0.9rem;
-  border-radius: 3px;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
   cursor: pointer;
   font: inherit;
+  font-weight: 500;
 }
 #label-form button:hover { background: #333; }
 #label-form button#prev-button, #label-form button#next-button {
   background: #f4f4f4;
   color: #333;
   border: 1px solid #ccc;
+  font-weight: 400;
 }
 #label-form button#prev-button:hover, #label-form button#next-button:hover { background: #e8e8e8; }
 
-#fm-fieldset.disabled { opacity: 0.4; pointer-events: none; }
-
 #save-status { font-size: 0.8rem; }
+
+.kbd-hint { margin: 0.8rem 0 0; font-size: 0.75rem; }
+.kbd-hint kbd {
+  display: inline-block;
+  padding: 0 0.35rem;
+  font-family: ui-monospace, monospace;
+  font-size: 0.75rem;
+  background: #f4f4f4;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+}

--- a/semantic_index/labeling_app/static/labeling.js
+++ b/semantic_index/labeling_app/static/labeling.js
@@ -101,21 +101,26 @@ function renderRowDetail() {
   $("#row-insufficient").hidden = !row.insufficient_signal;
   $("#row-pair").textContent = row.pair;
   $("#row-narrative").textContent = row.narrative || "(no narrative)";
-  $("#row-token-match").textContent = (row.token_match_score ?? 0).toFixed(3);
-  $("#row-source-data").textContent = formatArtist(row.source_data);
-  $("#row-target-data").textContent = formatArtist(row.target_data);
+  fillArtistDl($("#row-source-data"), row.source_data);
+  fillArtistDl($("#row-target-data"), row.target_data);
 
   const ul = $("#row-neighbors");
   ul.innerHTML = "";
   for (const n of row.shared_neighbors || []) {
     const li = document.createElement("li");
-    li.textContent = `${n.name} (aa ${(n.aa_score ?? 0).toFixed(2)})`;
+    const name = document.createElement("span");
+    name.textContent = n.name;
+    const score = document.createElement("span");
+    score.className = "score";
+    score.textContent = (n.aa_score ?? 0).toFixed(2);
+    score.title = "Adamic-Adar score: how strongly this neighbor links the two artists.";
+    li.append(name, score);
     ul.appendChild(li);
   }
   if (!ul.children.length) {
     const li = document.createElement("li");
-    li.textContent = "(none)";
-    li.style.opacity = "0.5";
+    li.className = "empty";
+    li.textContent = "no shared neighbors recorded";
     ul.appendChild(li);
   }
 
@@ -127,20 +132,51 @@ function renderRowDetail() {
   updateFailureModeAvailability();
 }
 
-function formatArtist(meta) {
-  if (!meta) return "(none)";
-  const lines = [];
-  if (meta.name != null) lines.push(`name:    ${meta.name}`);
-  if (meta.total_plays != null) lines.push(`plays:   ${meta.total_plays}`);
-  if (meta.genre != null) lines.push(`genre:   ${meta.genre}`);
-  if (Array.isArray(meta.styles) && meta.styles.length) lines.push(`styles:  ${meta.styles.join(", ")}`);
+// Map raw JSONL keys to plain-English labels. Order in this list is the
+// display order; keys absent from the metadata are simply skipped.
+const TOP_LEVEL_FIELDS = [
+  ["total_plays", "WXYC plays"],
+  ["genre", "WXYC genre"],
+  ["styles", "Discogs styles"],
+];
+const AUDIO_FIELDS = [
+  ["primary_genre", "Sounds like"],
+  ["danceability", "Danceability"],
+  ["top_moods", "Top moods"],
+  ["key", "Musical key"],
+  ["recording_count", "Recordings analyzed"],
+];
+
+function fillArtistDl(dl, meta) {
+  dl.innerHTML = "";
+  if (!meta) {
+    const empty = document.createElement("dd");
+    empty.className = "empty";
+    empty.textContent = "no metadata";
+    dl.appendChild(empty);
+    return;
+  }
+  for (const [key, label] of TOP_LEVEL_FIELDS) {
+    appendDlRow(dl, label, meta[key]);
+  }
   if (meta.audio) {
-    for (const [k, v] of Object.entries(meta.audio)) {
-      const val = Array.isArray(v) ? v.join(", ") : v;
-      lines.push(`audio.${k}: ${val}`);
+    for (const [key, label] of AUDIO_FIELDS) {
+      appendDlRow(dl, label, meta.audio[key]);
     }
   }
-  return lines.join("\n");
+}
+
+function appendDlRow(dl, label, value) {
+  if (value == null) return;
+  if (Array.isArray(value)) {
+    if (!value.length) return;
+    value = value.join(", ");
+  }
+  const dt = document.createElement("dt");
+  dt.textContent = label;
+  const dd = document.createElement("dd");
+  dd.textContent = String(value);
+  dl.append(dt, dd);
 }
 
 function escapeHtml(s) {

--- a/tests/unit/test_labeling_rowsource.py
+++ b/tests/unit/test_labeling_rowsource.py
@@ -65,7 +65,7 @@ class TestRowOrder:
         src = RowSource(jsonl_path)
         summaries = src.summaries()
         assert summaries[0]["row_id"] == "R0001"
-        assert summaries[0]["pair"] == "Pavement <-> Stereolab"
+        assert summaries[0]["pair"] == "Pavement ↔ Stereolab"
         assert summaries[0]["cell_id"] == "HIGH-RICH-SAME-DIRECT"
 
 
@@ -83,7 +83,7 @@ class TestRedaction:
         assert row["source_data"]["name"] == "Pavement"
         assert row["target_data"]["name"] == "Stereolab"
         assert row["shared_neighbors"][0]["name"] == "Roxy Music"
-        assert row["pair"] == "Pavement <-> Stereolab"
+        assert row["pair"] == "Pavement ↔ Stereolab"
 
     def test_get_unknown_row_id_raises(self, jsonl_path: Path) -> None:
         src = RowSource(jsonl_path)


### PR DESCRIPTION
## Summary

- Sticky header + sidebar; right pane scrolls with the body. No more iframe-y feel.
- Source/target panel rendered as labeled definition lists with plain-English field names (not `audio.foo` jargon).
- Severity / failure-mode radios show plain English with hover tooltips. The underlying rubric vocabulary stays as the radio `value=`, so API validation and `merge_labels.py` are unchanged.
- `<->` → `↔` in the pair joiner.
- Removed the `token-match: 0.000` diagnostic from the labeler-facing UI (still preserved in the JSONL backing for downstream analysis).

Closes #286.

## What's in here

- `semantic_index/labeling_app/row_source.py` — emit `↔` in the `pair` field.
- `semantic_index/labeling_app/static/index.html` — friendly radio labels, hover tooltips, restructured layout, kbd-hint footer.
- `semantic_index/labeling_app/static/labeling.css` — sticky layout, dl-based data cards with soft borders/shadows, selected-radio highlight, tooltip styling.
- `semantic_index/labeling_app/static/labeling.js` — `fillArtistDl()` replaces the monospace `formatArtist()`; token-match line removed.
- `tests/unit/test_labeling_rowsource.py` — assertions updated for `↔`.

## Why these changes (one paragraph)

After running the UI against the real 282-row eval set, five rough edges surfaced (see linked issue for the full list). The big two are about labeler experience: (a) the data-card was a `<pre>` block with `audio.recording_count`-style keys, which assumes the labeler knows the pipeline schema, and (b) the radio labels exposed the rubric's internal vocabulary. WXYC has volunteer labelers across the technical spectrum, so anything that reads like "you have to understand the codebase to label this" is a friction we should eliminate. The radio `value=` attributes stay as the rubric values (`severe`, `subject_hallucination`, etc.) so nothing downstream changes — only the visible labels and tooltips are different.

## Test plan

- [x] `pytest tests/unit/` — 925 passed (32 of which are labeling-app tests).
- [x] `ruff check` / `ruff format --check` clean across changed files.
- [x] `mypy semantic_index/labeling_app/` clean.
- [x] Smoke test against the real 282-row `labeling.jsonl`: ↔ pair renders, friendly labels visible, no `<->` in HTML, fieldset legend reads "How wrong is the narrative?".
- [ ] Reviewer can `python -m semantic_index.labeling_app --jsonl output/eval/labeling.jsonl --port 8092`, click around, and verify: (1) header + sidebar stay put when scrolling, (2) source/target cards have plain-English labels, (3) hovering a severity/failure-mode radio shows a tooltip, (4) the pair title uses `↔`.