### PR TITLE
api(database): lower mmap to 256 MiB and cache to 16 MiB

### DIFF
--- a/semantic_index/api/database.py
+++ b/semantic_index/api/database.py
@@ -7,8 +7,8 @@ from contextlib import contextmanager
 
 from fastapi import Request
 
-_MMAP_BYTES = 1 << 30  # 1 GiB — covers the full graph database
-_CACHE_PAGES = -65536  # negative → KiB; 65536 = 64 MiB per connection
+_MMAP_BYTES = 1 << 28  # 256 MiB — hot-page coverage that fits under the cgroup cap
+_CACHE_PAGES = -16384  # negative → KiB; 16384 = 16 MiB per connection
 
 
 @contextmanager
@@ -20,11 +20,15 @@ def _open_db(db_path: str):
       lock files and lets the OS keep file pages clean.
     - ``mmap_size``: maps the database file. Mapped pages live in the OS page
       cache and survive the connection close, so subsequent requests reuse
-      pages without disk I/O. Critical on memory-constrained hosts where the
-      per-connection page cache is too small to matter.
-    - ``cache_size``: bumps the per-connection page cache from 2 MiB to 64 MiB
-      so a single request that hits multiple edge tables reuses pages instead
-      of evicting them mid-query.
+      pages without disk I/O. Sized at 256 MiB to cover the hot pages
+      (artist/edge indexes, frequent lookups) without crowding the Python
+      heap inside the 1 GiB container cap from deploy.yml — file-backed
+      mmap pages count toward the cgroup memory.max, so an oversized mmap
+      pushes the worker closer to cgroup-OOM under traffic.
+    - ``cache_size``: bumps the per-connection page cache from 2 MiB to
+      16 MiB so a single affinity request that fans across edge tables
+      reuses pages instead of evicting them mid-query, while leaving
+      headroom for several concurrent connections inside the cap.
     - ``query_only``: belt-and-suspenders — even with ``mode=ro``, this
       guarantees no accidental writes from a misbehaving query.
     """

--- a/tests/unit/test_api_database.py
+++ b/tests/unit/test_api_database.py
@@ -1,0 +1,48 @@
+"""Tests for SQLite connection PRAGMAs in the Graph API."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from semantic_index.api.database import _CACHE_PAGES, _MMAP_BYTES, _open_db
+
+
+@pytest.fixture()
+def empty_db(tmp_path: Path) -> str:
+    """Create an empty SQLite database with valid header."""
+    path = tmp_path / "empty.db"
+    conn = sqlite3.connect(str(path))
+    conn.execute("CREATE TABLE _stub (id INTEGER)")
+    conn.commit()
+    conn.close()
+    return str(path)
+
+
+def test_open_db_applies_mmap_and_cache_pragmas(empty_db: str):
+    """_open_db must apply the tuned PRAGMAs and the values must fit inside the
+    1 GiB cgroup cap from deploy.yml.
+
+    The cgroup memory.max set by `docker run --memory 1g` counts file-backed
+    mmap pages, so mmap_size + per-connection cache + Python heap must all
+    coexist in 1 GiB. Hard ceiling sanity-checked here: mmap + cache must
+    leave at least ~512 MiB for the Python heap and overhead.
+    """
+    container_cap_bytes = 1 << 30  # matches --memory 1g in deploy.yml
+    heap_reservation_bytes = 1 << 29  # 512 MiB for Python heap + OS
+
+    cache_bytes = -_CACHE_PAGES * 1024  # _CACHE_PAGES is negative KiB
+    assert _MMAP_BYTES + cache_bytes + heap_reservation_bytes <= container_cap_bytes, (
+        "mmap + cache leaves no room for the Python heap inside the 1 GiB container cap"
+    )
+
+    with _open_db(empty_db) as conn:
+        mmap = conn.execute("PRAGMA mmap_size").fetchone()[0]
+        cache = conn.execute("PRAGMA cache_size").fetchone()[0]
+        query_only = conn.execute("PRAGMA query_only").fetchone()[0]
+
+    assert mmap == _MMAP_BYTES
+    assert cache == _CACHE_PAGES
+    assert query_only == 1


### PR DESCRIPTION
## Summary

Sizes `_MMAP_BYTES` and `_CACHE_PAGES` in `semantic_index/api/database.py` for the 1 GiB cgroup cap shipped in #318. The previous values (1 GiB mmap + 64 MiB cache) were set against the 504 MiB graph DB the [May 4 commit](https://github.com/WXYC/semantic-index/commit/0a19206) assumed; the live DB is now 3.1 GiB, the container runs under `--memory 1g`, and `cgroup memory.max` counts file-backed mmap pages — so an oversized mmap pushes the worker toward cgroup-OOM under traffic instead of merely caching cold pages.

New values:
- `_MMAP_BYTES = 1 << 28` (256 MiB) — covers the hot artist + edge indexes touched every `/graph` request.
- `_CACHE_PAGES = -16384` (16 MiB per connection) — 8x the SQLite default, comfortable with several concurrent connections.

Combined budget inside the 1 GiB cap: 256 + 16 + 512 (Python heap reservation for NetworkX + Essentia models) = 784 MiB, with ~240 MiB margin.

## Test plan

Adds `tests/unit/test_api_database.py`:
- **Ceiling property assertion** that fails if any future bump pushes `mmap + cache + heap reservation` past the 1 GiB cap (this was the assertion that failed against the old values during development).
- **PRAGMA smoke test** that `_open_db` actually applies `mmap_size`, `cache_size`, and `query_only = 1` on a real `sqlite3` connection.

- [x] `pytest tests/unit/test_api_database.py tests/unit/test_api.py` (13 passed)
- [x] `ruff format --check` clean
- [x] `ruff check` clean
- [x] `mypy` clean
- [ ] Verify post-deploy: `docker exec semantic-index sqlite3 /data/wxyc_artist_graph.db "PRAGMA mmap_size"` returns `268435456`

## Context

Follow-up #1 from the [WXYC/Backend-Service#937 RCA](https://github.com/WXYC/Backend-Service/issues/937) on the 2026-05-15 / 17 / 20 host wedges. #318 capped semantic-index at 1 GiB to contain blast radius; this PR sizes the SQLite tuning constants to fit inside that cap.