### PR TITLE
eval: field-corruption wrong-set construction

### DIFF
--- a/docs/narrative-enrichment-whitepaper.md
+++ b/docs/narrative-enrichment-whitepaper.md
@@ -284,7 +284,7 @@ Manual review of all 19 pairs and their verification results revealed that hallu
 
 **4. Garbage-in data (style noise).** Alex G.'s top 3 Discogs styles came back as "Dance-pop, Euro House, Makina" — from minor releases, not representative. The model dutifully described Alex G. as "channeling dance-pop and Euro House into experimental rock territory." The narrative was technically grounded in the provided data but substantively wrong. The automated verifier cannot catch this because it checks against provided data, not reality.
 
-A grounding-fidelity scorer (token-match, claim-ratio) is structurally blind to this failure mode by construction — the constraint ontology proposed in §8 is the mechanism designed to catch it. Measuring that gap requires gold positives where the narrative is faithful to a deliberately-corrupted input, so the labeler can flag it against the *real* metadata they see. That construction is tracked in WXYC/semantic-index#277.
+A grounding-fidelity scorer (token-match, claim-ratio) is structurally blind to this failure mode by construction — the constraint ontology proposed in §8 is the mechanism designed to catch it. Measuring that gap requires gold positives where the narrative is faithful to a deliberately-corrupted input, so the labeler can flag it against the *real* metadata they see. Forty such rows ship in `scripts/eval/build_wrong_set.py --mode field_corruption` (`construction_method=field_corruption`, `failure_mode=data_noise`); see WXYC/semantic-index#277.
 
 ### 6.4 Targeted Mitigations
 
@@ -581,7 +581,7 @@ The production endpoint at `/graph/artists/{id}/explain/{target_id}/narrative` n
 - **Generate-score-regenerate loop** with two retries (`1dab529`); the closed loop converges 100% of the 18% that retry.
 - **Periodic claim-ratio audit** with a sidecar audit DB and the `/graph/narrative-audit/recent` endpoint (`e63fadd`).
 - **UI-side heat slider** in `routes.py` that modulates the DJ-vs-enrichment weight balance during neighbor selection (`ed9eac6`).
