### PR TITLE
artist_resolver: adopt to_identity_match_form (E3 step 5e)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ SQLite ──→ api (FastAPI + aiosqlite) ──→ JSON responses
 |--------|---------------|
 | `semantic_index/sql_parser.py` | Parse MySQL INSERT statements from SQL dump files. Uses `wxyc_etl.parser` Rust extension for ~1000x faster parsing, with `sql_parser_rs` and pure-Python fallbacks. Set `WXYC_ETL_NO_RUST=1` to force pure-Python. |
 | `semantic_index/models.py` | Pydantic data models for all pipeline entities. |
-| `semantic_index/artist_resolver.py` | Multi-tier artist name resolution: compilation track (CTA from SQL dump + Discogs from `compilation_track_artists.json`), FK chain, name match, normalized (via `wxyc_etl.text.to_match_form` + local bracket/the/& transforms), fuzzy (Jaro-Winkler), Discogs search, raw fallback. Uses `wxyc_etl.text.split_artist_name` for alias splitting and `wxyc_etl.text.is_compilation_artist` for VA detection. |
+| `semantic_index/artist_resolver.py` | Multi-tier artist name resolution: compilation track (CTA from SQL dump + Discogs from `compilation_track_artists.json`), FK chain, name match, normalized (via `wxyc_etl.text.to_identity_match_form` plus an `&` → `and` shim applied first), fuzzy (Jaro-Winkler), Discogs search, raw fallback. Uses `wxyc_etl.text.split_artist_name` for alias splitting and `wxyc_etl.text.is_compilation_artist` for VA detection. |
 | `semantic_index/adjacency.py` | Extract consecutive artist pairs within radio shows. |
 | `semantic_index/pmi.py` | Compute Pointwise Mutual Information for artist co-occurrences. |
 | `semantic_index/node_attributes.py` | Extract and compute per-artist temporal, DJ, and request statistics. |
@@ -242,7 +242,8 @@ pytest -m slow                  # slow tests, e.g. the artist-resolver-rust perf
 
 The pipeline uses `wxyc-etl` (a Rust/PyO3 package) for shared text normalization, compilation detection, and schema constants:
 
-- **`wxyc_etl.text.to_match_form(name)`** -- WX-2 Normalizer Charter match form: NFKD decomposition + diacritics stripping + Cf-strip (preserving U+200D ZWJ) + Greek sigma fold + lowercase + trim/whitespace collapse. Used as the base layer in `artist_resolver._normalize()`, which adds semantic-index-specific transforms (bracket removal, "the " strip, `&` -> `and`).
+- **`wxyc_etl.text.to_identity_match_form(name)`** -- Cross-cache-identity normalizer per `library-hook-canonicalization-plan` §3.3.2 steps 4+5+7: NFKC + lowercase + enclosing paren/bracket strip + leading-article drop ("the ", "a ") + whitespace collapse. Used as the body of `artist_resolver._normalize()` (with a leading `&` -> `and` shim applied first, since the canonical step 6 collapses `&` to a space rather than the word "and").
+- **`wxyc_etl.text.to_match_form(name)`** -- WX-2 Normalizer Charter match form (NFKD + diacritics-strip + Cf-strip + Greek sigma fold + lowercase + whitespace collapse). Still imported by call sites that don't need cross-cache identity.
 - **`wxyc_etl.text.is_compilation_artist(name)`** -- Compilation/VA detection covering "Various Artists", "V/A", "v.a.", "Soundtrack", "Compilation". Replaces the old narrow `is_various_artists()` in `utils.py`.
 - **`wxyc_etl.text.split_artist_name(name)`** -- Context-free multi-artist splitting on `, `, ` / `, ` + `. Used in `artist_resolver._normalized_forms()`.
 - **`wxyc_etl.schema.*`** -- Table name constants (`RELEASE_TABLE`, `RELEASE_ARTIST_TABLE`, `RELEASE_LABEL_TABLE`, `RELEASE_STYLE_TABLE`, `RELEASE_TRACK_TABLE`, `RELEASE_TRACK_ARTIST_TABLE`) for all discogs-cache SQL queries in `discogs_client.py` and `reconciliation.py`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "rapidfuzz>=3.0.0",
     "psycopg[binary]>=3.1",
     "httpx>=0.25",
