### PR TITLE
Migrate artist_resolver to wxyc-etl 0.2.0 to_match_form (WX-2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ SQLite ──→ api (FastAPI + aiosqlite) ──→ JSON responses
 |--------|---------------|
 | `semantic_index/sql_parser.py` | Parse MySQL INSERT statements from SQL dump files. Uses `wxyc_etl.parser` Rust extension for ~1000x faster parsing, with `sql_parser_rs` and pure-Python fallbacks. Set `WXYC_ETL_NO_RUST=1` to force pure-Python. |
 | `semantic_index/models.py` | Pydantic data models for all pipeline entities. |
-| `semantic_index/artist_resolver.py` | Multi-tier artist name resolution: compilation track (CTA from SQL dump + Discogs from `compilation_track_artists.json`), FK chain, name match, normalized (via `wxyc_etl.text.normalize_artist_name` + local bracket/the/& transforms), fuzzy (Jaro-Winkler), Discogs search, raw fallback. Uses `wxyc_etl.text.split_artist_name` for alias splitting and `wxyc_etl.text.is_compilation_artist` for VA detection. |
+| `semantic_index/artist_resolver.py` | Multi-tier artist name resolution: compilation track (CTA from SQL dump + Discogs from `compilation_track_artists.json`), FK chain, name match, normalized (via `wxyc_etl.text.to_match_form` + local bracket/the/& transforms), fuzzy (Jaro-Winkler), Discogs search, raw fallback. Uses `wxyc_etl.text.split_artist_name` for alias splitting and `wxyc_etl.text.is_compilation_artist` for VA detection. |
 | `semantic_index/adjacency.py` | Extract consecutive artist pairs within radio shows. |
 | `semantic_index/pmi.py` | Compute Pointwise Mutual Information for artist co-occurrences. |
 | `semantic_index/node_attributes.py` | Extract and compute per-artist temporal, DJ, and request statistics. |
@@ -242,7 +242,7 @@ pytest -m slow                  # slow tests, e.g. the artist-resolver-rust perf
 
 The pipeline uses `wxyc-etl` (a Rust/PyO3 package) for shared text normalization, compilation detection, and schema constants:
 
-- **`wxyc_etl.text.normalize_artist_name(name)`** -- NFKD decomposition + diacritics stripping + lowercase + trim. Used as the base layer in `artist_resolver._normalize()`, which adds semantic-index-specific transforms (bracket removal, "the " strip, `&` -> `and`).
+- **`wxyc_etl.text.to_match_form(name)`** -- WX-2 Normalizer Charter match form: NFKD decomposition + diacritics stripping + Cf-strip (preserving U+200D ZWJ) + Greek sigma fold + lowercase + trim/whitespace collapse. Used as the base layer in `artist_resolver._normalize()`, which adds semantic-index-specific transforms (bracket removal, "the " strip, `&` -> `and`).
 - **`wxyc_etl.text.is_compilation_artist(name)`** -- Compilation/VA detection covering "Various Artists", "V/A", "v.a.", "Soundtrack", "Compilation". Replaces the old narrow `is_various_artists()` in `utils.py`.
 - **`wxyc_etl.text.split_artist_name(name)`** -- Context-free multi-artist splitting on `, `, ` / `, ` + `. Used in `artist_resolver._normalized_forms()`.
 - **`wxyc_etl.schema.*`** -- Table name constants (`RELEASE_TABLE`, `RELEASE_ARTIST_TABLE`, `RELEASE_LABEL_TABLE`, `RELEASE_STYLE_TABLE`, `RELEASE_TRACK_TABLE`, `RELEASE_TRACK_ARTIST_TABLE`) for all discogs-cache SQL queries in `discogs_client.py` and `reconciliation.py`.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Railway sets the `PORT` environment variable automatically. Set `DB_PATH` to poi
 
 ## Dependencies
 
-The pipeline depends on `wxyc-etl`, a shared Rust/PyO3 package providing text normalization (`normalize_artist_name`, `is_compilation_artist`, `split_artist_name`) and discogs-cache schema constants. All discogs-cache table names in SQL queries come from `wxyc_etl.schema` constants rather than hardcoded strings. See [CLAUDE.md](CLAUDE.md) for the full list of shared functions used.
+The pipeline depends on `wxyc-etl`, a shared Rust/PyO3 package providing text normalization (`to_match_form`, `is_compilation_artist`, `split_artist_name`) and discogs-cache schema constants. All discogs-cache table names in SQL queries come from `wxyc_etl.schema` constants rather than hardcoded strings. See [CLAUDE.md](CLAUDE.md) for the full list of shared functions used.
 
 ## Development
 

--- a/docs/narrative-enrichment-plan.md
+++ b/docs/narrative-enrichment-plan.md
@@ -146,7 +146,7 @@ Crawl times are bounded by polite rate limiting (1-2 second delays). Sources are
 Matching reviews to graph artists requires:
 
 1. **Source-specific title parsing** — review titles follow patterns like "Artist - Album" or "Review: Artist — Album" that vary by publication. Regex per source to extract the artist name from the title.
-2. **Name normalization** — NFKD decomposition, diacritics stripping, lowercase, splitting on `/` and `&` separators. The same logic already exists in `artist_resolver.py` via `wxyc_etl.text.normalize_artist_name`.
+2. **Name normalization** — NFKD decomposition, diacritics stripping, lowercase, splitting on `/` and `&` separators. The same logic already exists in `artist_resolver.py` via `wxyc_etl.text.to_match_form`.
 3. **Fuzzy matching** — Jaro-Winkler against canonical names for cases where the review uses a variant spelling (e.g., "Björk" vs "Bjork," "MF DOOM" vs "MF Doom").
 4. **Body text matching** — for reviews that mention artists as reference points (not the review subject), the comparative_artists field from the extraction step serves as a cross-reference signal.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "rapidfuzz>=3.0.0",
     "psycopg[binary]>=3.1",
     "httpx>=0.25",
-    "wxyc-etl>=0.1.0",
+    "wxyc-etl>=0.2.0",
     "sentry-sdk>=2.0",
 ]
 
