### PR TITLE
deploy: cap semantic-index container at 1 GiB with WORKERS=1

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -93,12 +93,19 @@ jobs:
             docker rm semantic-index || true
 
             echo "Starting new container..."
+            # WORKERS=1 + 1 GiB cgroup cap: post-2026-05-17 OOM-wedge hardening (BS#937).
+            # Pre-fix: 4 uvicorn workers x ~370 MB copy of NetworkX + Essentia each = 1.48 GB peak,
+            # unbounded, global-OOM-killing the t3.small host. cgroup cap keeps any future
+            # blowup scoped to this container so the global OOM-killer can't take the host down again.
             docker run -d \
               --name semantic-index \
               -p 8083:8083 \
               -v /home/ec2-user/semantic-index-data:/data \
               --restart unless-stopped \
               --env-file .env.semantic-index \
+              -e WORKERS=1 \
+              --memory 1g \
+              --memory-swap 1g \
               $IMAGE_URI
 
             echo "Waiting for health check..."


### PR DESCRIPTION
## Summary

Post-2026-05-17 OOM-wedge hardening. Persists the live mitigation applied to the EC2 host into the deploy workflow so subsequent pushes don't strip the cap.

The host ran out of memory at 2026-05-17 06:42 UTC when uvicorn (4 workers, each holding its own copy of NetworkX + Essentia) hit 1.48 GB anon-rss with no cgroup cap, triggering `oom-kill: constraint=CONSTRAINT_NONE, global_oom` and a 15-hour outage on api.wxyc.org. A cgroup constraint + single worker keeps any future blowup scoped to this container instead of taking the t3.small host down with it.

Changes to `docker run` in deploy.yml:
- `-e WORKERS=1` — one uvicorn worker (was `${WORKERS:-4}` in start.sh)
- `--memory 1g --memory-swap 1g` — cgroup cap, no swap inside the cgroup so OOM fires fast and predictably

Cold baseline post-fix on the host: 47 MiB / 1 GiB (vs 181 MiB with 4 workers). Health: 200.

Refs WXYC/Backend-Service#937 (recommended actions #1 + #2; canary fanout and CloudWatch agent fix are separate work).

## Test plan

- [x] Live-applied to the running container; `curl /health` returns 200; `docker stats` shows the cap enforced.
- [ ] Next deploy to main preserves the cap (verify via `docker inspect semantic-index --format '{{.HostConfig.Memory}}'` after CI completes).
- [ ] Monitor `MemUsage` over 48h for organic growth — second wedge on 2026-05-17 was 2 days after the prior on 2026-05-15, so a leak hypothesis should surface within that window.