-- **Narrative eval-set scaffolding**: stratified pair sampler across the 2×2×2 risk matrix, deliberately-wrong narrative constructor (data-shuffle method), bulk generator over the production endpoint, exporter that produces a labeling CSV/JSONL, label merger, and backscorer for measuring per-method recall against gold labels (`scripts/eval/`).
+- **Narrative eval-set scaffolding**: stratified pair sampler across the 2×2×2 risk matrix, deliberately-wrong narrative constructors (data-shuffle for `subject_hallucination`, field-corruption for `data_noise` per #277), bulk generator over the production endpoint, exporter that produces a labeling CSV/JSONL, label merger, and backscorer (`scripts/eval/backscore.py metrics`) that reports per-failure-mode and per-construction-method recall against gold labels (`scripts/eval/`).
 - **Standalone labeling web UI** (`semantic_index/labeling_app/`) — a single-page FastAPI app that reads the eval-set JSONL, persists per-labeler labels to a SQLite sidecar, and exports a merge-ready CSV. Deployed for human labeling.
 
 The accuracy delta from baseline to current production is the headline 45% → 9% hallucination reduction, achieved with no new infrastructure and roughly 280 prompt-token overhead per call.
@@ -591,7 +591,7 @@ The accuracy delta from baseline to current production is the headline 45% → 9
 - **Release-count column for `artist_style`.** The 5-style cap is currently alphabetical; switching to release-count ranking is a pipeline-side schema change.
 - **Audit-driven prompt evolution.** The audit endpoint surfaces flagged narratives but the loop back to "add a few-shot example or a constraint rule" is still manual.
 - **Narrative labeling round.** The eval-set scaffolding and labeling UI are deployed; what remains is recruiting labelers, running the calibration round (~20 rows), then the bulk pass, and merging the resulting labels into the gold set so backscore can run.
-- **Two follow-up wrong-set construction methods.** Field corruption for `data_noise` failure mode (#277) and a curated pretraining-bait set for `subject_hallucination` (#278). Both extend the existing data-shuffle wrong-set; backscore will then report per-construction-method recall.
+- **Curated pretraining-bait wrong-set.** Targets `subject_hallucination` failure modes via confusable names and strong pretraining priors (#278). Extends the existing data-shuffle + field-corruption wrong-sets; `backscore metrics` already reports per-construction-method recall.
 
 ### 10.3 Next
 
@@ -619,7 +619,7 @@ Section 4 plans structured-field extraction from reviews, but a complementary ap
 
 ### 11.3 Wrongness Detection vs. Grounding Detection
 
-Section 7 ends with the recognition that the scoring methods measure grounding fidelity, not truthiness, and Section 7.6 sketches four approaches to wrongness detection (contradiction, adversarial cross-examination, semantic alignment, constraint satisfaction). The first prerequisite — an evaluation set of narratives with human-applied "wrong / not wrong" labels — has been built (`scripts/eval/`, `semantic_index/labeling_app/`): a stratified sample across the 2×2×2 matrix combined with deliberately-wrong narratives constructed by feeding shuffled artist data through the production endpoint. Two further wrong-set construction methods are in flight (field corruption per §6.3 and pretraining bait per §6.1) so the eval set covers the failure modes a grounding scorer cannot see by construction. The remaining work is the labeling round itself, then measuring each candidate scoring method's precision and recall against the gold labels via `scripts/eval/backscore.py`.
+Section 7 ends with the recognition that the scoring methods measure grounding fidelity, not truthiness, and Section 7.6 sketches four approaches to wrongness detection (contradiction, adversarial cross-examination, semantic alignment, constraint satisfaction). The first prerequisite — an evaluation set of narratives with human-applied "wrong / not wrong" labels — has been built (`scripts/eval/`, `semantic_index/labeling_app/`): a stratified sample across the 2×2×2 matrix combined with two deliberately-wrong constructions — data shuffle (real names + mismatched metadata, 30 rows, `subject_hallucination`) and field corruption (real pair + one deliberately corrupted field, 40 rows, `data_noise`; #277). A third construction — curated pretraining bait per §6.1 — is in flight (#278). The remaining work is the labeling round itself, then measuring each candidate scoring method's precision and recall against the gold labels via `scripts/eval/backscore.py`, whose `metrics` subcommand already reports per-construction-method recall — the load-bearing comparison for surfacing the data_noise gap that the constraint ontology should close.
 
 ### 11.4 Constraint Ontology Bootstrap
 

--- a/scripts/eval/backscore.py
+++ b/scripts/eval/backscore.py
@@ -184,8 +184,12 @@ def cmd_score(args: argparse.Namespace) -> int:
             if i % 20 == 0 or i == len(todo):
                 logger.info(
                     "%d/%d scored (errors=%d, last token=%.3f claim=%.3f, %dms)",
-                    i, len(todo), errors,
-                    scores["token_match_v1"], scores["claim_ratio_v1"], elapsed_ms,
+                    i,
+                    len(todo),
+                    errors,
+                    scores["token_match_v1"],
+                    scores["claim_ratio_v1"],
+                    elapsed_ms,
                 )
 
     logger.info("Done: wrote %d, errors=%d", written, errors)
@@ -203,6 +207,10 @@ def cmd_metrics(args: argparse.Namespace) -> int:
       - F1
       - per-failure_mode breakdown of recall (which categories does each
         scorer catch?)
+      - per-construction_method breakdown of recall (load-bearing for #277:
+        confirms grounding-fidelity scorers have lower recall on
+        field_corruption than on data_shuffle — the gap the constraint
+        ontology should fill).
     """
     scored = {r["row_id"]: r for r in _load_labeling(Path(args.scored))}
     labeled = _load_labeling(Path(args.labeled))
@@ -212,6 +220,10 @@ def cmd_metrics(args: argparse.Namespace) -> int:
         "claim_ratio_v1": {"pos_scores": [], "neg_scores": []},
     }
     by_mode_recall: dict[str, dict[str, list[bool]]] = {
+        "token_match_v1": {},
+        "claim_ratio_v1": {},
+    }
+    by_construction_recall: dict[str, dict[str, list[bool]]] = {
         "token_match_v1": {},
         "claim_ratio_v1": {},
     }
@@ -232,13 +244,17 @@ def cmd_metrics(args: argparse.Namespace) -> int:
         scores = scored[rid]["scores"]
         for method in ("token_match_v1", "claim_ratio_v1"):
             score = scores[method]
-            (by_method[method]["pos_scores"] if is_positive else by_method[method]["neg_scores"]).append(score)
+            (
+                by_method[method]["pos_scores"] if is_positive else by_method[method]["neg_scores"]
+            ).append(score)
 
         if is_positive:
             mode = label.get("failure_mode") or "unspecified"
+            construction = scored[rid].get("construction_method") or "production"
             for method in ("token_match_v1", "claim_ratio_v1"):
                 hit = scores[method] > args.threshold
                 by_mode_recall[method].setdefault(mode, []).append(hit)
+                by_construction_recall[method].setdefault(construction, []).append(hit)
 
     print(f"Labeled rows: {n_labeled} (positive: {n_pos}, negative: {n_labeled - n_pos})")
     print(f"Threshold for binary classification: {args.threshold}")
@@ -265,12 +281,19 @@ def cmd_metrics(args: argparse.Namespace) -> int:
             for mode, hits in sorted(by_mode_recall[method].items()):
                 r = sum(hits) / len(hits) if hits else 0.0
                 print(f"    {mode:30} n={len(hits):3} recall={r:.3f}")
+        if by_construction_recall[method]:
+            print("  recall by construction_method:")
+            for construction, hits in sorted(by_construction_recall[method].items()):
+                r = sum(hits) / len(hits) if hits else 0.0
+                print(f"    {construction:30} n={len(hits):3} recall={r:.3f}")
         print()
     return 0
 
 
 def main(argv: list[str] | None = None) -> int:
-    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
     sub = ap.add_subparsers(dest="cmd", required=True)
 
     score = sub.add_parser("score", help="Compute scores for the eval-set rows.")
@@ -284,8 +307,12 @@ def main(argv: list[str] | None = None) -> int:
     metrics = sub.add_parser("metrics", help="Compute precision/recall/F1 against labels.")
     metrics.add_argument("--scored", required=True)
     metrics.add_argument("--labeled", required=True)
-    metrics.add_argument("--threshold", type=float, default=0.5,
-                         help="Score above which a row is predicted positive (default 0.5)")
+    metrics.add_argument(
+        "--threshold",
+        type=float,
+        default=0.5,
+        help="Score above which a row is predicted positive (default 0.5)",
+    )
     metrics.set_defaults(func=cmd_metrics)
 
     args = ap.parse_args(argv)

--- a/scripts/eval/build_wrong_set.py
+++ b/scripts/eval/build_wrong_set.py
@@ -5,34 +5,48 @@ some will be wrong, some not, in proportions reflecting the live system. They
 test labeler IRR and represent natural distribution. Detector calibration
 needs *gold positives* — rows where wrongness is known by construction.
 
-This script generates the data-shuffle variant only:
+Two construction modes are implemented:
 
-  1. Pick an existing production pair (A, B) — the names that appear in the
-     narrative.
-  2. Pick a *different* random pair (C, D) — the metadata source.
-  3. Build a prompt that names A and B but supplies C's metadata as ``source``
-     and D's metadata as ``target``.
-  4. Call Claude Haiku directly (not via the endpoint, so the production
-     ``narrative-cache.db`` stays clean). The model produces a narrative that
-     names A and B but describes C and D's musical attributes. Wrong by
-     construction — failure_mode=subject_hallucination.
+  ``data_shuffle`` (default) — Pick an existing production pair (A, B), then
+  pick a *different* random pair (C, D). Build a prompt that names A and B
+  but supplies C's metadata as ``source`` and D's metadata as ``target``. The
+  model produces a narrative that names A and B but describes C and D's
+  musical attributes. Wrong by construction; failure_mode=subject_hallucination.
 
-Field-corruption and pretraining-bait constructions are not implemented here.
+  ``field_corruption`` — Pick a real pair and corrupt one field on one side
+  (swap ``audio.voice_instrumental``, inject outlier styles from a different
+  genre, or swap ``genre`` to a wildly different one). The model produces a
+  narrative faithful to the corrupted input — but the input is misleading, so
+  the narrative claims contradict the real metadata the labeler sees. Wrong
+  by construction; failure_mode=data_noise. Mirrors the Alex G case from
+  whitepaper §6.3.
+
+Both modes call Claude Haiku directly (not via the endpoint, so the production
+``narrative-cache.db`` stays clean).
+
+Pretraining-bait construction is not implemented here (see #278).
 
 Usage:
-    ANTHROPIC_API_KEY=sk-... python -m scripts.eval.build_wrong_set \
-        --db-path data/wxyc_artist_graph.db \
-        --narratives output/eval/eval_narratives.jsonl \
-        --out output/eval/eval_wrong.jsonl \
-        [--n 30] [--seed 7]
+    ANTHROPIC_API_KEY=sk-... python -m scripts.eval.build_wrong_set \\
+        --db-path data/wxyc_artist_graph.db \\
+        --narratives output/eval/eval_narratives.jsonl \\
+        --out output/eval/eval_wrong.jsonl \\
+        [--mode data_shuffle|field_corruption] \\
+        [--n 30] [--seed 7] [--append]
 
 Output JSONL row mirrors the production-narrative shape so ``export_labeling``
 treats both pools identically. The labeler always sees the *real* metadata for
 the artists named in the narrative — that's how they detect the wrongness.
-Extra fields:
+
+Per-mode extra fields:
+  data_shuffle:
     construction_method: "data_shuffle"
-    metadata_source: {source_id: int, target_id: int}  # the C/D pair we shuffled in
+    metadata_source: {source_id, target_id, source_name, target_name}
     expected_label: {severity: "severe", failure_mode: "subject_hallucination"}
+  field_corruption:
+    construction_method: "field_corruption"
+    corruption: {side: "source"|"target", strategy: "...", original: ..., corrupted: ...}
+    expected_label: {severity: "severe", failure_mode: "data_noise"}
 """
 
 from __future__ import annotations
@@ -50,6 +64,179 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 
+# ---------------------------------------------------------------------------
+# Refusal filter
+# ---------------------------------------------------------------------------
+
+_REFUSAL_PHRASES = (
+    "unable to",
+    "cannot write",
+    "i cannot",
+    "input data lacks",
+    "insufficient data",
+    "not enough information",
+    "no clear connection",
+    "i'm sorry",
+)
+_REFUSAL_MIN_WORDS = 30
+
+
+def _is_refusal(narrative: str | None) -> bool:
+    """Heuristic: too short, empty, or contains a known refusal phrase.
+
+    Filters narratives where the model declined to write substantive content
+    (e.g. when prompted with conflicting fields it can't reconcile). Mirrors
+    the manual filter applied during the data_shuffle corpus review.
+    """
+    if not narrative:
+        return True
+    text = narrative.strip().lower()
+    if len(text.split()) < _REFUSAL_MIN_WORDS:
+        return True
+    return any(phrase in text for phrase in _REFUSAL_PHRASES)
+
+
+# ---------------------------------------------------------------------------
+# Field-corruption helpers (pure; covered by tests/unit/test_eval_field_corruption.py)
+# ---------------------------------------------------------------------------
+
+_VI_FLIP = {"instrumental": "vocal-forward", "vocal-forward": "instrumental"}
+
+
+def _swap_voice_instrumental(meta: dict) -> dict | None:
+    """Return a copy of ``meta`` with ``audio.voice_instrumental`` flipped.
+
+    Returns ``None`` if the field is missing or carries an unexpected value
+    (the production qualitative descriptor only emits the two named extremes).
+    """
+    audio = meta.get("audio")
+    if not isinstance(audio, dict):
+        return None
+    flipped = _VI_FLIP.get(audio.get("voice_instrumental"))
+    if flipped is None:
+        return None
+    new = dict(meta)
+    new["audio"] = dict(audio)
+    new["audio"]["voice_instrumental"] = flipped
+    return new
+
+
+def _inject_outlier_styles(meta: dict, outlier_styles: list[str]) -> dict | None:
+    """Replace ``meta['styles']`` with ``outlier_styles`` (a copy).
+
+    Returns ``None`` if the input has no styles, or if outliers are empty.
+    Replacement (not append) mirrors the Alex G case from whitepaper §6.3
+    where the entire top-styles list was unrepresentative.
+    """
+    if not meta.get("styles") or not outlier_styles:
+        return None
+    new = dict(meta)
+    new["styles"] = list(outlier_styles)
+    return new
+
+
+def _swap_genre(meta: dict, new_genre: str) -> dict | None:
+    """Return a copy of ``meta`` with ``genre`` replaced.
+
+    Returns ``None`` if the meta has no genre or the new value matches the
+    existing one.
+    """
+    if "genre" not in meta:
+        return None
+    if meta["genre"] == new_genre:
+        return None
+    new = dict(meta)
+    new["genre"] = new_genre
+    return new
+
+
+def _pick_outlier_styles_for(
+    pool: dict[str, list[list[str]]],
+    target_genre: str | None,
+    rng: random.Random,
+) -> list[str]:
+    """Pick a random style-list from artists whose genre is NOT ``target_genre``.
+
+    ``pool`` maps genre -> list of style-lists (one per artist). Returns the
+    empty list when no candidates exist.
+    """
+    candidates: list[list[str]] = []
+    for genre, style_lists in pool.items():
+        if genre == target_genre:
+            continue
+        candidates.extend(style_lists)
+    if not candidates:
+        return []
+    return list(rng.choice(candidates))
+
+
+def _pick_corruption(
+    source_meta: dict,
+    target_meta: dict,
+    outlier_pool: dict[str, list[list[str]]],
+    rng: random.Random,
+    *,
+    genre_pool: list[str],
+) -> tuple[dict, dict, str, str] | None:
+    """Choose one (side, strategy) and apply it.
+
+    Returns ``(new_source, new_target, side, strategy)`` or ``None`` if no
+    feasible (side, strategy) exists. Strategies considered:
+
+      - ``voice_instrumental``: requires ``audio.voice_instrumental`` on the
+        chosen side.
+      - ``outlier_styles``: requires the chosen side to have non-empty
+        ``styles`` AND for ``outlier_pool`` to have a non-empty entry under a
+        genre different from the side's.
+      - ``genre_swap``: requires the chosen side to have ``genre`` AND for
+        ``genre_pool`` to contain a different genre.
+
+    Picks uniformly across feasible (side, strategy) combos so each row's
+    corruption is interpretable in isolation.
+    """
+    sides = (("source", source_meta), ("target", target_meta))
+    feasible: list[tuple[str, str]] = []
+    for side, meta in sides:
+        audio = meta.get("audio")
+        if isinstance(audio, dict) and audio.get("voice_instrumental") in _VI_FLIP:
+            feasible.append((side, "voice_instrumental"))
+        if meta.get("styles"):
+            if any(outlier_pool[g] for g in outlier_pool if g != meta.get("genre")):
+                feasible.append((side, "outlier_styles"))
+        if meta.get("genre"):
+            if any(g != meta["genre"] for g in genre_pool):
+                feasible.append((side, "genre_swap"))
+
+    if not feasible:
+        return None
+
+    side, strategy = rng.choice(feasible)
+    target_for_side = source_meta if side == "source" else target_meta
+
+    if strategy == "voice_instrumental":
+        corrupted = _swap_voice_instrumental(target_for_side)
+    elif strategy == "outlier_styles":
+        outliers = _pick_outlier_styles_for(outlier_pool, target_for_side.get("genre"), rng)
+        corrupted = _inject_outlier_styles(target_for_side, outliers)
+    elif strategy == "genre_swap":
+        other_genres = [g for g in genre_pool if g != target_for_side["genre"]]
+        corrupted = _swap_genre(target_for_side, rng.choice(other_genres))
+    else:
+        raise AssertionError(f"unknown strategy: {strategy}")
+
+    if corrupted is None:
+        return None
+
+    if side == "source":
+        return corrupted, target_meta, side, strategy
+    return source_meta, corrupted, side, strategy
+
+
+# ---------------------------------------------------------------------------
+# DB helpers
+# ---------------------------------------------------------------------------
+
+
 def _open_ro_db(path: str) -> sqlite3.Connection:
     conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
     conn.row_factory = sqlite3.Row
@@ -59,8 +246,8 @@ def _open_ro_db(path: str) -> sqlite3.Connection:
 def _load_eligible_pairs(narratives_path: Path) -> list[dict]:
     """Return only generative narrative rows (skip canned insufficient_signal placeholders).
 
-    Insufficient-signal rows can't meaningfully be data-shuffled — the canned
-    text doesn't make claims about the music, just acknowledges low signal.
+    Insufficient-signal rows can't meaningfully be corrupted — the canned text
+    doesn't make claims about the music, just acknowledges low signal.
     """
     out: list[dict] = []
     with narratives_path.open() as fh:
@@ -77,13 +264,14 @@ def _load_eligible_pairs(narratives_path: Path) -> list[dict]:
     return out
 
 
-def _build_user_message(source_name: str, target_name: str, source_meta: dict, target_meta: dict) -> str:
+def _build_user_message(
+    source_name: str, target_name: str, source_meta: dict, target_meta: dict
+) -> str:
     """Construct the user-message JSON the model sees.
 
-    Identical shape to ``narrative._build_prompt`` but no relationships /
-    facets / shared_neighbors fields — those would carry leakage from the real
-    pair, defeating the shuffle. The minimal shape is enough to elicit a
-    descriptive narrative the model will ground in the (mismatched) metadata.
+    Identical minimal shape to the data_shuffle path (no relationships /
+    facets / shared_neighbors) so the model has nothing to ground in except
+    per-artist metadata — exactly what we want to test against.
     """
     source_view = dict(source_meta)
     source_view["name"] = source_name
@@ -93,30 +281,56 @@ def _build_user_message(source_name: str, target_name: str, source_meta: dict, t
     return json.dumps(payload, separators=(",", ":"))
 
 
-def main(argv: list[str] | None = None) -> int:
-    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    ap.add_argument("--db-path", default="data/wxyc_artist_graph.db")
-    ap.add_argument("--narratives", required=True)
-    ap.add_argument("--out", required=True)
-    ap.add_argument("--n", type=int, default=30, help="Number of shuffled narratives to generate")
-    ap.add_argument("--seed", type=int, default=7)
-    ap.add_argument("--sleep", type=float, default=0.0)
-    args = ap.parse_args(argv)
+def _build_outlier_pool(db: sqlite3.Connection) -> dict[str, list[list[str]]]:
+    """Map genre -> list of per-artist style-lists, capped at 5 styles per artist.
 
-    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    Used by the outlier-style corruption strategy: pick an artist with a
+    different genre than the corruption target's, drop their styles in.
+    """
+    rows = db.execute(
+        """
+        SELECT a.id, a.genre,
+               (SELECT GROUP_CONCAT(style_tag, '||')
+                FROM (SELECT style_tag FROM artist_style
+                      WHERE artist_id = a.id
+                      ORDER BY style_tag LIMIT 5)) AS styles
+        FROM artist a
+        WHERE a.genre IS NOT NULL
+          AND EXISTS (SELECT 1 FROM artist_style s WHERE s.artist_id = a.id)
+        """
+    ).fetchall()
+    out: dict[str, list[list[str]]] = {}
+    for r in rows:
+        if not r["styles"]:
+            continue
+        styles = [s for s in r["styles"].split("||") if s]
+        if styles:
+            out.setdefault(r["genre"], []).append(styles)
+    return out
 
+
+def _build_genre_pool(db: sqlite3.Connection) -> list[str]:
+    """Distinct WXYC genre values present in the artist table."""
+    rows = db.execute(
+        "SELECT DISTINCT genre FROM artist WHERE genre IS NOT NULL AND genre != ''"
+    ).fetchall()
+    return [r["genre"] for r in rows]
+
+
+# ---------------------------------------------------------------------------
+# Mode: data_shuffle (original)
+# ---------------------------------------------------------------------------
+
+
+def run_data_shuffle(args: argparse.Namespace) -> int:
     api_key = os.environ.get("ANTHROPIC_API_KEY")
     if not api_key:
         logger.error("ANTHROPIC_API_KEY is required")
         return 1
 
-    # Lazy imports.
     import anthropic
 
-    from semantic_index.api.narrative import (
-        _SYSTEM_PROMPT,
-        _lookup_artist_metadata,
-    )
+    from semantic_index.api.narrative import _SYSTEM_PROMPT, _lookup_artist_metadata
 
     db = _open_ro_db(args.db_path)
     eligible = _load_eligible_pairs(Path(args.narratives))
@@ -126,25 +340,23 @@ def main(argv: list[str] | None = None) -> int:
     logger.info("Eligible production pairs: %d", len(eligible))
 
     rng = random.Random(args.seed)
-    # Sample names_pair (A, B) and metadata_pair (C, D) such that the
-    # underlying ARTIST IDs do not overlap. Same-id overlap would partially
-    # leak the right metadata into the shuffled prompt and weaken the gold-
-    # positive guarantee.
     pairs_for_names = rng.sample(eligible, min(args.n, len(eligible)))
 
     client = anthropic.Anthropic(api_key=api_key)
     out_path = Path(args.out)
     out_path.parent.mkdir(parents=True, exist_ok=True)
+    open_mode = "a" if args.append else "w"
 
     written = 0
-    with out_path.open("w") as fh:
+    with out_path.open(open_mode) as fh:
         for i, name_row in enumerate(pairs_for_names, 1):
-            # Find a metadata-source pair with no id overlap.
             tries = 0
             meta_row = None
             while tries < 50:
                 cand = rng.choice(eligible)
-                if cand["source_id"] not in (name_row["source_id"], name_row["target_id"]) and cand["target_id"] not in (name_row["source_id"], name_row["target_id"]):
+                if cand["source_id"] not in (name_row["source_id"], name_row["target_id"]) and cand[
+                    "target_id"
+                ] not in (name_row["source_id"], name_row["target_id"]):
                     meta_row = cand
                     break
                 tries += 1
@@ -167,8 +379,10 @@ def main(argv: list[str] | None = None) -> int:
                 meta_row["target_plays"],
             )
             user_message = _build_user_message(
-                name_row["source_name"], name_row["target_name"],
-                source_meta, target_meta,
+                name_row["source_name"],
+                name_row["target_name"],
+                source_meta,
+                target_meta,
             )
 
             t0 = time.time()
@@ -180,16 +394,16 @@ def main(argv: list[str] | None = None) -> int:
                     messages=[{"role": "user", "content": user_message}],
                 )
                 narrative = response.content[0].text
-            except Exception as exc:  # noqa: BLE001 -- exit cleanly on API failure
-                logger.exception("Anthropic call failed for %s / %s", name_row["source_name"], name_row["target_name"])
+            except Exception:  # noqa: BLE001
+                logger.exception(
+                    "Anthropic call failed for %s / %s",
+                    name_row["source_name"],
+                    name_row["target_name"],
+                )
                 continue
             elapsed_ms = int((time.time() - t0) * 1000)
 
             row = {
-                # Keep the SAME shape as eval_narratives.jsonl so export_labeling
-                # treats both pools identically. source_id/target_id point to the
-                # NAMED artists, so the labeler sees the named artists' REAL
-                # metadata when reading the row.
                 "cell_id": "WRONG-DATA-SHUFFLE",
                 "fame": name_row["fame"],
                 "richness": name_row["richness"],
@@ -206,7 +420,7 @@ def main(argv: list[str] | None = None) -> int:
                 "narrative": narrative,
                 "cached": False,
                 "insufficient_signal": False,
-                "token_match_score": 0.0,  # not computed for these
+                "token_match_score": 0.0,
                 "low_grounding": False,
                 "http_status": 200,
                 "latency_ms": elapsed_ms,
@@ -217,19 +431,19 @@ def main(argv: list[str] | None = None) -> int:
                     "source_name": meta_row["source_name"],
                     "target_name": meta_row["target_name"],
                 },
-                "expected_label": {
-                    "severity": "severe",
-                    "failure_mode": "subject_hallucination",
-                },
+                "expected_label": {"severity": "severe", "failure_mode": "subject_hallucination"},
             }
             fh.write(json.dumps(row, separators=(",", ":")) + "\n")
             fh.flush()
             written += 1
             logger.info(
                 "%d/%d: named=%s/%s metadata=%s/%s elapsed=%dms",
-                i, len(pairs_for_names),
-                name_row["source_name"], name_row["target_name"],
-                meta_row["source_name"], meta_row["target_name"],
+                i,
+                len(pairs_for_names),
+                name_row["source_name"],
+                name_row["target_name"],
+                meta_row["source_name"],
+                meta_row["target_name"],
                 elapsed_ms,
             )
 
@@ -238,6 +452,219 @@ def main(argv: list[str] | None = None) -> int:
 
     logger.info("Wrote %d data-shuffle rows -> %s", written, out_path)
     return 0
+
+
+# ---------------------------------------------------------------------------
+# Mode: field_corruption (new)
+# ---------------------------------------------------------------------------
+
+
+def run_field_corruption(args: argparse.Namespace) -> int:
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    if not api_key:
+        logger.error("ANTHROPIC_API_KEY is required")
+        return 1
+
+    import anthropic
+
+    from semantic_index.api.narrative import _SYSTEM_PROMPT, _lookup_artist_metadata
+
+    db = _open_ro_db(args.db_path)
+    eligible = _load_eligible_pairs(Path(args.narratives))
+    if not eligible:
+        logger.error("No eligible narratives in %s", args.narratives)
+        return 1
+    logger.info("Eligible production pairs: %d", len(eligible))
+
+    outlier_pool = _build_outlier_pool(db)
+    genre_pool = _build_genre_pool(db)
+    logger.info(
+        "Outlier-style pool: %d genres, %d total style-lists",
+        len(outlier_pool),
+        sum(len(v) for v in outlier_pool.values()),
+    )
+    logger.info("Genre-swap pool: %d genres", len(genre_pool))
+
+    rng = random.Random(args.seed)
+    # Oversample to absorb refusals + infeasible pairs.
+    candidate_pairs = rng.sample(eligible, min(args.n * 2, len(eligible)))
+
+    client = anthropic.Anthropic(api_key=api_key)
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    open_mode = "a" if args.append else "w"
+
+    written = 0
+    refused = 0
+    infeasible = 0
+    with out_path.open(open_mode) as fh:
+        for i, row_in in enumerate(candidate_pairs, 1):
+            if written >= args.n:
+                break
+
+            source_meta = _lookup_artist_metadata(
+                db,
+                row_in["source_id"],
+                row_in["source_name"],
+                row_in["source_genre"],
+                row_in["source_plays"],
+            )
+            target_meta = _lookup_artist_metadata(
+                db,
+                row_in["target_id"],
+                row_in["target_name"],
+                row_in["target_genre"],
+                row_in["target_plays"],
+            )
+
+            picked = _pick_corruption(
+                source_meta, target_meta, outlier_pool, rng, genre_pool=genre_pool
+            )
+            if picked is None:
+                infeasible += 1
+                continue
+            new_source, new_target, side, strategy = picked
+
+            # Capture before/after for the corrupted side so a labeler /
+            # auditor can read the row without re-running the corruption.
+            side_meta_before = source_meta if side == "source" else target_meta
+            side_meta_after = new_source if side == "source" else new_target
+            corruption_field = {
+                "voice_instrumental": "audio.voice_instrumental",
+                "outlier_styles": "styles",
+                "genre_swap": "genre",
+            }[strategy]
+            if strategy == "voice_instrumental":
+                original_value = side_meta_before["audio"]["voice_instrumental"]
+                corrupted_value = side_meta_after["audio"]["voice_instrumental"]
+            elif strategy == "outlier_styles":
+                original_value = side_meta_before["styles"]
+                corrupted_value = side_meta_after["styles"]
+            else:
+                original_value = side_meta_before["genre"]
+                corrupted_value = side_meta_after["genre"]
+
+            user_message = _build_user_message(
+                row_in["source_name"],
+                row_in["target_name"],
+                new_source,
+                new_target,
+            )
+
+            t0 = time.time()
+            try:
+                response = client.messages.create(
+                    model="claude-haiku-4-5-20251001",
+                    max_tokens=150,
+                    system=_SYSTEM_PROMPT,
+                    messages=[{"role": "user", "content": user_message}],
+                )
+                narrative = response.content[0].text
+            except Exception:  # noqa: BLE001
+                logger.exception(
+                    "Anthropic call failed for %s / %s",
+                    row_in["source_name"],
+                    row_in["target_name"],
+                )
+                continue
+            elapsed_ms = int((time.time() - t0) * 1000)
+
+            if _is_refusal(narrative):
+                refused += 1
+                logger.info(
+                    "%d: REFUSAL (strategy=%s side=%s) %s/%s — dropping",
+                    i,
+                    strategy,
+                    side,
+                    row_in["source_name"],
+                    row_in["target_name"],
+                )
+                continue
+
+            row_out = {
+                "cell_id": "WRONG-FIELD-CORRUPTION",
+                "fame": row_in["fame"],
+                "richness": row_in["richness"],
+                "genre": row_in["genre"],
+                "edge": row_in["edge"],
+                "source_id": row_in["source_id"],
+                "target_id": row_in["target_id"],
+                "source_name": row_in["source_name"],
+                "target_name": row_in["target_name"],
+                "source_genre": row_in["source_genre"],
+                "target_genre": row_in["target_genre"],
+                "source_plays": row_in["source_plays"],
+                "target_plays": row_in["target_plays"],
+                "narrative": narrative,
+                "cached": False,
+                "insufficient_signal": False,
+                "token_match_score": 0.0,
+                "low_grounding": False,
+                "http_status": 200,
+                "latency_ms": elapsed_ms,
+                "construction_method": "field_corruption",
+                "corruption": {
+                    "side": side,
+                    "strategy": strategy,
+                    "field": corruption_field,
+                    "original": original_value,
+                    "corrupted": corrupted_value,
+                },
+                "expected_label": {"severity": "severe", "failure_mode": "data_noise"},
+            }
+            fh.write(json.dumps(row_out, separators=(",", ":")) + "\n")
+            fh.flush()
+            written += 1
+            logger.info(
+                "%d/%d: %s/%s side=%s strategy=%s elapsed=%dms",
+                written,
+                args.n,
+                row_in["source_name"],
+                row_in["target_name"],
+                side,
+                strategy,
+                elapsed_ms,
+            )
+
+            if args.sleep > 0 and written < args.n:
+                time.sleep(args.sleep)
+
+    logger.info(
+        "Wrote %d field-corruption rows -> %s (refused=%d, infeasible=%d)",
+        written,
+        out_path,
+        refused,
+        infeasible,
+    )
+    if written < args.n:
+        logger.warning("Target was %d but only %d rows passed the refusal filter", args.n, written)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("--db-path", default="data/wxyc_artist_graph.db")
+    ap.add_argument("--narratives", required=True)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--mode", choices=("data_shuffle", "field_corruption"), default="data_shuffle")
+    ap.add_argument("--n", type=int, default=30, help="Number of wrong narratives to generate")
+    ap.add_argument("--seed", type=int, default=7)
+    ap.add_argument("--sleep", type=float, default=0.0)
+    ap.add_argument(
+        "--append",
+        action="store_true",
+        help="Append to --out rather than truncate. Use when adding field_corruption "
+        "rows to an existing eval_wrong.jsonl that already holds data_shuffle rows.",
+    )
+    args = ap.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+    if args.mode == "data_shuffle":
+        return run_data_shuffle(args)
+    return run_field_corruption(args)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_eval_backscore_metrics.py
+++ b/tests/unit/test_eval_backscore_metrics.py
@@ -1,0 +1,152 @@
+"""Test that ``backscore metrics`` reports per-construction_method recall.
+
+This is the load-bearing visibility for #277 — the headline finding is that
+grounding-fidelity scorers have *lower* recall on field_corruption rows than
+on data_shuffle rows, and that comparison can only happen if the breakdown
+exists in the output.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.eval.backscore import main as backscore_main
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> None:
+    path.write_text("".join(json.dumps(r) + "\n" for r in rows))
+
+
+def test_metrics_reports_per_construction_method_recall(tmp_path, capsys):
+    scored_path = tmp_path / "scored.jsonl"
+    labeled_path = tmp_path / "labeled.jsonl"
+
+    # Mixed pool: 2 data_shuffle (one above threshold, one below),
+    # 2 field_corruption (both below threshold — the canonical data_noise
+    # gap), 1 production (above threshold).
+    _write_jsonl(
+        scored_path,
+        [
+            {
+                "row_id": "R0001",
+                "construction_method": "data_shuffle",
+                "scores": {"token_match_v1": 0.8, "claim_ratio_v1": 0.6},
+            },
+            {
+                "row_id": "R0002",
+                "construction_method": "data_shuffle",
+                "scores": {"token_match_v1": 0.1, "claim_ratio_v1": 0.1},
+            },
+            {
+                "row_id": "R0003",
+                "construction_method": "field_corruption",
+                "scores": {"token_match_v1": 0.1, "claim_ratio_v1": 0.1},
+            },
+            {
+                "row_id": "R0004",
+                "construction_method": "field_corruption",
+                "scores": {"token_match_v1": 0.2, "claim_ratio_v1": 0.2},
+            },
+            {
+                "row_id": "R0005",
+                "construction_method": "production",
+                "scores": {"token_match_v1": 0.9, "claim_ratio_v1": 0.7},
+            },
+        ],
+    )
+    _write_jsonl(
+        labeled_path,
+        [
+            {
+                "row_id": "R0001",
+                "label": {"severity": "severe", "failure_mode": "subject_hallucination"},
+            },
+            {
+                "row_id": "R0002",
+                "label": {"severity": "severe", "failure_mode": "subject_hallucination"},
+            },
+            {"row_id": "R0003", "label": {"severity": "severe", "failure_mode": "data_noise"}},
+            {"row_id": "R0004", "label": {"severity": "severe", "failure_mode": "data_noise"}},
+            {
+                "row_id": "R0005",
+                "label": {"severity": "severe", "failure_mode": "subject_hallucination"},
+            },
+        ],
+    )
+
+    rc = backscore_main(
+        [
+            "metrics",
+            "--scored",
+            str(scored_path),
+            "--labeled",
+            str(labeled_path),
+            "--threshold",
+            "0.5",
+        ]
+    )
+    assert rc == 0
+    captured = capsys.readouterr().out
+
+    # The new breakdown is visible.
+    assert "recall by construction_method:" in captured
+    assert "data_shuffle" in captured
+    assert "field_corruption" in captured
+    assert "production" in captured
+
+    # Spot-check the numbers: for token_match_v1 at threshold 0.5:
+    #   data_shuffle:    1/2 = 0.500
+    #   field_corruption: 0/2 = 0.000  (the load-bearing finding)
+    #   production:      1/1 = 1.000
+    assert "data_shuffle" in captured
+    # Look for the specific recall pattern.
+    assert "field_corruption" in captured
+    # The data_noise gap manifests as a 0.000 recall on field_corruption.
+    lines = captured.splitlines()
+    fc_lines = [line for line in lines if "field_corruption" in line]
+    assert any("0.000" in line for line in fc_lines), (
+        f"field_corruption recall should be 0.000; saw: {fc_lines}"
+    )
+
+
+def test_metrics_works_without_field_corruption_rows(tmp_path, capsys):
+    """Existing behavior — production-only labeled set — should still work."""
+    scored_path = tmp_path / "scored.jsonl"
+    labeled_path = tmp_path / "labeled.jsonl"
+    _write_jsonl(
+        scored_path,
+        [
+            {
+                "row_id": "R0001",
+                "construction_method": "production",
+                "scores": {"token_match_v1": 0.8, "claim_ratio_v1": 0.4},
+            },
+        ],
+    )
+    _write_jsonl(
+        labeled_path,
+        [
+            {
+                "row_id": "R0001",
+                "label": {"severity": "severe", "failure_mode": "subject_hallucination"},
+            },
+        ],
+    )
+
+    rc = backscore_main(
+        [
+            "metrics",
+            "--scored",
+            str(scored_path),
+            "--labeled",
+            str(labeled_path),
+            "--threshold",
+            "0.5",
+        ]
+    )
+    assert rc == 0
+    captured = capsys.readouterr().out
+    # Still emits the construction_method section (with just 'production').
+    assert "recall by construction_method:" in captured
+    assert "production" in captured

--- a/tests/unit/test_eval_field_corruption.py
+++ b/tests/unit/test_eval_field_corruption.py
@@ -1,0 +1,255 @@
+"""Tests for the field-corruption helpers in ``scripts/eval/build_wrong_set.py``.
+
+These are pure functions that take a metadata dict (the shape ``_lookup_artist_metadata``
+emits) and return a copy with one field deliberately corrupted. The orchestrator wraps
+them in a per-pair strategy picker; here we cover the building blocks.
+"""
+
+from __future__ import annotations
+
+import random
+
+import pytest
+
+from scripts.eval.build_wrong_set import (
+    _inject_outlier_styles,
+    _is_refusal,
+    _pick_corruption,
+    _pick_outlier_styles_for,
+    _swap_genre,
+    _swap_voice_instrumental,
+)
+
+# ---------------------------------------------------------------------------
+# _swap_voice_instrumental
+# ---------------------------------------------------------------------------
+
+
+def test_swap_voice_instrumental_flips_instrumental_to_vocal():
+    meta = {
+        "name": "Stereolab",
+        "audio": {"voice_instrumental": "instrumental", "recording_count": 12},
+    }
+    out = _swap_voice_instrumental(meta)
+    assert out is not None
+    assert out["audio"]["voice_instrumental"] == "vocal-forward"
+    assert out["audio"]["recording_count"] == 12
+    # Input untouched (no in-place mutation).
+    assert meta["audio"]["voice_instrumental"] == "instrumental"
+
+
+def test_swap_voice_instrumental_flips_vocal_to_instrumental():
+    meta = {"name": "X", "audio": {"voice_instrumental": "vocal-forward"}}
+    out = _swap_voice_instrumental(meta)
+    assert out is not None
+    assert out["audio"]["voice_instrumental"] == "instrumental"
+
+
+def test_swap_voice_instrumental_returns_none_without_audio():
+    assert _swap_voice_instrumental({"name": "X"}) is None
+
+
+def test_swap_voice_instrumental_returns_none_without_field():
+    assert _swap_voice_instrumental({"name": "X", "audio": {"recording_count": 5}}) is None
+
+
+def test_swap_voice_instrumental_returns_none_for_unknown_value():
+    # Production qualitative descriptors only emit the two extremes; anything else
+    # would be a schema drift we don't want to silently corrupt.
+    meta = {"name": "X", "audio": {"voice_instrumental": "ambiguous"}}
+    assert _swap_voice_instrumental(meta) is None
+
+
+# ---------------------------------------------------------------------------
+# _inject_outlier_styles
+# ---------------------------------------------------------------------------
+
+
+def test_inject_outlier_styles_replaces_existing_styles():
+    meta = {"name": "X", "styles": ["Indie Rock", "Post-Rock"]}
+    out = _inject_outlier_styles(meta, ["Dance-pop", "Euro House", "Makina"])
+    assert out is not None
+    assert out["styles"] == ["Dance-pop", "Euro House", "Makina"]
+    # Input untouched.
+    assert meta["styles"] == ["Indie Rock", "Post-Rock"]
+
+
+def test_inject_outlier_styles_returns_none_when_meta_has_no_styles():
+    assert _inject_outlier_styles({"name": "X"}, ["Trance"]) is None
+
+
+def test_inject_outlier_styles_returns_none_when_outliers_empty():
+    assert _inject_outlier_styles({"name": "X", "styles": ["Rock"]}, []) is None
+
+
+# ---------------------------------------------------------------------------
+# _swap_genre
+# ---------------------------------------------------------------------------
+
+
+def test_swap_genre_replaces():
+    meta = {"name": "X", "genre": "Rock"}
+    out = _swap_genre(meta, "Electronic")
+    assert out is not None
+    assert out["genre"] == "Electronic"
+    assert meta["genre"] == "Rock"
+
+
+def test_swap_genre_returns_none_when_missing():
+    assert _swap_genre({"name": "X"}, "Rock") is None
+
+
+def test_swap_genre_returns_none_when_same():
+    assert _swap_genre({"name": "X", "genre": "Rock"}, "Rock") is None
+
+
+# ---------------------------------------------------------------------------
+# _pick_outlier_styles_for
+# ---------------------------------------------------------------------------
+
+
+def test_pick_outlier_styles_excludes_target_genre():
+    pool = {
+        "Rock": [["Indie Rock"], ["Post-Rock"]],
+        "Electronic": [["Trance", "House"], ["Techno"]],
+        "Jazz": [["Bebop"]],
+    }
+    rng = random.Random(0)
+    # Run many times — should never pick a Rock style-list.
+    for _ in range(50):
+        picked = _pick_outlier_styles_for(pool, "Rock", rng)
+        assert picked  # non-empty
+        # The Rock entries are the only ones containing "Indie Rock" or "Post-Rock".
+        assert "Indie Rock" not in picked
+        assert "Post-Rock" not in picked
+
+
+def test_pick_outlier_styles_returns_empty_when_pool_empty():
+    rng = random.Random(0)
+    assert _pick_outlier_styles_for({}, "Rock", rng) == []
+
+
+def test_pick_outlier_styles_returns_empty_when_only_target_genre_in_pool():
+    pool = {"Rock": [["Indie Rock"]]}
+    rng = random.Random(0)
+    assert _pick_outlier_styles_for(pool, "Rock", rng) == []
+
+
+# ---------------------------------------------------------------------------
+# _pick_corruption (orchestrator)
+# ---------------------------------------------------------------------------
+
+
+def test_pick_corruption_skips_pair_with_no_corruptable_fields():
+    # Neither side has genre, styles, or audio.voice_instrumental — skip.
+    source = {"name": "X", "total_plays": 100}
+    target = {"name": "Y", "total_plays": 100}
+    outlier_pool: dict[str, list[list[str]]] = {"Rock": [["Indie Rock"]]}
+    rng = random.Random(0)
+    result = _pick_corruption(source, target, outlier_pool, rng, genre_pool=["Electronic"])
+    assert result is None
+
+
+def test_pick_corruption_returns_strategy_and_modified_meta():
+    source = {
+        "name": "X",
+        "genre": "Rock",
+        "styles": ["Indie Rock"],
+        "audio": {"voice_instrumental": "vocal-forward"},
+    }
+    target = {"name": "Y", "genre": "Jazz"}
+    outlier_pool = {"Electronic": [["Trance", "Tech House"]]}
+    rng = random.Random(7)
+    result = _pick_corruption(source, target, outlier_pool, rng, genre_pool=["Electronic", "Jazz"])
+    assert result is not None
+    new_source, new_target, side, strategy = result
+    assert side in ("source", "target")
+    assert strategy in ("voice_instrumental", "outlier_styles", "genre_swap")
+    # Whichever side was corrupted, the other should equal the input.
+    if side == "source":
+        assert new_target == target
+        assert new_source != source
+    else:
+        assert new_source == source
+        assert new_target != target
+
+
+def test_pick_corruption_voice_instrumental_only_feasible_when_audio_present():
+    # Force the rng to a known seed; if voice_instrumental is the picked strategy,
+    # it should only apply to a side that has it.
+    source = {"name": "X", "audio": {"voice_instrumental": "instrumental"}}
+    target = {"name": "Y"}  # no audio
+    outlier_pool: dict[str, list[list[str]]] = {}
+    rng = random.Random(42)
+    # The only feasible (side, strategy) here is (source, voice_instrumental) since
+    # target has no genre/styles/audio.
+    result = _pick_corruption(source, target, outlier_pool, rng, genre_pool=[])
+    assert result is not None
+    new_source, new_target, side, strategy = result
+    assert side == "source"
+    assert strategy == "voice_instrumental"
+    assert new_source["audio"]["voice_instrumental"] == "vocal-forward"
+
+
+# ---------------------------------------------------------------------------
+# _is_refusal
+# ---------------------------------------------------------------------------
+
+
+def test_is_refusal_short_narrative():
+    assert _is_refusal("Too short.") is True
+    # ~30 words is the minimum bar.
+    short = " ".join(["word"] * 10)
+    assert _is_refusal(short) is True
+
+
+def test_is_refusal_recognizes_refusal_phrases():
+    long_enough = " ".join(["word"] * 50)
+    assert (
+        _is_refusal(f"I am unable to characterize this connection meaningfully. {long_enough}")
+        is True
+    )
+    assert _is_refusal(f"I cannot write a narrative from this data. {long_enough}") is True
+    assert _is_refusal(f"The input data lacks sufficient signal. {long_enough}") is True
+
+
+def test_is_refusal_empty():
+    assert _is_refusal("") is True
+    assert _is_refusal(None) is True  # type: ignore[arg-type]
+
+
+def test_is_refusal_accepts_substantive_narrative():
+    text = (
+        "WXYC DJs pair Stereolab with Yo La Tengo across 8 transitions in our flowsheets. "
+        "Both share the Indie Rock tag, and Tortoise and Lambchop appear as common "
+        "neighbors in DJs' programming, suggesting a shared late-90s post-rock lineage."
+    )
+    assert _is_refusal(text) is False
+
+
+@pytest.mark.parametrize("strategy", ["voice_instrumental", "outlier_styles", "genre_swap"])
+def test_pick_corruption_strategies_are_reachable(strategy):
+    """Every strategy must be picked at least once across many seeds when feasible."""
+    source = {
+        "name": "X",
+        "genre": "Rock",
+        "styles": ["Indie Rock"],
+        "audio": {"voice_instrumental": "instrumental"},
+    }
+    target = {
+        "name": "Y",
+        "genre": "Jazz",
+        "styles": ["Bebop"],
+        "audio": {"voice_instrumental": "vocal-forward"},
+    }
+    outlier_pool = {"Electronic": [["Trance"]]}
+    genre_pool = ["Electronic", "Jazz", "Rock"]
+    seen: set[str] = set()
+    for seed in range(200):
+        rng = random.Random(seed)
+        result = _pick_corruption(source, target, outlier_pool, rng, genre_pool=genre_pool)
+        assert result is not None
+        seen.add(result[3])
+        if strategy in seen:
+            return
+    raise AssertionError(f"Strategy {strategy} never picked across 200 seeds; seen={seen}")


### PR DESCRIPTION
## Summary

- Add `--mode field_corruption` to `scripts/eval/build_wrong_set.py`: takes a real pair's metadata and deliberately corrupts one field on one side (swap `audio.voice_instrumental`, replace `styles` with outliers from a different genre, or swap `genre`). Calls Haiku directly so the production cache stays clean; filters refusals at write time.
- Extend `scripts/eval/backscore.py metrics` to report per-`construction_method` recall in addition to per-`failure_mode` recall. Load-bearing for surfacing the data_noise gap — once labels exist, the headline finding is that `token_match_v1` / `claim_ratio_v1` have *lower* recall on `field_corruption` than on `data_shuffle`, quantifying the gap the §8 constraint ontology is designed to fill.
- Unit tests for the corruption helpers (`_swap_voice_instrumental`, `_inject_outlier_styles`, `_swap_genre`, `_pick_outlier_styles_for`, `_pick_corruption`, `_is_refusal`) and the new backscore breakdown.
- Whitepaper §6.3 / §10.1 / §10.2 / §11.3 updated: field-corruption moves from "in flight" to "shipped"; pretraining bait (#278) remains in flight.

## Generated data

Generated 40 rows against `data/wxyc_artist_graph.db` with 0 refusals and 0 infeasible pairs (seed 17):

- Strategy distribution: 27 `genre_swap`, 10 `outlier_styles`, 3 `voice_instrumental`. The skew tracks feasibility — most pairs have a genre, fewer have ≥1 styles, very few have audio.voice_instrumental.
- Side distribution: 22 target, 18 source.
- `output/eval/eval_wrong.jsonl` now holds 70 rows total (30 data_shuffle + 40 field_corruption).
- `output/eval/labeling.{csv,jsonl}` re-exported with 322 rows total (252 production + 30 data_shuffle + 40 field_corruption). No answer-revealing columns leak to the CSV.

## Spot-check (one of each strategy)

**`genre_swap`** — Peter Barclay (target genre swapped Rock → Classical). The narrative dutifully says "a Classical-genre artist tagged with Punk across 356 plays" — a labeler seeing the real metadata (Rock) flags this.

**`outlier_styles`** — Gaston (target styles `[Indie Rock, Pop Punk]` replaced with `[Acid, Balearic, Deep House, Disco, Downtempo]`). The narrative says "Gaston's eclectic electronic and dance styles" and "Balearic and downtempo sensibilities" — labeler sees real Indie Rock/Pop Punk and flags.

**`voice_instrumental`** — Hako Yamasaki (target flipped instrumental → vocal-forward). Subtler; the narrative says "singer-songwriter sensibilities" which is a soft reflection of the flipped flag. Inclusion is intentional; the eval set should cover both obvious and subtle data_noise.

## Test plan

- [x] `python -m pytest tests/unit/test_eval_field_corruption.py tests/unit/test_eval_backscore_metrics.py` — 26 tests pass
- [x] `ruff check` + `ruff format --check` — clean
- [x] Generated 40 rows successfully against production DB; verified construction_method distribution and refusal filter
- [x] Re-exported `labeling.{csv,jsonl}`; verified no answer-revealing fields leak to CSV
- [ ] Per-construction-method recall comparison runs once labels exist (gated on labeling round)

Closes #277