-    "wxyc-etl>=0.2.0",
+    "wxyc-etl>=0.3.0",
     "sentry-sdk>=2.0",
 ]
 
@@ -32,7 +32,7 @@ archive = [
     "essentia-tensorflow>=2.1b6",
 ]
 rust = [
-    "wxyc-etl>=0.2.0",
+    "wxyc-etl>=0.3.0",
 ]
 dev = [
     "pytest>=7.0.0",

--- a/semantic_index/artist_resolver.py
+++ b/semantic_index/artist_resolver.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 import logging
 import os
-import re
 from collections import Counter
 from typing import TYPE_CHECKING
 
@@ -26,7 +25,7 @@ from rapidfuzz.distance import JaroWinkler
 from wxyc_etl.text import (  # type: ignore[import-untyped]
     is_compilation_artist,
     split_artist_name,
-    to_match_form,
+    to_identity_match_form,
 )
 
 from semantic_index.models import FlowsheetEntry, LibraryCode, LibraryRelease, ResolvedEntry
@@ -60,24 +59,20 @@ FUZZY_RELAXED_MIN_PLAYS = 10
 # If the top two candidates differ by less than this, reject as ambiguous
 FUZZY_AMBIGUITY_THRESHOLD = 0.02
 
-_BRACKET_RE = re.compile(r"\s*\[.*?\]\s*$")
-
 
 def _normalize(name: str) -> str:
-    """Normalize an artist name for matching.
+    """Normalize an artist name for identity matching.
 
-    Uses wxyc_etl.text.to_match_form (WX-2 Normalizer Charter) as the base layer:
-    NFKD decomposition, diacritics stripping, Cf-strip (preserving U+200D ZWJ),
-    Greek sigma fold, lowercasing, and whitespace trim/collapse. Then applies
-    semantic-index-specific transforms: bracket removal, leading 'the ' strip,
-    '&' -> 'and'.
+    Wraps wxyc_etl.text.to_identity_match_form (cross-cache-identity normalizer
+    per library-hook-canonicalization-plan §3.3.2 steps 4+5+7): NFKC + lowercase
+    + enclosing paren/bracket strip + leading-article drop ("the ", "a ") +
+    whitespace collapse. The `&` -> `and` shim is applied first so it survives
+    identity normalization (the canonical step 6 collapses `&` to a space, not
+    "and"; this shim is semantic-index-specific).
     """
-    s = to_match_form(name)
-    s = _BRACKET_RE.sub("", s)
-    if s.startswith("the "):
-        s = s[4:]
-    s = s.replace(" & ", " and ")
-    return s
+    s = name.replace(" & ", " and ")
+    result: str = to_identity_match_form(s)
+    return result
 
 
 def _normalized_forms(name: str) -> list[str]:


### PR DESCRIPTION
## Summary
- Migrates `semantic_index/artist_resolver.py:_normalize` from layered `to_match_form` + bracket strip + leading-`the ` strip + `&` → `and` shim to `wxyc_etl.text.to_identity_match_form` per [library-hook-canonicalization-plan §3.3.2 steps 4+5+7](https://github.com/WXYC/wiki/blob/main/plans/library-hook-canonicalization-plan.md#332-algorithm-locked-except-where-noted).
- Bumps `wxyc-etl` floor from `>=0.2.0` to `>=0.3.0` (runtime + `rust` extras).
- Drops the local `_BRACKET_RE` regex (paren/bracket strip is baked into `to_identity_match_form`).
- The `&` → `and` shim is applied **before** `to_identity_match_form` (per the issue design notes — the canonical step 6 collapses `&` to a space, not "and"; this shim is semantic-index-specific).

## Behavioral note
Article drop now strips leading `a ` as well as `the ` (e.g. "A Tribe Called Quest" → "tribe called quest"). This is the canonical algorithm per plan §3.3.2 step 5; deliberate semantic shift per §3.3.4's ≤2% per-step shift threshold.

## Test plan
- [x] `pytest tests/unit/test_artist_resolver.py -x` — 71 passed
- [x] `pytest -m "not pg and not slow"` — 959 passed
- [x] `ruff check semantic_index/artist_resolver.py` — clean
- [x] `mypy semantic_index/artist_resolver.py` — clean

Closes #291
Refs WXYC/wxyc-etl#73 (E3 step 5e)