@@ -32,7 +32,7 @@ archive = [
     "essentia-tensorflow>=2.1b6",
 ]
 rust = [
-    "wxyc-etl>=0.1.0",
+    "wxyc-etl>=0.2.0",
 ]
 dev = [
     "pytest>=7.0.0",

--- a/semantic_index/artist_resolver.py
+++ b/semantic_index/artist_resolver.py
@@ -25,8 +25,8 @@ from rapidfuzz import process as rfprocess
 from rapidfuzz.distance import JaroWinkler
 from wxyc_etl.text import (  # type: ignore[import-untyped]
     is_compilation_artist,
-    normalize_artist_name,
     split_artist_name,
+    to_match_form,
 )
 
 from semantic_index.models import FlowsheetEntry, LibraryCode, LibraryRelease, ResolvedEntry
@@ -66,11 +66,13 @@ _BRACKET_RE = re.compile(r"\s*\[.*?\]\s*$")
 def _normalize(name: str) -> str:
     """Normalize an artist name for matching.
 
-    Uses wxyc_etl.text.normalize_artist_name for NFKD decomposition, diacritics
-    stripping, lowercasing, and trimming. Then applies semantic-index-specific
-    transforms: bracket removal, leading 'the ' strip, '&' -> 'and'.
+    Uses wxyc_etl.text.to_match_form (WX-2 Normalizer Charter) as the base layer:
+    NFKD decomposition, diacritics stripping, Cf-strip (preserving U+200D ZWJ),
+    Greek sigma fold, lowercasing, and whitespace trim/collapse. Then applies
+    semantic-index-specific transforms: bracket removal, leading 'the ' strip,
+    '&' -> 'and'.
     """
-    s = normalize_artist_name(name)
+    s = to_match_form(name)
     s = _BRACKET_RE.sub("", s)
     if s.startswith("the "):
         s = s[4:]

--- a/tests/unit/test_migration_parity.py
+++ b/tests/unit/test_migration_parity.py
@@ -2,7 +2,8 @@
 
 These tests verify that:
 1. wxyc_etl.text.is_compilation_artist covers all cases that utils.is_various_artists handles
-2. wxyc_etl.text.normalize_artist_name produces equivalent results to artist_resolver._normalize
+2. wxyc_etl.text.to_match_form (WX-2 Normalizer Charter) produces the expected base
+   normalization used by artist_resolver._normalize
 3. wxyc_etl.schema constants cover all hardcoded table names in discogs_client.py
 """
 
@@ -73,7 +74,7 @@ def test_is_compilation_artist_false_for_real_artists(name):
     assert text.is_compilation_artist(name) is False
 
 
-# --- normalize_artist_name parity with artist_resolver._normalize ---
+# --- to_match_form parity with artist_resolver._normalize base layer ---
 
 
 @pytest.mark.parametrize(
@@ -86,8 +87,7 @@ def test_is_compilation_artist_false_for_real_artists(name):
         # Diacritics (NFKD decomposition)
         ("Bjork", "bjork"),
         ("Sigur Ros", "sigur ros"),
-        # wxyc_etl does NFKD + strip diacritics, which is a superset of what
-        # the old _normalize did (the old one only did lowercase + strip)
+        # NFKD + strip diacritics
         ("Cafe Tacvba", "cafe tacvba"),
         # Empty
         ("", ""),
@@ -95,14 +95,9 @@ def test_is_compilation_artist_false_for_real_artists(name):
         ("  Mixed Case  ", "mixed case"),
     ],
 )
-def test_normalize_artist_name_parity(input_name, expected):
-    """wxyc_etl.normalize_artist_name produces equivalent results for common cases."""
-    assert text.normalize_artist_name(input_name) == expected
-
-
-def test_normalize_handles_none():
-    """normalize_artist_name accepts None and returns empty string."""
-    assert text.normalize_artist_name(None) == ""
+def test_to_match_form_parity(input_name, expected):
+    """wxyc_etl.to_match_form produces the expected base normalization for common cases."""
+    assert text.to_match_form(input_name) == expected
 
 
 # --- split_artist_name parity with artist_resolver._normalized_forms ---

--- a/tests/unit/test_nightly_sync.py
+++ b/tests/unit/test_nightly_sync.py
@@ -340,7 +340,7 @@ def _stub_wxyc_etl():
         return
     stub = MagicMock()
     # text sub-module used by artist_resolver and graph_metrics
-    stub.text.normalize_artist_name = lambda name: name.lower().strip()
+    stub.text.to_match_form = lambda name: name.lower().strip()
     stub.text.is_compilation_artist = lambda name: name.lower() in ("various artists", "v/a")
     stub.text.split_artist_name = lambda name: [name]
     for name in (


### PR DESCRIPTION
## Summary

Migrates the two semantic-index callsites of the deprecated `wxyc_etl.text.normalize_artist_name` to the WX-2 Normalizer Charter form `to_match_form`. Bumps `wxyc-etl` from `>=0.1.0` to `>=0.2.0` so the deprecation warnings introduced in 0.2.0 stop firing in Sentry.

Closes #289.

## Callsites changed

| File | Before | After |
|---|---|---|
| `semantic_index/artist_resolver.py` (`_normalize`) | `normalize_artist_name(name)` | `to_match_form(name)` — comparison/match path; bracket/the/`&`-fold transforms unchanged |
| `tests/unit/test_migration_parity.py` | parity vs. `normalize_artist_name`, plus `test_normalize_handles_none` | parity vs. `to_match_form`; the `None`-input test was retired (charter API is `str` only; no caller passes `None`) |
| `tests/unit/test_nightly_sync.py` (`_stub_wxyc_etl`) | stubbed `text.normalize_artist_name` | stubs `text.to_match_form` to match the new production import |
| `pyproject.toml` | `wxyc-etl>=0.1.0` (both core deps and `[rust]` extra) | `wxyc-etl>=0.2.0` |
| `README.md` / `CLAUDE.md` / `docs/narrative-enrichment-plan.md` | referenced the old name | now reference `to_match_form` |

`graph_metrics.py` was flagged as a possible callsite in the original plan; verified it only imports `is_compilation_artist` (not in the deprecated set), so out of scope.

## Behavior diff (`normalize_artist_name` -> `to_match_form`)

Verified with a probe over representative WXYC names. The match form differs in three ways:

1. **Internal whitespace collapse** — `"John  Smith"` -> `"john smith"` (was `"john  smith"`).
2. **Cf-class code points stripped** — soft hyphens (U+00AD), ZWNJ, etc. are removed. `U+200D` ZWJ is intentionally preserved (charter rule).
3. **Greek sigma fold** — final `ς` folds to canonical `σ`.

For everything else in the WXYC corpus (NFKD, diacritics strip, lowercase, trim) the output is identical to the legacy function. Probe samples: Björk, Sigur Rós, Café Tacvba, Beyoncé, Csillagrablók, Hermanos Gutiérrez, Nilüfer Yanya, Σtella, Mötley Crüe, MF DOOM — all unchanged.

## Graph rebuild — not triggered

`_normalize` is a *match form* used to look up incoming flowsheet names against a normalized catalog index; the graph itself stores `canonical_name` from the catalog row, not the normalized form. The migration therefore cannot retroactively split or merge existing graph nodes — it can only change which catalog row an *incoming* name resolves to.

In the worst case, names with internal multi-space or soft-hyphen variants that previously failed to match the catalog will now match correctly (charter intent). The next nightly `nightly_sync.py` run picks this up automatically; no manual rebuild is needed and none was triggered.

If a downstream operator notices a node-identity shift after the next nightly run, file a follow-up at WXYC/semantic-index — do not silently rebuild.

## Test plan

- [x] `pytest tests/` -> 959 passed, 13 deselected (default no-marker run)
- [x] `pytest tests/ -W error::DeprecationWarning` -> 959 passed (no remaining legacy callsites firing the deprecation warning)
- [x] `ruff check .` clean
- [x] `ruff format --check .` clean
- [x] `mypy semantic_index/` clean
- [x] grep for `normalize_artist_name`, `strip_diacritics`, `normalize_title`, `batch_normalize` returns nothing
- [x] verified `graph_metrics.py` does not call any deprecated function

## Acceptance criteria (from #289)

- [x] `pyproject.toml` pins `wxyc-etl>=0.2.0` (both `[project] dependencies` and the `[rust]` extra)
- [x] No remaining import of `normalize_artist_name` / `strip_diacritics` / `normalize_title` / `batch_normalize` (grep clean)
- [x] `pytest tests/` green; behavior diffs explained above
- [x] Graph rebuild assessed — not needed; no follow-up filed