### PR TITLE
deps: bump wxyc-etl to 0.5.0 (anchored is_compilation_artist)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "rapidfuzz>=3.0.0",
     "psycopg[binary]>=3.1",
     "httpx>=0.25",
-    "wxyc-etl>=0.3.0",
+    "wxyc-etl>=0.5.0",
     "wxyc-fastapi[psycopg]>=1.0.0,<2.0.0",
 ]
 
@@ -32,7 +32,7 @@ archive = [
     "essentia-tensorflow>=2.1b6",
 ]
 rust = [
-    "wxyc-etl>=0.3.0",
+    "wxyc-etl>=0.5.0",
 ]
 dev = [
     "pytest>=7.0.0",

--- a/tests/unit/test_migration_parity.py
+++ b/tests/unit/test_migration_parity.py
@@ -20,14 +20,12 @@ from wxyc_etl import schema, text
         "Various",
         "Various Artists",
         "various artists",
-        "  Various Artists  ",
     ],
     ids=[
         "V/A",
         "Various",
         "Various_Artists",
         "various_artists_lowercase",
-        "various_artists_padded",
     ],
 )
 def test_is_compilation_artist_covers_old_is_various_artists(name):
@@ -41,14 +39,12 @@ def test_is_compilation_artist_covers_old_is_various_artists(name):
     [
         "Soundtrack",
         "Compilation",
-        "Original Motion Picture Soundtrack",
         "v.a.",
         "VARIOUS",
     ],
     ids=[
         "Soundtrack",
         "Compilation",
-        "Motion_Picture_Soundtrack",
         "v.a.",
         "VARIOUS_caps",
     ],
@@ -62,15 +58,24 @@ def test_is_compilation_artist_additional_coverage(name):
 @pytest.mark.parametrize(
     "name",
     [
+        # Real artists — never flagged.
         "Autechre",
         "Stereolab",
         "Cat Power",
         "Father John Misty",
         "",
+        # Tightened semantics in wxyc-etl 0.5.0 (anchored leading-prefix + exact-only):
+        # the legacy substring matcher returned True for these; the new matcher
+        # returns False. "soundtrack" / "various" / "compilation" are exact-only;
+        # padded forms no longer satisfy the leading anchor at position 0.
+        "  Various Artists  ",
+        "Original Motion Picture Soundtrack",
+        "A Compilation Album",
+        "Various Production",
     ],
 )
 def test_is_compilation_artist_false_for_real_artists(name):
-    """Real artist names should not be flagged as compilation artists."""
+    """Real artist names and tightened non-matches should not be flagged."""
     assert text.is_compilation_artist(name) is False
 
 


### PR DESCRIPTION
## Summary

- Bumps `wxyc-etl` from `>=0.3.0` to `>=0.5.0` in both top-level dependencies and the `rust` extras of `pyproject.toml`.
- Updates `tests/unit/test_migration_parity.py` for the tightened `is_compilation_artist` semantics in wxyc-etl 0.5.0 (anchored leading-prefix + exact-only).
- Documents the new false-cases in the parity test with an inline comment so future readers don't try to "fix" them back to True.

## Behavior change (upstream)

`is_compilation_artist` no longer does a substring scan. Effective semantics:

- **Leading prefixes** (anchored — must start at position 0 followed by a non-alphanumeric boundary): `various artists`, `v/a`, `v.a`, `soundtracks`
- **Exact-only** (case-insensitive equality): `various`, `soundtrack`, `compilation`

Upstream PR: WXYC/wxyc-etl#130.

## Affected call sites in semantic-index

`is_compilation_artist` is invoked from:

- `semantic_index/graph_metrics.py` — filters compilation rows when computing graph centrality.
- `semantic_index/archive_match.py` — short-circuits compilation strings in the archive name matcher.
- `semantic_index/artist_resolver.py` — gates the CTA / Discogs track-artist tiers for compilation releases.

Each consumes real-world VA strings (`"Various Artists"`, `"V/A"`, `"Soundtracks - <letter>"`, etc.) that still match under the new anchored rule. No production logic needed to change.

## Test changes

`tests/unit/test_migration_parity.py`:

- Drops the padded `"  Various Artists  "` row from the positive-coverage parametrize (the anchored leading-prefix rule now rejects leading whitespace).
- Drops the `"Original Motion Picture Soundtrack"` row from the additional-coverage parametrize (`"soundtrack"` is exact-only; embedded suffix no longer matches).
- Adds those two strings — plus `"A Compilation Album"` and `"Various Production"` — to the negative-coverage parametrize so we have an active pin against any future regression toward the substring matcher.

Full preflight (`ruff check`, `ruff format --check`, `mypy semantic_index/`, `pytest tests/`) is green: 1026 passed, 13 deselected.

## Test plan

- [x] `ruff check .`
- [x] `ruff format --check .`
- [x] `mypy semantic_index/`
- [x] `pytest tests/` (1026 passed)
- [ ] CI green

Closes #325