### PR TITLE
api(observability): wire init_sentry from wxyc-fastapi

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -261,6 +261,8 @@ Both pipeline entrypoints (`run_pipeline.py` and `scripts/nightly_sync.py`) init
 
 Sentry activates automatically when `SENTRY_DSN` is set in the environment; without it, JSON logging still initializes and Sentry stays inactive. TODO: provision `SENTRY_DSN` in the EC2 `.env.semantic-index` and the GitHub Actions deploy workflow (separate child task — see Phase A epic).
 
+The Graph API service (`semantic_index/api/app.py`) initializes Sentry separately via `wxyc_fastapi.observability.init_sentry` in `_create_app_from_settings()`. It reads `SENTRY_DSN`, `SENTRY_ENVIRONMENT`, and `SENTRY_RELEASE` from the environment via `Settings`. `service.name` is set to `"semantic-index"`. The default `HttpxIntegration` is on, so outbound calls (Anthropic, iTunes, Spotify, Bandcamp, Deezer) are traced. Pass `integrations=[FastApiIntegration()]` to opt out if quota becomes a concern.
+
 ### Code Style
 
 - Python 3.12+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "psycopg[binary]>=3.1",
     "httpx>=0.25",
     "wxyc-etl>=0.3.0",
-    "sentry-sdk>=2.0",
+    "wxyc-fastapi>=0.1.0,<0.2.0",
 ]
 
 [project.optional-dependencies]

--- a/semantic_index/api/app.py
+++ b/semantic_index/api/app.py
@@ -10,6 +10,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
+from wxyc_fastapi.observability import init_sentry
 
 from semantic_index.api.bio import bio_router
 from semantic_index.api.narrative import narrative_router
@@ -103,6 +104,12 @@ def _create_app_from_settings() -> FastAPI:
     from semantic_index.api.config import Settings
 
     settings = Settings()
