### PR TITLE
#309 migrate to wxyc-fastapi db.lazy_pg

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "psycopg[binary]>=3.1",
     "httpx>=0.25",
     "wxyc-etl>=0.3.0",
-    "wxyc-fastapi>=0.2.0,<0.3.0",
+    "wxyc-fastapi[psycopg]>=1.0.0,<2.0.0",
 ]
 
 [project.optional-dependencies]

--- a/semantic_index/acousticbrainz_client.py
+++ b/semantic_index/acousticbrainz_client.py
@@ -9,6 +9,8 @@ JOIN query.
 import json
 import logging
 
+from wxyc_fastapi.db import LazyPgConnection
+
 from semantic_index.acousticbrainz import (
     GENRE_ELECTRONIC_LABELS,
     GENRE_LABELS,
@@ -18,7 +20,7 @@ from semantic_index.acousticbrainz import (
     RHYTHM_LABELS,
     RecordingFeatures,
 )
-from semantic_index.utils import LazyPgConnection, batched_with_log
+from semantic_index.utils import batched_with_log
 
 logger = logging.getLogger(__name__)
 

--- a/semantic_index/discogs_client.py
+++ b/semantic_index/discogs_client.py
@@ -20,6 +20,7 @@ from wxyc_etl.schema import (  # type: ignore[import-untyped]
     RELEASE_TRACK_ARTIST_TABLE,
     RELEASE_TRACK_TABLE,
 )
+from wxyc_fastapi.db import LazyPgConnection
 
 from semantic_index.models import (
     CompilationEdge,
@@ -32,7 +33,6 @@ from semantic_index.models import (
     SharedPersonnelEdge,
     SharedStyleEdge,
 )
-from semantic_index.utils import LazyPgConnection
 
 logger = logging.getLogger(__name__)
 

--- a/semantic_index/musicbrainz_client.py
+++ b/semantic_index/musicbrainz_client.py
@@ -8,7 +8,9 @@ moved to LML.
 
 import logging
 
-from semantic_index.utils import LazyPgConnection, batched_with_log
+from wxyc_fastapi.db import LazyPgConnection
+
+from semantic_index.utils import batched_with_log
 
 logger = logging.getLogger(__name__)
 

--- a/semantic_index/utils.py
+++ b/semantic_index/utils.py
@@ -6,40 +6,7 @@ import logging
 import sqlite3
 from collections.abc import Iterator
 
-import psycopg
-
 logger = logging.getLogger(__name__)
-
-
-class LazyPgConnection:
-    """Lazy, reconnecting PostgreSQL connection wrapper.
-
-    Defers connection creation until first use and transparently reconnects
-    when the connection is closed. Returns ``None`` when no DSN is configured
-    or on connection failure, matching the graceful-degradation pattern used
-    by the pipeline's PostgreSQL clients.
-
-    Args:
-        dsn: PostgreSQL connection string, or ``None`` to disable.
-        label: Human-readable name for log messages (e.g. ``"discogs-cache"``).
-    """
-
-    def __init__(self, dsn: str | None, label: str) -> None:
-        self._dsn = dsn
-        self._label = label
-        self._conn: psycopg.Connection | None = None
-
-    def get(self) -> psycopg.Connection | None:
-        """Return an open connection, or ``None`` if unavailable."""
-        if self._dsn is None:
-            return None
-        if self._conn is None or self._conn.closed:
-            try:
-                self._conn = psycopg.connect(self._dsn, autocommit=True)
-            except Exception:
-                logger.warning("Failed to connect to %s", self._label, exc_info=True)
-                return None
-        return self._conn
 
 
 def batched_with_log(

--- a/semantic_index/wikidata_client.py
+++ b/semantic_index/wikidata_client.py
@@ -14,13 +14,13 @@ import re
 import time
 
 import httpx
+from wxyc_fastapi.db import LazyPgConnection
 
 from semantic_index.models import (
     WikidataEntity,
     WikidataInfluence,
     WikidataLabelHierarchy,
 )
-from semantic_index.utils import LazyPgConnection
 
 logger = logging.getLogger(__name__)
 

--- a/tests/unit/test_lazy_pg_migration.py
+++ b/tests/unit/test_lazy_pg_migration.py
@@ -1,0 +1,56 @@
+"""Regression: pipeline modules consume the shared LazyPgConnection from wxyc-fastapi.
+
+semantic-index used to ship its own ``LazyPgConnection`` in ``utils.py``. Phase E
+of the wxyc-fastapi project (issue #309) lifted that class verbatim into
+``wxyc_fastapi.db.lazy_pg`` and made semantic-index a consumer. These tests pin
+the post-migration contract:
+
+* The four PG-cache pipeline clients hold a ``wxyc_fastapi.db.LazyPgConnection``
+  instance (not a local copy that happens to share the name).
+* ``semantic_index.utils`` no longer defines the class itself.
+
+If any client regresses to a local class, the isinstance check fails. If a future
+change re-introduces a local ``LazyPgConnection`` in ``utils.py``, the absence
+check fails.
+"""
+
+from __future__ import annotations
+
+from wxyc_fastapi.db import LazyPgConnection as SharedLazyPgConnection
+
+from semantic_index.acousticbrainz_client import AcousticBrainzClient
+from semantic_index.discogs_client import DiscogsClient
+from semantic_index.musicbrainz_client import MusicBrainzClient
+from semantic_index.wikidata_client import WikidataClient
+
+
+def test_discogs_client_uses_shared_lazy_pg() -> None:
+    client = DiscogsClient(cache_dsn=None, api_base_url=None)
+    assert isinstance(client._pg, SharedLazyPgConnection)
+
+
+def test_musicbrainz_client_uses_shared_lazy_pg() -> None:
+    # cache_dsn is annotated `str` but LazyPgConnection accepts None at runtime
+    # (graceful-degradation contract); pass None to avoid touching real PG.
+    client = MusicBrainzClient(cache_dsn=None)  # type: ignore[arg-type]
+    assert isinstance(client._pg, SharedLazyPgConnection)
+
+
+def test_wikidata_client_uses_shared_lazy_pg() -> None:
+    client = WikidataClient(cache_dsn=None)
+    assert isinstance(client._pg, SharedLazyPgConnection)
+
+
+def test_acousticbrainz_client_uses_shared_lazy_pg() -> None:
+    client = AcousticBrainzClient(cache_dsn=None)  # type: ignore[arg-type]
+    assert isinstance(client._pg, SharedLazyPgConnection)
+
+
+def test_utils_no_longer_defines_lazy_pg_connection() -> None:
+    """utils.py must not re-export a local LazyPgConnection after Phase E."""
+    import semantic_index.utils as utils_mod
+
+    assert not hasattr(utils_mod, "LazyPgConnection"), (
+        "semantic_index.utils should not define LazyPgConnection after the "
+        "Phase E migration to wxyc_fastapi.db.lazy_pg (issue #309)."
+    )


### PR DESCRIPTION
## Summary

- Bumps `wxyc-fastapi` to `[psycopg]>=1.0.0,<2.0.0` and swaps `LazyPgConnection` imports in the four PG-cache pipeline clients (`discogs_client`, `musicbrainz_client`, `wikidata_client`, `acousticbrainz_client`) to consume the shared class from `wxyc_fastapi.db`.
- Removes the local `LazyPgConnection` definition from `semantic_index/utils.py`. The rest of that module (`batched_with_log`, `ensure_columns`) is unchanged.
- Adds a regression test (`tests/unit/test_lazy_pg_migration.py`) that pins each caller's `_pg` attribute to the shared `wxyc_fastapi.db.LazyPgConnection` and asserts `utils.py` no longer defines the class.

This is the **final consumer migration** of the wxyc-fastapi project ([Phase E](https://github.com/WXYC/wxyc-fastapi/issues/1)). The shared module was lifted byte-for-byte from this repo's own `utils.py:14-42` into [`wxyc_fastapi.db.lazy_pg`](https://github.com/WXYC/wxyc-fastapi/blob/main/src/wxyc_fastapi/db/lazy_pg.py) and shipped in [v1.0.0](https://pypi.org/project/wxyc-fastapi/1.0.0/), so this is a pure import swap with zero behavioral change. The issue body said `[asyncpg]` but per the wxyc-fastapi v1.0.0 README and CLAUDE.md, the actual driver dependency for `db.lazy_pg` is `[psycopg]`; `[asyncpg]` is forward-looking for async-pool consumers (no consumer today).

Closes #309. Refs WXYC/wxyc-fastapi#1, WXYC/wxyc-fastapi#6.

## Test plan

- [x] `pytest tests/` — 973 passed, 13 deselected (5 new regression tests in `test_lazy_pg_migration.py`)
- [x] `pytest tests/ -m pg` — 12 passed (PG-marker route still healthy)
- [x] `ruff check .` — clean
- [x] `ruff format --check .` — clean
- [x] `mypy semantic_index/` — clean
- [x] Acceptance: `git grep "class LazyPgConnection"` returns zero