### PR TITLE
Heat slider modulates DJ-vs-enrichment weight balance

### DIFF
--- a/semantic_index/api/routes.py
+++ b/semantic_index/api/routes.py
@@ -1019,9 +1019,19 @@ def _neighbors_affinity_batch(
         except sqlite3.OperationalError:
             continue
 
-    dim_weights: dict[str, float] = {"djTransition": 3.0}
+    # Heat slider modulates DJ-vs-enrichment weight balance:
+    #   heat=0.0 → pure mirror: DJ full, enrichment damped to zero
+    #   heat=0.5 → balanced: DJ full, enrichment at base weights (existing behavior)
+    #   heat=1.0 → discovery: DJ damped to zero, enrichment doubled
+    # DJ stays at full weight across the cool half then ramps to zero at the hot end;
+    # enrichment ramps linearly from 0 (cool) through 1× (center) to 2× (hot).
+    dj_factor = min(1.0, 2.0 * (1.0 - heat))
+    enrichment_factor = 2.0 * heat
+    dim_weights: dict[str, float] = {"djTransition": 3.0 * dj_factor}
     for etype_default, source in affinity_sources:
-        dim_weights[source.affinity_type_name or etype_default] = source.affinity_weight
+        dim_weights[source.affinity_type_name or etype_default] = (
+            source.affinity_weight * enrichment_factor
+        )
 
     per_source_top: dict[int, list[tuple[int, float, list[str]]]] = {}
     all_top_nids: set[int] = set()

--- a/tests/unit/test_api_routes.py
+++ b/tests/unit/test_api_routes.py
@@ -498,6 +498,75 @@ class TestAffinityAcousticRescale:
         assert weights["TopMatch"] > weights["MidMatch"] > weights["MarginalMatch"]
 
 
+class TestAffinityHeatBalance:
+    """Heat slider should shift the DJ-vs-enrichment weight balance.
+
+    Cool end (heat=0): DJ-only neighbors dominate, enrichment-only damped to zero
+    (pure WXYC mirror). Center (heat=0.5): existing balanced behavior preserved.
+    Hot end (heat=1): DJ damped to zero, enrichment up-weighted (discovery —
+    enrichment-only neighbors can outrank DJ-only ones).
+    """
+
+    @pytest_asyncio.fixture
+    async def heat_client(self) -> AsyncClient:
+        from tests.conftest import make_artist_stats
+
+        path = tempfile.mktemp(suffix=".db")
+        stats = {
+            "Source": make_artist_stats("Source", total_plays=10),
+            "DjOnly": make_artist_stats("DjOnly", total_plays=10),
+            "EnrichOnly": make_artist_stats("EnrichOnly", total_plays=10),
+        }
+        # DjOnly is reachable via dj_transition only; EnrichOnly via acoustic only.
+        pmi_edges = [PmiEdge(source="Source", target="DjOnly", raw_count=5, pmi=2.0)]
+        export_sqlite(path, artist_stats=stats, pmi_edges=pmi_edges, xref_edges=[], min_count=1)
+        conn = sqlite3.connect(path)
+        conn.executescript(
+            "CREATE TABLE IF NOT EXISTS acoustic_similarity ("
+            " artist_a_id INTEGER NOT NULL, artist_b_id INTEGER NOT NULL,"
+            " similarity REAL NOT NULL, PRIMARY KEY (artist_a_id, artist_b_id))"
+        )
+        ids = {r[1]: r[0] for r in conn.execute("SELECT id, canonical_name FROM artist")}
+        a, b = sorted([ids["Source"], ids["EnrichOnly"]])
+        # Use 0.99 so the rescaled score is at the saturation-floor cap (≈1.0).
+        conn.execute("INSERT INTO acoustic_similarity VALUES (?, ?, ?)", (a, b, 0.99))
+        conn.commit()
+        conn.close()
+        app = create_app(path)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            yield ac, ids
+
+    @pytest.mark.asyncio
+    async def test_cool_slider_dj_only_outranks_enrichment_only(
+        self, heat_client: tuple[AsyncClient, dict[str, int]]
+    ) -> None:
+        client, ids = heat_client
+        resp = await client.get(
+            f"/graph/artists/{ids['Source']}/neighbors",
+            params={"type": "affinity", "limit": 10, "heat": 0.0},
+        )
+        assert resp.status_code == 200
+        weights = {n["artist"]["canonical_name"]: n["weight"] for n in resp.json()["neighbors"]}
+        assert weights["DjOnly"] > 0
+        # At cool, enrichment is damped to zero — EnrichOnly should drop out entirely.
+        assert weights.get("EnrichOnly", 0) == 0
+
+    @pytest.mark.asyncio
+    async def test_hot_slider_enrichment_only_outranks_dj_only(
+        self, heat_client: tuple[AsyncClient, dict[str, int]]
+    ) -> None:
+        client, ids = heat_client
+        resp = await client.get(
+            f"/graph/artists/{ids['Source']}/neighbors",
+            params={"type": "affinity", "limit": 10, "heat": 1.0},
+        )
+        assert resp.status_code == 200
+        weights = {n["artist"]["canonical_name"]: n["weight"] for n in resp.json()["neighbors"]}
+        # At hot, DJ contribution is zero — DjOnly should drop out, EnrichOnly should remain.
+        assert weights.get("EnrichOnly", 0) > 0
+        assert weights.get("DjOnly", 0) == 0
+
+
 class TestBatchNeighbors:
     @pytest.mark.asyncio
     async def test_batch_returns_results_per_artist(


### PR DESCRIPTION
## Summary

- Heat now scales the per-dimension weights in the affinity composite, in addition to its existing PMI blend on DJ transition.
- Cool end (heat=0) is a pure WXYC mirror: DJ at full weight, enrichment damped to zero. Hot end (heat=1) is discovery: DJ damped to zero, enrichment doubled. Center (heat=0.5) preserves the existing balanced default.
- Piecewise mapping: DJ stays full across the cool half then ramps to zero at hot; enrichment ramps linearly from 0 through 1× at center to 2× at hot. Default behavior at heat=0.5 is unchanged.

## Verification on production

For Autechre on the production graph:

- Cool (heat=0): Aphex Twin, Growing, Kraftwerk, Tangerine Dream — DJ-driven WXYC mirror.
- Center (heat=0.5): Aphex Twin, Pan Sonic, Matmos, Boards of Canada — unchanged from pre-PR.
- Hot (heat=1.0): Bill Laswell, Excepter, Higher Intelligence Agency, Two Lone Swordsmen — enrichment-only neighbors surface.

## Test plan

- [x] New unit tests assert cool damps enrichment-only neighbors to weight 0
- [x] New unit tests assert hot damps DJ-only neighbors to weight 0
- [x] Existing affinity tests (including acoustic rescale, batch, explain) still pass at heat=0.5 default
- [x] ruff check / ruff format / mypy clean
- [x] Spot-checked production data for Autechre across cool / center / hot

Closes #295