### PR TITLE
api(healthcheck): adopt wxyc-fastapi readiness_router; add /health/ready

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "psycopg[binary]>=3.1",
     "httpx>=0.25",
     "wxyc-etl>=0.3.0",
-    "wxyc-fastapi>=0.1.0,<0.2.0",
+    "wxyc-fastapi>=0.2.0,<0.3.0",
 ]
 
 [project.optional-dependencies]

--- a/semantic_index/api/app.py
+++ b/semantic_index/api/app.py
@@ -10,6 +10,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
+from wxyc_fastapi.healthcheck import Check, readiness_router
 from wxyc_fastapi.observability import init_sentry
 
 from semantic_index.api.bio import bio_router
@@ -61,6 +62,13 @@ def create_app(
     app.include_router(preview_router)
     app.include_router(narrative_audit_router)
 
+    # Liveness/health: kept inline because semantic-index returns a custom
+    # `artist_count` field in addition to `status`, which the shared
+    # `wxyc_fastapi.healthcheck.liveness_router` does not surface. Adopting
+    # `liveness_router` would drop the `artist_count` field that the WXYC
+    # synthetic-DJ canary parses (see WXYC/wxyc-canary). Readiness, which
+    # is shape-compatible with the shared router, *is* delegated below.
+    # Tracked: WXYC/wxyc-fastapi#19 (extra-fields hook for liveness).
     @app.get("/health", include_in_schema=False)
     def health() -> JSONResponse:
         """Health check — verifies the SQLite database is readable."""
@@ -74,6 +82,31 @@ def create_app(
                 {"status": "unhealthy", "detail": str(exc)},
                 status_code=503,
             )
+
+    async def _probe_artist_count_query() -> str:
+        """Readiness probe: confirms the SQLite graph DB is readable.
+
+        Returns ``"ok"`` if a `SELECT COUNT(*) FROM artist` succeeds against
+        the read-only sqlite URI; raises otherwise (the shared readiness
+        router treats any exception as ``"unavailable"``).
+        """
+        # sqlite3.connect is sync but cheap; the readiness router runs probes
+        # concurrently with a 3s default timeout, so we don't need to thread
+        # it. If this becomes a hot path, switch to aiosqlite.
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        try:
+            conn.execute("SELECT COUNT(*) FROM artist").fetchone()
+        finally:
+            conn.close()
+        return "ok"
+
+    app.include_router(
+        readiness_router(
+            checks=[
+                Check(name="database", probe=_probe_artist_count_query, required=True),
+            ],
+        ),
+    )
 
     @app.get("/", include_in_schema=False)
     def root() -> FileResponse:

--- a/semantic_index/api/app.py
+++ b/semantic_index/api/app.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import sqlite3
 from pathlib import Path
@@ -83,21 +84,25 @@ def create_app(
                 status_code=503,
             )
 
+    def _probe_artist_count_sync() -> None:
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        try:
+            conn.execute("SELECT COUNT(*) FROM artist").fetchone()
+        finally:
+            conn.close()
+
     async def _probe_artist_count_query() -> str:
         """Readiness probe: confirms the SQLite graph DB is readable.
 
         Returns ``"ok"`` if a `SELECT COUNT(*) FROM artist` succeeds against
         the read-only sqlite URI; raises otherwise (the shared readiness
         router treats any exception as ``"unavailable"``).
+
+        The sync `sqlite3` work is offloaded via `asyncio.to_thread` so the
+        probe never blocks the event loop, even if the SQLite file is on slow
+        storage or the OS file cache is cold.
         """
-        # sqlite3.connect is sync but cheap; the readiness router runs probes
-        # concurrently with a 3s default timeout, so we don't need to thread
-        # it. If this becomes a hot path, switch to aiosqlite.
-        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
-        try:
-            conn.execute("SELECT COUNT(*) FROM artist").fetchone()
-        finally:
-            conn.close()
+        await asyncio.to_thread(_probe_artist_count_sync)
         return "ok"
 
     app.include_router(

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -112,6 +112,55 @@ class TestReadinessEndpoint:
         data = response.json()
         assert data == {"status": "unhealthy", "services": {"database": "unavailable"}}
 
+    @pytest.mark.asyncio
+    async def test_health_ready_probe_does_not_block_event_loop(
+        self, test_db: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Concurrent readiness probes must run in parallel via asyncio.to_thread.
+
+        If `_probe_artist_count_query` were to call `sqlite3.connect` inline
+        (sync) on the event loop, two concurrent requests would serialize and
+        take ~2x the per-call latency. Offloading to a thread pool lets them
+        overlap, so wall-clock time should stay close to the per-call latency.
+        """
+        import asyncio
+        import sqlite3
+        import time
+
+        from httpx import ASGITransport, AsyncClient
+
+        from semantic_index.api.app import create_app
+
+        per_call_delay = 0.2  # seconds
+        real_connect = sqlite3.connect
+
+        def slow_connect(*args, **kwargs):
+            time.sleep(per_call_delay)
+            return real_connect(*args, **kwargs)
+
+        monkeypatch.setattr("semantic_index.api.app.sqlite3.connect", slow_connect)
+
+        app = create_app(str(test_db))
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            start = time.monotonic()
+            r1, r2 = await asyncio.gather(
+                ac.get("/health/ready"),
+                ac.get("/health/ready"),
+            )
+            elapsed = time.monotonic() - start
+
+        assert r1.status_code == 200
+        assert r2.status_code == 200
+        # Two serialized 0.2s probes would take ~0.4s; parallel should be ~0.2s.
+        # Generous ceiling at 1.5x per-call latency leaves room for CI jitter
+        # while still failing if the probe blocks the event loop.
+        assert elapsed < per_call_delay * 1.5, (
+            f"Concurrent readiness probes took {elapsed:.3f}s, "
+            f"expected < {per_call_delay * 1.5:.3f}s. The probe is likely "
+            "blocking the event loop instead of using asyncio.to_thread."
+        )
+
 
 class TestRootRoute:
     def test_root_returns_explorer_html(self, client: TestClient):

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -93,6 +93,26 @@ class TestHealthEndpoint:
         assert data["status"] == "unhealthy"
 
 
+class TestReadinessEndpoint:
+    """`/health/ready` is mounted via `wxyc_fastapi.healthcheck.readiness_router`.
+
+    Snapshot tests for the new route. `/health/ready` is the only route allowed
+    to fail with 503; aggregate semantics come from the shared router.
+    """
+
+    def test_health_ready_returns_200_when_db_reachable(self, client: TestClient):
+        response = client.get("/health/ready")
+        assert response.status_code == 200
+        data = response.json()
+        assert data == {"status": "healthy", "services": {"database": "ok"}}
+
+    def test_health_ready_returns_503_when_db_missing(self, client_missing_db: TestClient):
+        response = client_missing_db.get("/health/ready")
+        assert response.status_code == 503
+        data = response.json()
+        assert data == {"status": "unhealthy", "services": {"database": "unavailable"}}
+
+
 class TestRootRoute:
     def test_root_returns_explorer_html(self, client: TestClient):
         response = client.get("/")


### PR DESCRIPTION
Closes [#308](https://github.com/WXYC/semantic-index/issues/308).

## Summary

- Bumps `wxyc-fastapi` to `>=0.2.0,<0.3.0` (just published today).
- Mounts `wxyc_fastapi.healthcheck.readiness_router` with one required `database` Check, exposing a new `GET /health/ready` route that returns `{"status":"healthy","services":{"database":"ok"}}` on success and 503 with `services.database == "unavailable"` on failure.
- Keeps the existing inline `@app.get("/health")` handler unchanged for byte-equivalent backward compatibility (see Design Choice below).
- Adds snapshot tests for both `/health/ready` paths in `tests/unit/test_api.py`.

## Design choice — Option A: keep inline `/health`, only adopt readiness

The shared `liveness_router` returns a fixed `{"status":"healthy"}` payload. semantic-index's `/health` returns `{"status":"healthy","artist_count":N}`. The `artist_count` field is parsed by the [WXYC synthetic-DJ canary](https://github.com/WXYC/wxyc-canary) and surfaces in EC2 deploy smoke checks; dropping it would be a silent regression.

Three options were on the table:

- **A (this PR)** — Keep the inline handler, mount only `readiness_router`. Loses symmetry but preserves the field. Documented in a code comment in `app.py`.
- **B** — Adopt `liveness_router` and drop `artist_count`. Rejected: regression for canary/smoke tests.
- **C** — Add an `extra_fields` hook upstream and adopt. Correct long-term but blocks this PR; filed as [WXYC/wxyc-fastapi#19](https://github.com/WXYC/wxyc-fastapi/issues/19) for follow-up.

When upstream #19 lands, the inline handler can be replaced with `liveness_router(extra_fields=...)` in a follow-up PR.

## Test plan

- [x] `pytest tests/unit/test_api.py -v` — 11 passed including 2 new readiness tests
- [x] `pytest tests/ -q` — 967 passed, 13 deselected
- [x] `ruff check .` + `ruff format --check .` clean
- [x] `mypy semantic_index/` clean
- [ ] After merge: confirm canary `semanticIndexSearch` probe stays green for 24 h

## Related

- Epic: [WXYC/wxyc-fastapi#1](https://github.com/WXYC/wxyc-fastapi/issues/1)
- Phase B epic: [WXYC/wxyc-fastapi#12](https://github.com/WXYC/wxyc-fastapi/issues/12)
- Depends on: [WXYC/wxyc-fastapi#3](https://github.com/WXYC/wxyc-fastapi/issues/3) (closed; v0.2.0 published today)
- Sibling consumers: [WXYC/request-o-matic#115](https://github.com/WXYC/request-o-matic/issues/115), [WXYC/library-metadata-lookup#282](https://github.com/WXYC/library-metadata-lookup/issues/282)
- Upstream follow-up: [WXYC/wxyc-fastapi#19](https://github.com/WXYC/wxyc-fastapi/issues/19) (extra-fields hook for liveness)