### PR TITLE
api/bio + api/preview: force UTF-8 on Bandcamp HTML scrapes

### DIFF
--- a/semantic_index/api/bio.py
+++ b/semantic_index/api/bio.py
@@ -318,6 +318,9 @@ def _fetch_bandcamp_album(bandcamp_id: str) -> tuple[str, str] | None:
         ) as client:
             resp = client.get(f"https://{bandcamp_id}.bandcamp.com")
             resp.raise_for_status()
+            # Bandcamp omits charset= on most pages; force UTF-8 so diacritic
+            # album titles don't mojibake.
+            resp.encoding = "utf-8"
             html = resp.text
 
             # Extract album IDs from data-item-id attributes

--- a/semantic_index/api/preview.py
+++ b/semantic_index/api/preview.py
@@ -166,6 +166,10 @@ def _try_bandcamp(bandcamp_id: str) -> dict | None:
         if resp.status_code != 200:
             return None
 
+        # Bandcamp omits charset= on most pages; force UTF-8 before reading
+        # resp.text so diacritics don't mojibake.
+        resp.encoding = "utf-8"
+
         # Find album links on the artist page
         album_match = re.search(r'<a href="(/album/[^"]+)"', resp.text)
         album_url = None
@@ -180,6 +184,7 @@ def _try_bandcamp(bandcamp_id: str) -> dict | None:
             resp = _http_get(album_url)
             if resp.status_code != 200:
                 return None
+            resp.encoding = "utf-8"
 
         # Extract data-tralbum JSON
         tralbum_match = re.search(r"data-tralbum='([^']*)'", resp.text)

--- a/tests/unit/test_bio.py
+++ b/tests/unit/test_bio.py
@@ -4,14 +4,15 @@ from __future__ import annotations
 
 import sqlite3
 import tempfile
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 
 from semantic_index.api.app import create_app
-from semantic_index.api.bio import _generated_summary, parse_discogs_markup
+from semantic_index.api.bio import _fetch_bandcamp_album, _generated_summary, parse_discogs_markup
 from semantic_index.models import ArtistStats
 from semantic_index.pipeline_db import PipelineDB
 
@@ -271,3 +272,32 @@ class TestBioEndpoint:
     async def test_404_unknown_id(self, bio_client: AsyncClient) -> None:
         resp = await bio_client.get("/graph/artists/99999/bio")
         assert resp.status_code == 404
+
+
+def test_fetch_bandcamp_album_forces_utf8_when_no_charset_in_content_type() -> None:
+    # httpx defaults to ISO-8859-1 when Content-Type omits charset=; force UTF-8
+    # so diacritic-bearing album titles survive the regex pass.
+    title = "Csillagrabl\u00f3k"
+    body = (
+        b'<div data-item-id="album-12345"></div><p class="title">' + title.encode("utf-8") + b"</p>"
+    )
+    response = httpx.Response(
+        200,
+        headers={"Content-Type": "text/html"},
+        content=body,
+        default_encoding="iso-8859-1",
+        request=httpx.Request("GET", "https://csillagrablok.bandcamp.com"),
+    )
+
+    mock_client = MagicMock()
+    mock_client.__enter__ = MagicMock(return_value=mock_client)
+    mock_client.__exit__ = MagicMock(return_value=False)
+    mock_client.get = MagicMock(return_value=response)
+
+    with patch("semantic_index.api.bio.httpx.Client", return_value=mock_client):
+        result = _fetch_bandcamp_album("csillagrablok")
+
+    assert result is not None
+    album_id, album_title = result
+    assert album_id == "12345"
+    assert album_title == title

--- a/tests/unit/test_preview.py
+++ b/tests/unit/test_preview.py
@@ -12,6 +12,7 @@ import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 
 from semantic_index.api.app import create_app
+from semantic_index.api.preview import _try_bandcamp
 from semantic_index.models import ArtistStats
 from semantic_index.pipeline_db import PipelineDB
 
@@ -393,3 +394,33 @@ class TestPreviewEndpoint:
         data = resp.json()
         assert data["preview_url"] == "https://audio-ssl.itunes.apple.com/stereolab_jenny.m4a"
         assert data["source"] == "itunes_search"
+
+
+def _http_response(body: bytes, default_encoding: str = "iso-8859-1") -> httpx.Response:
+    return httpx.Response(
+        200,
+        headers={"Content-Type": "text/html"},
+        content=body,
+        default_encoding=default_encoding,
+        request=httpx.Request("GET", "https://x.bandcamp.com"),
+    )
+
+
+def test_try_bandcamp_forces_utf8_when_no_charset_in_content_type() -> None:
+    # httpx defaults to ISO-8859-1 when Content-Type omits charset=; force UTF-8
+    # so diacritic-bearing artist names in data-tralbum survive the regex+JSON pass.
+    artist = "Csillagrabl\u00f3k"
+    artist_page = b'<a href="/album/the-album">x</a>'
+    tralbum_json = (
+        b'{"trackinfo":[{"title":"t","file":{"mp3-128":"https://x/y.mp3"}}],'
+        b'"current":{"artist":"' + artist.encode("utf-8") + b'"}}'
+    )
+    album_page = b"<script data-tralbum='" + tralbum_json + b"'></script>"
+
+    responses = iter([_http_response(artist_page), _http_response(album_page)])
+
+    with patch("semantic_index.api.preview._http_get", side_effect=lambda *a, **k: next(responses)):
+        result = _try_bandcamp("csillagrablok")
+
+    assert result is not None
+    assert result["artist_name"] == artist


### PR DESCRIPTION
## Summary

- Mirror WXYC/library-metadata-lookup PR #263's fix at the two semantic-index Bandcamp HTML-scrape sites surfaced by the WX-3.F audit (WXYC/docs#19): `semantic_index/api/bio.py:_fetch_bandcamp_album` and `semantic_index/api/preview.py:_try_bandcamp`.
- One-line `resp.encoding = "utf-8"` before each `resp.text` read. Bandcamp omits `charset=` on most responses; httpx falls back to ISO-8859-1 and mojibakes diacritic-bearing artist/album names ("Csillagrablók" → "CsillagrablÃ³k").
- Deterministic unit tests for both helpers using `httpx.Response(..., default_encoding="iso-8859-1")` to trigger the broken decode path.

Closes #293.

## Test plan

- [x] Failing tests added first (TDD red), confirmed to fail with `'CsillagrablÃ³k' == 'Csillagrablók'` mojibake.
- [x] After fix, both pass; full unit suite — 926 passed, 1 deselected.
- [x] `ruff check`, `ruff format --check`, `mypy` — all clean (pre-commit hook also enforced).