+    init_sentry(
+        dsn=settings.sentry_dsn,
+        service_name="semantic-index",
+        environment=settings.sentry_environment,
+        release=settings.sentry_release,
+    )
     return create_app(
         settings.db_path,
         anthropic_api_key=settings.anthropic_api_key,

--- a/semantic_index/api/config.py
+++ b/semantic_index/api/config.py
@@ -19,6 +19,10 @@ class Settings(BaseSettings):
     port: int = 8000
     anthropic_api_key: str | None = None
 
+    sentry_dsn: str | None = None
+    sentry_environment: str = "local"
+    sentry_release: str | None = None
+
     # Nightly sync scheduler
     sync_enabled: bool = False
     sync_hour_utc: int = 9  # 9:00 UTC = 5:00 AM ET

--- a/tests/unit/test_app_sentry_init.py
+++ b/tests/unit/test_app_sentry_init.py
@@ -1,0 +1,46 @@
+"""Tests for Sentry initialization in the Graph API factory."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+
+def test_create_app_from_settings_initializes_sentry(monkeypatch, tmp_path) -> None:
+    """``_create_app_from_settings`` calls ``init_sentry`` with the service name."""
+    db_path = tmp_path / "graph.db"
+    db_path.touch()
+    monkeypatch.setenv("DB_PATH", str(db_path))
+    monkeypatch.setenv("SENTRY_DSN", "https://public@sentry.example.com/1")
+    monkeypatch.setenv("SENTRY_ENVIRONMENT", "test")
+    monkeypatch.setenv("SENTRY_RELEASE", "test-1.2.3")
+
+    with patch("semantic_index.api.app.init_sentry") as mock_init:
+        from semantic_index.api.app import _create_app_from_settings
+
+        _create_app_from_settings()
+
+    mock_init.assert_called_once()
+    kwargs = mock_init.call_args.kwargs
+    assert kwargs["dsn"] == "https://public@sentry.example.com/1"
+    assert kwargs["service_name"] == "semantic-index"
+    assert kwargs["environment"] == "test"
+    assert kwargs["release"] == "test-1.2.3"
+
+
+def test_create_app_from_settings_passes_none_dsn_when_unset(monkeypatch, tmp_path) -> None:
+    """Without ``SENTRY_DSN``, ``init_sentry`` is still called (it no-ops on None)."""
+    db_path = tmp_path / "graph.db"
+    db_path.touch()
+    monkeypatch.setenv("DB_PATH", str(db_path))
+    monkeypatch.delenv("SENTRY_DSN", raising=False)
+    monkeypatch.delenv("SENTRY_ENVIRONMENT", raising=False)
+    monkeypatch.delenv("SENTRY_RELEASE", raising=False)
+
+    with patch("semantic_index.api.app.init_sentry") as mock_init:
+        from semantic_index.api.app import _create_app_from_settings
+
+        _create_app_from_settings()
+
+    mock_init.assert_called_once()
+    assert mock_init.call_args.kwargs["dsn"] is None
+    assert mock_init.call_args.kwargs["service_name"] == "semantic-index"

--- a/tests/unit/test_app_sentry_init.py
+++ b/tests/unit/test_app_sentry_init.py
@@ -5,16 +5,16 @@ from __future__ import annotations
 from unittest.mock import patch
 
 
-def test_create_app_from_settings_initializes_sentry(monkeypatch, tmp_path) -> None:
+def test_create_app_from_settings_initializes_sentry(monkeypatch) -> None:
     """``_create_app_from_settings`` calls ``init_sentry`` with the service name."""
-    db_path = tmp_path / "graph.db"
-    db_path.touch()
-    monkeypatch.setenv("DB_PATH", str(db_path))
     monkeypatch.setenv("SENTRY_DSN", "https://public@sentry.example.com/1")
     monkeypatch.setenv("SENTRY_ENVIRONMENT", "test")
     monkeypatch.setenv("SENTRY_RELEASE", "test-1.2.3")
 
-    with patch("semantic_index.api.app.init_sentry") as mock_init:
+    with (
+        patch("semantic_index.api.app.init_sentry") as mock_init,
+        patch("semantic_index.api.app.create_app"),
+    ):
         from semantic_index.api.app import _create_app_from_settings
 
         _create_app_from_settings()
@@ -27,16 +27,16 @@ def test_create_app_from_settings_initializes_sentry(monkeypatch, tmp_path) -> N
     assert kwargs["release"] == "test-1.2.3"
 
 
-def test_create_app_from_settings_passes_none_dsn_when_unset(monkeypatch, tmp_path) -> None:
+def test_create_app_from_settings_passes_none_dsn_when_unset(monkeypatch) -> None:
     """Without ``SENTRY_DSN``, ``init_sentry`` is still called (it no-ops on None)."""
-    db_path = tmp_path / "graph.db"
-    db_path.touch()
-    monkeypatch.setenv("DB_PATH", str(db_path))
     monkeypatch.delenv("SENTRY_DSN", raising=False)
     monkeypatch.delenv("SENTRY_ENVIRONMENT", raising=False)
     monkeypatch.delenv("SENTRY_RELEASE", raising=False)
 
-    with patch("semantic_index.api.app.init_sentry") as mock_init:
+    with (
+        patch("semantic_index.api.app.init_sentry") as mock_init,
+        patch("semantic_index.api.app.create_app"),
+    ):
         from semantic_index.api.app import _create_app_from_settings
 
         _create_app_from_settings()


### PR DESCRIPTION
## Summary

Closes #307. Wires `wxyc_fastapi.observability.init_sentry` into `_create_app_from_settings()` so the Graph API service finally reports errors to Sentry. The `sentry-sdk` dependency has been declared since the service was created, but `init_sentry()` was never called — that's the latent bug this ticket targeted.

## Changes

- `pyproject.toml`: replace `sentry-sdk>=2.0` with `wxyc-fastapi>=0.1.0,<0.2.0` (sentry-sdk comes in transitively).
- `semantic_index/api/config.py`: add `sentry_dsn`, `sentry_environment` (default `"local"`), `sentry_release` settings.
- `semantic_index/api/app.py`: import `init_sentry` and call it once in `_create_app_from_settings()` before `create_app()`. `service_name="semantic-index"` is hard-coded.
- `tests/unit/test_app_sentry_init.py`: two tests covering the wired-up case (`SENTRY_DSN` set) and the unset case (`init_sentry` still called, with `dsn=None` so it no-ops).
- `CLAUDE.md`: document the new init path under the Observability section.

The pipeline entrypoints (`run_pipeline.py`, `scripts/nightly_sync.py`) continue to use `wxyc_etl.logger.init_logger()` and are unaffected.

## Consumer impact

`HttpxIntegration` is default-on in `wxyc-fastapi.init_sentry`, so outbound httpx calls from the Graph API (Anthropic narrative generation, iTunes/Spotify/Bandcamp/Deezer preview lookups) will now show up in Sentry as spans tied to parent transactions. Watch quota after deploy; opt out via `integrations=[FastApiIntegration()]` if it spikes.

## Deployment follow-up

A Sentry project for `semantic-index` needs to exist in the WXYC Sentry org, and `SENTRY_DSN`/`SENTRY_ENVIRONMENT`/`SENTRY_RELEASE` need to land in the EC2 `.env.semantic-index` plus the GitHub Actions deploy workflow before a real event will be visible. Until then, `init_sentry(dsn=None, ...)` is a no-op (logs an info line and returns), so this is safe to merge.

## Test plan

- [x] `pytest` — 965 passed locally (no regressions).
- [x] `ruff check` + `ruff format --check` — clean.
- [x] `mypy semantic_index/` — clean.
- [ ] After merge: trigger a test exception in staging via a temporary `/debug/sentry` route or by hitting an unimplemented path; confirm the event lands; remove the test trigger.