### PR TITLE
Fix affinity endpoint cold-cache stall: prune enrichment edges + cap per-source SQL

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,8 @@ SQLite ──→ api (FastAPI + aiosqlite) ──→ JSON responses
 | `semantic_index/wikidata_influence.py` | Extract directed Wikidata P737 influence edges between reconciled artists. Resolves QIDs to canonical names via the pipeline database. |
 | `semantic_index/label_hierarchy.py` | Populate label and label_hierarchy tables from Wikidata P749/P355 relationships via Discogs label ID (P1902) lookups. |
 | `semantic_index/discogs_enrichment.py` | Aggregate Discogs metadata (styles, personnel, labels, compilations) per artist. |
-| `semantic_index/discogs_edges.py` | Compute Discogs-derived edges: shared personnel, shared style (Jaccard), label family, compilation co-appearance. |
+| `semantic_index/discogs_edges.py` | Compute Discogs-derived edges: shared personnel, shared style (Jaccard), label family, compilation co-appearance. Per-artist top-K prune for shared_personnel and label_family delegates to `edge_prune`. |
+| `semantic_index/edge_prune.py` | Shared top-K-per-artist prune for symmetric `(artist_a_id, artist_b_id)` edge tables. Backs `prune_acoustic_similarity` (in `acousticbrainz.py`), `prune_shared_personnel`, and `prune_label_family` (in `discogs_edges.py`). |
 | `semantic_index/acousticbrainz.py` | Load AcousticBrainz high-level features, aggregate per-artist audio profiles (59-dim feature vector across 18 classifiers), compute cosine similarity edges. Supports both PG and tar-based loading. |
 | `semantic_index/acousticbrainz_client.py` | PostgreSQL client for AcousticBrainz features. Queries `ab_recording` in musicbrainz-cache, joining with `mb_artist_recording` for per-artist feature retrieval. Preferred over tar-based loading. |
 | `semantic_index/musicbrainz_client.py` | MusicBrainz cache client: recording MBID resolution via `mb_artist_recording` materialized view. Identity resolution methods (lookup_by_name, batch_lookup) have been moved to LML. |
@@ -477,6 +478,7 @@ The SQLite database and sidecar caches live in the bind-mounted `/data` director
 - `SYNC_HOUR_UTC` — hour (UTC) to run the daily sync (default: `9`, i.e. 5:00 AM ET)
 - `DATABASE_URL_BACKEND` — Backend-Service PostgreSQL DSN for nightly sync (required when `SYNC_ENABLED=true`; uses the RDS private endpoint since EC2 and RDS share a VPC)
 - `SYNC_MIN_COUNT` — minimum co-occurrence count for DJ transition edges (default: `2`)
+- `ENRICHMENT_TOP_K` — per-artist neighbor cap applied to `shared_personnel` and `label_family` on every nightly sync (default: `50`, `0` disables). Without it both tables grow into the 10M+ row range and stall the affinity composite-edge endpoint on cold cache.
 
 **Cross-cache-identity feature flags.** Per-cache toggles for which `wxyc_library` hook table the resolver reads (legacy schema vs. new normalized schema). All default `false`. The **canonical inventory** (with naming-convention rationale and approval gates) lives in `WXYC/Backend-Service/CLAUDE.md` "Cross-cache-identity feature flags (canonical inventory)". When a flag is renamed or its default changes, both the canonical Backend section AND this list must update in the same PR; CI on this repo grep-asserts the names listed here match the §4.2 inventory.
 
@@ -512,8 +514,9 @@ The API service includes a built-in sync scheduler that runs `nightly_sync()` as
 - `SYNC_HOUR_UTC=9` — hour to run daily sync (default: 9 = 5:00 AM ET)
 - `DATABASE_URL_BACKEND=postgresql://...` — Backend-Service PG DSN (required when sync enabled)
 - `SYNC_MIN_COUNT=2` — minimum co-occurrence count for DJ transition edges
+- `ENRICHMENT_TOP_K=50` — per-artist neighbor cap for `shared_personnel` and `label_family` applied as Step 7c of every sync; 0 disables.
 
-The scheduler sleeps until the configured hour, runs the full pipeline (PG → resolve → PMI → export → entity dedup → facets → graph metrics), atomically swaps the database, then sleeps until the next day. The API continues serving requests during the rebuild. Runtime is ~5 minutes.
+The scheduler sleeps until the configured hour, runs the full pipeline (PG → resolve → PMI → export → entity dedup → enrichment-edge prune → facets → graph metrics), atomically swaps the database, then sleeps until the next day. The API continues serving requests during the rebuild. Runtime is ~5 minutes.
 
 The sync can also be run manually via CLI: `python scripts/nightly_sync.py --dsn postgresql://... --verbose`
 

--- a/semantic_index/acousticbrainz.py
+++ b/semantic_index/acousticbrainz.py
@@ -903,91 +903,18 @@ def prune_acoustic_similarity(
 ) -> tuple[int, int]:
     """Prune ``acoustic_similarity`` to top-K most-similar edges per artist.
 
-    For each artist X, the K edges with the highest similarity to X are kept.
-    An edge (a, b) is retained if it appears in either A's or B's top-K — so
-    every artist always has at least their best matches present, even if the
-    other endpoint is heavily connected.
-
-    Why: with the production threshold of 0.97, the table grows to millions of
+    With the production threshold of 0.97 the table grows to millions of
     near-uniform edges (avg similarity 0.977) that contribute almost no
     discriminating signal after per-source max-normalization. Top-K-per-artist
     keeps the meaningful tail and shrinks the I/O footprint of every affinity
-    query.
-
-    Args:
-        conn: SQLite connection to the graph database. The caller is
-            responsible for committing or rolling back; this function does
-            not commit so it composes cleanly with dry-run wrappers.
-        top_k: Per-artist neighbor cap (must be > 0).
-
-    Returns:
-        ``(rows_before, rows_after)`` count tuple for reporting.
+    query. See :func:`semantic_index.edge_prune.prune_symmetric_edge_table` for
+    the either-side semantics and transaction contract.
     """
-    if top_k <= 0:
-        raise ValueError(f"top_k must be positive, got {top_k}")
+    from semantic_index.edge_prune import prune_symmetric_edge_table
 
-    before = conn.execute("SELECT COUNT(*) FROM acoustic_similarity").fetchone()[0]
-    if before == 0:
-        return 0, 0
-
-    # Compute (artist_a_id, artist_b_id) pairs to keep into a temp table.
-    # For each row, rn_a = rank within artist_a_id's neighbors, rn_b = rank within
-    # artist_b_id's neighbors. We keep rows where either rank is <= top_k.
-    # Tiebreaker on artist id for determinism.
-    # Use plain execute() rather than executescript(): the latter issues an
-    # implicit COMMIT, which would silently break the "caller manages the
-    # transaction" contract documented above (e.g., the dry-run wrapper).
-    conn.execute("DROP TABLE IF EXISTS _keep_acoustic")
-    conn.execute(
-        """
-        CREATE TEMP TABLE _keep_acoustic (
-            artist_a_id INTEGER NOT NULL,
-            artist_b_id INTEGER NOT NULL,
-            PRIMARY KEY (artist_a_id, artist_b_id)
-        )
-        """
+    return prune_symmetric_edge_table(
+        conn,
+        table="acoustic_similarity",
+        weight_expr="similarity",
+        top_k=top_k,
     )
-    # For each artist X, rank ALL neighbors (regardless of canonical direction) by
-    # similarity. Keep edges where either endpoint considers the other a top-K
-    # neighbor, then re-canonicalize to (a < b) order via MIN/MAX.
-    conn.execute(
-        """
-        INSERT OR IGNORE INTO _keep_acoustic (artist_a_id, artist_b_id)
-        SELECT MIN(x_id, y_id), MAX(x_id, y_id) FROM (
-            SELECT x_id, y_id, ROW_NUMBER() OVER (
-                PARTITION BY x_id ORDER BY similarity DESC, y_id
-            ) AS rn
-            FROM (
-                SELECT artist_a_id AS x_id, artist_b_id AS y_id, similarity
-                FROM acoustic_similarity
-                UNION ALL
-                SELECT artist_b_id, artist_a_id, similarity
-                FROM acoustic_similarity
-            )
-        )
-        WHERE rn <= ?
-        """,
-        (top_k,),
-    )
-
-    conn.execute(
-        """
-        DELETE FROM acoustic_similarity
-        WHERE NOT EXISTS (
-            SELECT 1 FROM _keep_acoustic k
-            WHERE k.artist_a_id = acoustic_similarity.artist_a_id
-              AND k.artist_b_id = acoustic_similarity.artist_b_id
-        )
-        """
-    )
-    conn.execute("DROP TABLE _keep_acoustic")
-
-    after = conn.execute("SELECT COUNT(*) FROM acoustic_similarity").fetchone()[0]
-    logger.info(
-        "Acoustic similarity prune: %d → %d edges (top_k=%d, kept %.1f%%)",
-        before,
-        after,
-        top_k,
-        (after / before * 100) if before else 0,
-    )
-    return before, after

--- a/semantic_index/api/app.py
+++ b/semantic_index/api/app.py
@@ -36,6 +36,7 @@ def create_app(
     sync_hour_utc: int = 9,
     sync_dsn: str | None = None,
     sync_min_count: int = 2,
+    enrichment_top_k: int = 50,
 ) -> FastAPI:
     """Create a FastAPI application wired to the given SQLite database.
 
@@ -47,6 +48,8 @@ def create_app(
         sync_hour_utc: Hour (UTC) to run the daily sync.
         sync_dsn: PostgreSQL DSN for Backend-Service (required when sync_enabled).
         sync_min_count: Minimum co-occurrence count for DJ transition edges.
+        enrichment_top_k: Per-artist neighbor cap for shared_personnel and
+            label_family applied on every nightly sync. 0 disables.
     """
     app = FastAPI(title="WXYC Semantic Graph API", version="0.1.0")
     app.add_middleware(
@@ -133,6 +136,7 @@ def create_app(
                 dsn=sync_dsn,
                 min_count=sync_min_count,
                 hour_utc=sync_hour_utc,
+                enrichment_top_k=enrichment_top_k,
             )
 
     return app
@@ -166,6 +170,7 @@ def _create_app_from_settings() -> FastAPI:
         sync_hour_utc=settings.sync_hour_utc,
         sync_dsn=settings.database_url_backend,
         sync_min_count=settings.sync_min_count,
+        enrichment_top_k=settings.enrichment_top_k,
     )
 
 

--- a/semantic_index/api/config.py
+++ b/semantic_index/api/config.py
@@ -28,3 +28,4 @@ class Settings(BaseSettings):
     sync_hour_utc: int = 9  # 9:00 UTC = 5:00 AM ET
     database_url_backend: str | None = None
     sync_min_count: int = 2
+    enrichment_top_k: int = 50

--- a/semantic_index/api/routes.py
+++ b/semantic_index/api/routes.py
@@ -999,8 +999,6 @@ def _neighbors_affinity_batch(
         affinity_sources.append((_MEMBER_OF_AFFINITY.affinity_type_name or "", _MEMBER_OF_AFFINITY))
 
         placeholders = ",".join("?" * len(artist_ids))
-        # Each affinity SQL has two halves (source / target) and a final
-        # ``rn <= ?`` filter, so params are: ids + cap, then ids + cap again.
         cap = AFFINITY_PER_SOURCE_CAP
         params = [*artist_ids, cap, *artist_ids, cap]
 
@@ -1011,12 +1009,8 @@ def _neighbors_affinity_batch(
             aid: {} for aid in artist_ids
         }
 
-        # ``WHERE source_id IN (...)`` would still fetch every edge for a hub
-        # like Stevie Wonder (thousands per direction). Wrap each direction in
-        # ``ROW_NUMBER() OVER (PARTITION BY sid ORDER BY raw_count DESC)`` so
-        # the engine reads index-clustered rows per source and stops after the
-        # top ``cap``. raw_count is the cheapest stable rank key (no PMI math
-        # in SQL — Python still does the cool/hot blend on the survivors).
+        # raw_count is the rank key (not pmi) because Python still applies the
+        # cool/hot blend on the survivors — keeping the SQL stable and cheap.
         dj_query = (
             "SELECT sid, nid, score, raw_count FROM (\n"  # noqa: S608
             "    SELECT source_id AS sid, target_id AS nid, pmi AS score, raw_count,\n"
@@ -1048,9 +1042,6 @@ def _neighbors_affinity_batch(
 
         for etype_default, source in affinity_sources:
             etype = source.affinity_type_name or etype_default
-            # ``score_expr`` is the affinity rank key (e.g. ``shared_count``);
-            # use it for both the SELECT value and the ROW_NUMBER ordering so
-            # the SQL cap keeps the highest-scoring per-source rows.
             score_expr = source.affinity_score_expr
             query = (
                 f"SELECT sid, nid, score FROM (\n"  # noqa: S608

--- a/semantic_index/api/routes.py
+++ b/semantic_index/api/routes.py
@@ -93,6 +93,18 @@ class EdgeSchema:
 # acoustic dimension is treated as zero contribution to affinity.
 ACOUSTIC_SATURATION_FLOOR = 0.97
 
+# Per-source SQL cap for the affinity composite query. The per-artist top-K prune
+# on shared_personnel/label_family/acoustic_similarity bounds OUT-degree but not
+# IN-degree: a hub artist like Stevie Wonder appears in thousands of other
+# artists' top-K sets, so `WHERE col_b IN (hub_id)` still returns thousands of
+# rows pointing AT them. The window-function cap below ensures the affinity
+# query never fetches more than AFFINITY_PER_SOURCE_CAP rows per (source, table)
+# pair, regardless of the source artist's centrality. 100 is well above any
+# realistic ``limit`` value the endpoint exposes and leaves headroom for the
+# weighted composite scorer to find good neighbors across all eight signal
+# types.
+AFFINITY_PER_SOURCE_CAP = 100
+
 
 EDGE_REGISTRY: dict[EdgeType, EdgeSchema] = {
     EdgeType.SHARED_STYLE: EdgeSchema(
@@ -987,7 +999,10 @@ def _neighbors_affinity_batch(
         affinity_sources.append((_MEMBER_OF_AFFINITY.affinity_type_name or "", _MEMBER_OF_AFFINITY))
 
         placeholders = ",".join("?" * len(artist_ids))
-        params = list(artist_ids) + list(artist_ids)
+        # Each affinity SQL has two halves (source / target) and a final
+        # ``rn <= ?`` filter, so params are: ids + cap, then ids + cap again.
+        cap = AFFINITY_PER_SOURCE_CAP
+        params = [*artist_ids, cap, *artist_ids, cap]
 
         per_source_edges: dict[int, dict[int, list[tuple[str, float]]]] = {
             aid: {} for aid in artist_ids
@@ -996,12 +1011,26 @@ def _neighbors_affinity_batch(
             aid: {} for aid in artist_ids
         }
 
+        # ``WHERE source_id IN (...)`` would still fetch every edge for a hub
+        # like Stevie Wonder (thousands per direction). Wrap each direction in
+        # ``ROW_NUMBER() OVER (PARTITION BY sid ORDER BY raw_count DESC)`` so
+        # the engine reads index-clustered rows per source and stops after the
+        # top ``cap``. raw_count is the cheapest stable rank key (no PMI math
+        # in SQL — Python still does the cool/hot blend on the survivors).
         dj_query = (
-            f"SELECT source_id AS sid, target_id AS nid, pmi AS score, raw_count "  # noqa: S608
-            f"FROM dj_transition WHERE source_id IN ({placeholders}) "
-            "UNION ALL "
-            "SELECT target_id, source_id, pmi, raw_count "
-            f"FROM dj_transition WHERE target_id IN ({placeholders})"
+            "SELECT sid, nid, score, raw_count FROM (\n"  # noqa: S608
+            "    SELECT source_id AS sid, target_id AS nid, pmi AS score, raw_count,\n"
+            "           ROW_NUMBER() OVER (PARTITION BY source_id "
+            "                              ORDER BY raw_count DESC, target_id) AS rn\n"
+            f"    FROM dj_transition WHERE source_id IN ({placeholders})\n"
+            ") WHERE rn <= ?\n"
+            "UNION ALL\n"
+            "SELECT sid, nid, score, raw_count FROM (\n"
+            "    SELECT target_id AS sid, source_id AS nid, pmi AS score, raw_count,\n"
+            "           ROW_NUMBER() OVER (PARTITION BY target_id "
+            "                              ORDER BY raw_count DESC, source_id) AS rn\n"
+            f"    FROM dj_transition WHERE target_id IN ({placeholders})\n"
+            ") WHERE rn <= ?"
         )
         with sentry_sdk.start_span(op="db.sqlite", name="dj_transition") as span:
             row_count = 0
@@ -1019,13 +1048,26 @@ def _neighbors_affinity_batch(
 
         for etype_default, source in affinity_sources:
             etype = source.affinity_type_name or etype_default
+            # ``score_expr`` is the affinity rank key (e.g. ``shared_count``);
+            # use it for both the SELECT value and the ROW_NUMBER ordering so
+            # the SQL cap keeps the highest-scoring per-source rows.
+            score_expr = source.affinity_score_expr
             query = (
-                f"SELECT {source.col_a} AS sid, {source.col_b} AS nid, "  # noqa: S608
-                f"{source.affinity_score_expr} AS score "
-                f"FROM {source.table} WHERE {source.col_a} IN ({placeholders}) "
-                "UNION ALL "
-                f"SELECT {source.col_b}, {source.col_a}, {source.affinity_score_expr} "
-                f"FROM {source.table} WHERE {source.col_b} IN ({placeholders})"
+                f"SELECT sid, nid, score FROM (\n"  # noqa: S608
+                f"    SELECT {source.col_a} AS sid, {source.col_b} AS nid,\n"
+                f"           ({score_expr}) AS score,\n"
+                f"           ROW_NUMBER() OVER (PARTITION BY {source.col_a} "
+                f"                              ORDER BY ({score_expr}) DESC, {source.col_b}) AS rn\n"
+                f"    FROM {source.table} WHERE {source.col_a} IN ({placeholders})\n"
+                f") WHERE rn <= ?\n"
+                f"UNION ALL\n"
+                f"SELECT sid, nid, score FROM (\n"
+                f"    SELECT {source.col_b} AS sid, {source.col_a} AS nid,\n"
+                f"           ({score_expr}) AS score,\n"
+                f"           ROW_NUMBER() OVER (PARTITION BY {source.col_b} "
+                f"                              ORDER BY ({score_expr}) DESC, {source.col_a}) AS rn\n"
+                f"    FROM {source.table} WHERE {source.col_b} IN ({placeholders})\n"
+                f") WHERE rn <= ?"
             )
             with sentry_sdk.start_span(op="db.sqlite", name=source.table) as span:
                 row_count = 0

--- a/semantic_index/api/routes.py
+++ b/semantic_index/api/routes.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from enum import StrEnum
 from typing import Any
 
+import sentry_sdk
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
@@ -964,146 +965,175 @@ def _neighbors_affinity_batch(
     Mirrors :func:`_neighbors_affinity` but issues a single ``WHERE source_id IN (...)``
     query per edge table instead of two-per-table-per-source. Per-source ranking
     semantics (heat blend, type-max normalization, weighted composite) are unchanged.
+
+    Sentry trace shape (no-op when no transaction is active): one ``affinity.batch``
+    parent span around the whole call, one ``db.sqlite`` child per edge table with
+    ``rows`` set, one ``affinity.score`` child for the Python ranking pass, and one
+    ``db.sqlite`` child for the final artist hydration.
     """
     if not artist_ids:
         return {}
 
-    affinity_sources: list[tuple[str, EdgeSchema]] = [
-        (edge_type.value, schema)
-        for edge_type, schema in EDGE_REGISTRY.items()
-        if schema.affinity_score_expr is not None
-    ]
-    affinity_sources.append((_MEMBER_OF_AFFINITY.affinity_type_name or "", _MEMBER_OF_AFFINITY))
+    with sentry_sdk.start_span(op="affinity.batch", name="affinity_batch") as parent:
+        parent.set_data("artist_count", len(artist_ids))
+        parent.set_data("limit", limit)
+        parent.set_data("heat", heat)
 
-    placeholders = ",".join("?" * len(artist_ids))
-    params = list(artist_ids) + list(artist_ids)
+        affinity_sources: list[tuple[str, EdgeSchema]] = [
+            (edge_type.value, schema)
+            for edge_type, schema in EDGE_REGISTRY.items()
+            if schema.affinity_score_expr is not None
+        ]
+        affinity_sources.append((_MEMBER_OF_AFFINITY.affinity_type_name or "", _MEMBER_OF_AFFINITY))
 
-    per_source_edges: dict[int, dict[int, list[tuple[str, float]]]] = {
-        aid: {} for aid in artist_ids
-    }
-    per_source_dj_raw: dict[int, dict[int, tuple[float, float]]] = {aid: {} for aid in artist_ids}
+        placeholders = ",".join("?" * len(artist_ids))
+        params = list(artist_ids) + list(artist_ids)
 
-    dj_query = (
-        f"SELECT source_id AS sid, target_id AS nid, pmi AS score, raw_count "  # noqa: S608
-        f"FROM dj_transition WHERE source_id IN ({placeholders}) "
-        "UNION ALL "
-        "SELECT target_id, source_id, pmi, raw_count "
-        f"FROM dj_transition WHERE target_id IN ({placeholders})"
-    )
-    try:
-        for row in db.execute(dj_query, params):
-            sid, nid, score, raw_count = row[0], row[1], float(row[2]), float(row[3])
-            if sid not in per_source_edges:
-                continue
-            per_source_dj_raw[sid][nid] = (score, raw_count)
-            per_source_edges[sid].setdefault(nid, []).append(("djTransition", score))
-    except sqlite3.OperationalError:
-        pass
+        per_source_edges: dict[int, dict[int, list[tuple[str, float]]]] = {
+            aid: {} for aid in artist_ids
+        }
+        per_source_dj_raw: dict[int, dict[int, tuple[float, float]]] = {
+            aid: {} for aid in artist_ids
+        }
 
-    for etype_default, source in affinity_sources:
-        etype = source.affinity_type_name or etype_default
-        query = (
-            f"SELECT {source.col_a} AS sid, {source.col_b} AS nid, "  # noqa: S608
-            f"{source.affinity_score_expr} AS score "
-            f"FROM {source.table} WHERE {source.col_a} IN ({placeholders}) "
+        dj_query = (
+            f"SELECT source_id AS sid, target_id AS nid, pmi AS score, raw_count "  # noqa: S608
+            f"FROM dj_transition WHERE source_id IN ({placeholders}) "
             "UNION ALL "
-            f"SELECT {source.col_b}, {source.col_a}, {source.affinity_score_expr} "
-            f"FROM {source.table} WHERE {source.col_b} IN ({placeholders})"
+            "SELECT target_id, source_id, pmi, raw_count "
+            f"FROM dj_transition WHERE target_id IN ({placeholders})"
         )
-        try:
-            for row in db.execute(query, params):
-                sid, nid, score = row[0], row[1], float(row[2])
-                if sid not in per_source_edges:
-                    continue
-                per_source_edges[sid].setdefault(nid, []).append((etype, score))
-        except sqlite3.OperationalError:
-            continue
+        with sentry_sdk.start_span(op="db.sqlite", name="dj_transition") as span:
+            row_count = 0
+            try:
+                for row in db.execute(dj_query, params):
+                    sid, nid, score, raw_count = row[0], row[1], float(row[2]), float(row[3])
+                    row_count += 1
+                    if sid not in per_source_edges:
+                        continue
+                    per_source_dj_raw[sid][nid] = (score, raw_count)
+                    per_source_edges[sid].setdefault(nid, []).append(("djTransition", score))
+            except sqlite3.OperationalError:
+                pass
+            span.set_data("rows", row_count)
 
-    # Heat slider modulates DJ-vs-enrichment weight balance:
-    #   heat=0.0 → pure mirror: DJ full, enrichment damped to zero
-    #   heat=0.5 → balanced: DJ full, enrichment at base weights (existing behavior)
-    #   heat=1.0 → discovery: DJ damped to zero, enrichment doubled
-    # DJ stays at full weight across the cool half then ramps to zero at the hot end;
-    # enrichment ramps linearly from 0 (cool) through 1× (center) to 2× (hot).
-    dj_factor = min(1.0, 2.0 * (1.0 - heat))
-    enrichment_factor = 2.0 * heat
-    dim_weights: dict[str, float] = {"djTransition": 3.0 * dj_factor}
-    for etype_default, source in affinity_sources:
-        dim_weights[source.affinity_type_name or etype_default] = (
-            source.affinity_weight * enrichment_factor
-        )
-
-    per_source_top: dict[int, list[tuple[int, float, list[str]]]] = {}
-    all_top_nids: set[int] = set()
-
-    for sid in artist_ids:
-        neighbor_edges = per_source_edges[sid]
-        if not neighbor_edges:
-            per_source_top[sid] = []
-            continue
-
-        dj_raw = per_source_dj_raw[sid]
-        if dj_raw:
-            max_pmi = max(p for p, _ in dj_raw.values()) or 1
-            max_rc = max(rc for _, rc in dj_raw.values()) or 1
-            for nid, (pmi, rc) in dj_raw.items():
-                blended = (1 - heat) * (rc / max_rc) + heat * (pmi / max_pmi)
-                neighbor_edges[nid] = [
-                    (etype, blended if etype == "djTransition" else score)
-                    for etype, score in neighbor_edges[nid]
-                ]
-
-        type_maxes: dict[str, float] = {}
-        for edges in neighbor_edges.values():
-            for etype, score in edges:
-                type_maxes[etype] = max(type_maxes.get(etype, 0), score)
-
-        scored: list[tuple[int, float, list[str]]] = []
-        for nid, edges in neighbor_edges.items():
-            composite = 0.0
-            types: list[str] = []
-            seen_types: set[str] = set()
-            for etype, score in edges:
-                if etype in seen_types:
-                    continue
-                seen_types.add(etype)
-                max_score = type_maxes.get(etype, 1) or 1
-                w = dim_weights.get(etype, 1.0)
-                composite += w * (score / max_score)
-                types.append(etype)
-            scored.append((nid, composite, types))
-
-        scored.sort(key=lambda x: x[1], reverse=True)
-        top = scored[:limit]
-        per_source_top[sid] = top
-        all_top_nids.update(nid for nid, _, _ in top)
-
-    if not all_top_nids:
-        return {sid: [] for sid in artist_ids}
-
-    nbr_placeholders = ",".join("?" * len(all_top_nids))
-    artist_rows = db.execute(
-        f"SELECT {_scols()} FROM artist WHERE id IN ({nbr_placeholders})",  # noqa: S608
-        list(all_top_nids),
-    ).fetchall()
-    artist_map = {r["id"]: r for r in artist_rows}
-
-    results: dict[int, list[NeighborEntry]] = {}
-    for sid in artist_ids:
-        entries: list[NeighborEntry] = []
-        for nid, composite, types in per_source_top.get(sid, []):
-            r = artist_map.get(nid)
-            if not r:
-                continue
-            entries.append(
-                NeighborEntry(
-                    artist=_artist_summary(r),
-                    weight=round(composite, 3),
-                    detail={"dimensions": len(types), "types": types},
-                )
+        for etype_default, source in affinity_sources:
+            etype = source.affinity_type_name or etype_default
+            query = (
+                f"SELECT {source.col_a} AS sid, {source.col_b} AS nid, "  # noqa: S608
+                f"{source.affinity_score_expr} AS score "
+                f"FROM {source.table} WHERE {source.col_a} IN ({placeholders}) "
+                "UNION ALL "
+                f"SELECT {source.col_b}, {source.col_a}, {source.affinity_score_expr} "
+                f"FROM {source.table} WHERE {source.col_b} IN ({placeholders})"
             )
-        results[sid] = entries
-    return results
+            with sentry_sdk.start_span(op="db.sqlite", name=source.table) as span:
+                row_count = 0
+                try:
+                    for row in db.execute(query, params):
+                        sid, nid, score = row[0], row[1], float(row[2])
+                        row_count += 1
+                        if sid not in per_source_edges:
+                            continue
+                        per_source_edges[sid].setdefault(nid, []).append((etype, score))
+                except sqlite3.OperationalError:
+                    span.set_data("error", "missing_table")
+                    span.set_data("rows", row_count)
+                    continue
+                span.set_data("rows", row_count)
+
+        # Heat slider modulates DJ-vs-enrichment weight balance:
+        #   heat=0.0 → pure mirror: DJ full, enrichment damped to zero
+        #   heat=0.5 → balanced: DJ full, enrichment at base weights (existing behavior)
+        #   heat=1.0 → discovery: DJ damped to zero, enrichment doubled
+        # DJ stays at full weight across the cool half then ramps to zero at the hot end;
+        # enrichment ramps linearly from 0 (cool) through 1× (center) to 2× (hot).
+        dj_factor = min(1.0, 2.0 * (1.0 - heat))
+        enrichment_factor = 2.0 * heat
+        dim_weights: dict[str, float] = {"djTransition": 3.0 * dj_factor}
+        for etype_default, source in affinity_sources:
+            dim_weights[source.affinity_type_name or etype_default] = (
+                source.affinity_weight * enrichment_factor
+            )
+
+        per_source_top: dict[int, list[tuple[int, float, list[str]]]] = {}
+        all_top_nids: set[int] = set()
+
+        with sentry_sdk.start_span(op="affinity.score", name="score_and_rank") as span:
+            total_candidates = 0
+            for sid in artist_ids:
+                neighbor_edges = per_source_edges[sid]
+                if not neighbor_edges:
+                    per_source_top[sid] = []
+                    continue
+                total_candidates += len(neighbor_edges)
+
+                dj_raw = per_source_dj_raw[sid]
+                if dj_raw:
+                    max_pmi = max(p for p, _ in dj_raw.values()) or 1
+                    max_rc = max(rc for _, rc in dj_raw.values()) or 1
+                    for nid, (pmi, rc) in dj_raw.items():
+                        blended = (1 - heat) * (rc / max_rc) + heat * (pmi / max_pmi)
+                        neighbor_edges[nid] = [
+                            (etype, blended if etype == "djTransition" else score)
+                            for etype, score in neighbor_edges[nid]
+                        ]
+
+                type_maxes: dict[str, float] = {}
+                for edges in neighbor_edges.values():
+                    for etype, score in edges:
+                        type_maxes[etype] = max(type_maxes.get(etype, 0), score)
+
+                scored: list[tuple[int, float, list[str]]] = []
+                for nid, edges in neighbor_edges.items():
+                    composite = 0.0
+                    types: list[str] = []
+                    seen_types: set[str] = set()
+                    for etype, score in edges:
+                        if etype in seen_types:
+                            continue
+                        seen_types.add(etype)
+                        max_score = type_maxes.get(etype, 1) or 1
+                        w = dim_weights.get(etype, 1.0)
+                        composite += w * (score / max_score)
+                        types.append(etype)
+                    scored.append((nid, composite, types))
+
+                scored.sort(key=lambda x: x[1], reverse=True)
+                top = scored[:limit]
+                per_source_top[sid] = top
+                all_top_nids.update(nid for nid, _, _ in top)
+            span.set_data("candidate_neighbors", total_candidates)
+            span.set_data("returned_neighbors", len(all_top_nids))
+
+        if not all_top_nids:
+            return {sid: [] for sid in artist_ids}
+
+        with sentry_sdk.start_span(op="db.sqlite", name="hydrate_artists") as span:
+            nbr_placeholders = ",".join("?" * len(all_top_nids))
+            artist_rows = db.execute(
+                f"SELECT {_scols()} FROM artist WHERE id IN ({nbr_placeholders})",  # noqa: S608
+                list(all_top_nids),
+            ).fetchall()
+            span.set_data("artist_count", len(artist_rows))
+        artist_map = {r["id"]: r for r in artist_rows}
+
+        results: dict[int, list[NeighborEntry]] = {}
+        for sid in artist_ids:
+            entries: list[NeighborEntry] = []
+            for nid, composite, types in per_source_top.get(sid, []):
+                r = artist_map.get(nid)
+                if not r:
+                    continue
+                entries.append(
+                    NeighborEntry(
+                        artist=_artist_summary(r),
+                        weight=round(composite, 3),
+                        detail={"dimensions": len(types), "types": types},
+                    )
+                )
+            results[sid] = entries
+        return results
 
 
 def _neighbors_shared_personnel(

--- a/semantic_index/api/sync_scheduler.py
+++ b/semantic_index/api/sync_scheduler.py
@@ -44,7 +44,7 @@ def _seconds_until_next_run(hour_utc: int) -> float:
     return delta
 
 
-def _run_sync(db_path: str, dsn: str, min_count: int) -> None:
+def _run_sync(db_path: str, dsn: str, min_count: int, enrichment_top_k: int) -> None:
     """Execute a single sync run, catching all exceptions."""
     try:
         from semantic_index.nightly_sync import nightly_sync
@@ -53,6 +53,7 @@ def _run_sync(db_path: str, dsn: str, min_count: int) -> None:
             db_path=db_path,
             dsn=dsn,
             min_count=min_count,
+            enrichment_top_k=enrichment_top_k,
             dry_run=False,
             verbose=False,
         )
@@ -84,7 +85,9 @@ def _sleep_with_heartbeat(total_seconds: float, hour_utc: int) -> None:
             )
 
 
-def _scheduler_loop(db_path: str, dsn: str, min_count: int, hour_utc: int) -> None:
+def _scheduler_loop(
+    db_path: str, dsn: str, min_count: int, hour_utc: int, enrichment_top_k: int
+) -> None:
     """Sleep-and-run loop for the background thread.
 
     The outer ``try``/``except`` is load-bearing: this runs as a ``daemon=True``
@@ -104,7 +107,7 @@ def _scheduler_loop(db_path: str, dsn: str, min_count: int, hour_utc: int) -> No
             _sleep_with_heartbeat(wait, hour_utc)
 
             logger.info("Starting scheduled sync...")
-            _run_sync(db_path, dsn, min_count)
+            _run_sync(db_path, dsn, min_count, enrichment_top_k)
     except BaseException:
         logger.exception(
             "Sync scheduler thread crashed — daily sync will not run until the process restarts"
@@ -117,6 +120,7 @@ def start_scheduler(
     dsn: str,
     min_count: int = 2,
     hour_utc: int = 9,
+    enrichment_top_k: int = 50,
 ) -> threading.Thread | None:
     """Start the sync scheduler as a daemon thread.
 
@@ -128,6 +132,8 @@ def start_scheduler(
         dsn: PostgreSQL DSN for Backend-Service.
         min_count: Minimum co-occurrence count for DJ transition edges.
         hour_utc: Hour (UTC) to run the daily sync.
+        enrichment_top_k: Per-artist neighbor cap for shared_personnel and
+            label_family. 0 disables.
 
     Returns:
         The daemon thread (already started), or None if the lock is held.
@@ -147,7 +153,7 @@ def start_scheduler(
 
     thread = threading.Thread(
         target=_scheduler_loop,
-        args=(db_path, dsn, min_count, hour_utc),
+        args=(db_path, dsn, min_count, hour_utc, enrichment_top_k),
         name="sync-scheduler",
         daemon=True,
     )

--- a/semantic_index/discogs_edges.py
+++ b/semantic_index/discogs_edges.py
@@ -3,9 +3,14 @@
 Four pure functions that compute edges between artists based on shared personnel,
 overlapping style tags, shared record labels, and co-appearance on compilations.
 All functions use inverted indexes for efficient pair generation.
+
+Also provides per-artist top-K prune for shared_personnel and label_family —
+without it both tables grow into the 10M+ row, 1 GB+ range on the WXYC graph
+and stall the affinity composite-edge endpoint on cold cache.
 """
 
 import logging
+import sqlite3
 from collections import defaultdict
 from itertools import combinations
 
@@ -248,3 +253,162 @@ def extract_compilation_coappearance(
 
     logger.info("Extracted %d compilation-coappearance edges", len(edges))
     return edges
+
+
+def _prune_symmetric_edge_table(
+    conn: sqlite3.Connection,
+    *,
+    table: str,
+    weight_expr: str,
+    top_k: int,
+) -> tuple[int, int]:
+    """Prune a symmetric ``(artist_a_id, artist_b_id)`` edge table to top-K per artist.
+
+    For each artist X, the K edges with the highest ``weight_expr`` value at X
+    are kept (either-side semantics: an edge survives if it appears in either
+    endpoint's top-K). The function does not commit; the caller owns the
+    transaction so it composes with dry-run wrappers.
+
+    Args:
+        conn: SQLite connection to the graph database.
+        table: Edge table name. Must have ``artist_a_id`` and ``artist_b_id``
+            columns with the canonical ``artist_a_id < artist_b_id`` invariant.
+        weight_expr: SQL expression evaluated against rows of ``table`` that
+            returns a sortable ranking key (higher = stronger edge). For
+            example ``"shared_count"`` for shared_personnel or
+            ``"json_array_length(shared_labels)"`` for label_family.
+        top_k: Per-artist neighbor cap (must be > 0).
+
+    Returns:
+        ``(rows_before, rows_after)`` count tuple for reporting.
+    """
+    if top_k <= 0:
+        raise ValueError(f"top_k must be positive, got {top_k}")
+
+    before = conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]  # noqa: S608
+    if before == 0:
+        return 0, 0
+
+    # _keep_<table> is a TEMP table holding (a,b) pairs to keep. For each artist
+    # X, rank ALL neighbors (regardless of canonical direction) by weight DESC
+    # with a tiebreaker on the other endpoint id. Then re-canonicalize via
+    # MIN/MAX so the kept pair set matches the ``a < b`` invariant.
+    #
+    # Use plain execute() rather than executescript(): the latter issues an
+    # implicit COMMIT which would break the "caller manages the transaction"
+    # contract documented above.
+    conn.execute(f"DROP TABLE IF EXISTS _keep_{table}")
+    conn.execute(
+        f"""
+        CREATE TEMP TABLE _keep_{table} (
+            artist_a_id INTEGER NOT NULL,
+            artist_b_id INTEGER NOT NULL,
+            PRIMARY KEY (artist_a_id, artist_b_id)
+        )
+        """  # noqa: S608
+    )
+    conn.execute(
+        f"""
+        INSERT OR IGNORE INTO _keep_{table} (artist_a_id, artist_b_id)
+        SELECT MIN(x_id, y_id), MAX(x_id, y_id) FROM (
+            SELECT x_id, y_id, ROW_NUMBER() OVER (
+                PARTITION BY x_id ORDER BY w DESC, y_id
+            ) AS rn
+            FROM (
+                SELECT artist_a_id AS x_id, artist_b_id AS y_id, ({weight_expr}) AS w
+                FROM {table}
+                UNION ALL
+                SELECT artist_b_id, artist_a_id, ({weight_expr})
+                FROM {table}
+            )
+        )
+        WHERE rn <= ?
+        """,  # noqa: S608
+        (top_k,),
+    )
+    conn.execute(
+        f"""
+        DELETE FROM {table}
+        WHERE NOT EXISTS (
+            SELECT 1 FROM _keep_{table} k
+            WHERE k.artist_a_id = {table}.artist_a_id
+              AND k.artist_b_id = {table}.artist_b_id
+        )
+        """  # noqa: S608
+    )
+    conn.execute(f"DROP TABLE _keep_{table}")
+
+    after = conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]  # noqa: S608
+    logger.info(
+        "%s prune: %d → %d edges (top_k=%d, kept %.1f%%)",
+        table,
+        before,
+        after,
+        top_k,
+        (after / before * 100) if before else 0,
+    )
+    return before, after
+
+
+def prune_shared_personnel(
+    conn: sqlite3.Connection,
+    top_k: int,
+) -> tuple[int, int]:
+    """Prune ``shared_personnel`` to top-K most-shared-personnel edges per artist.
+
+    Ranks per-artist edges by ``shared_count DESC`` with a deterministic
+    tiebreaker on the other endpoint id. An edge survives if it appears in
+    either endpoint's top-K — see :func:`_prune_symmetric_edge_table` for the
+    either-side semantics and transaction contract.
+
+    Why: on the WXYC graph the table grows to ~12M rows (1.3 GB on disk
+    including indexes) because popular artists accumulate 8K–10K personnel
+    neighbors each. After per-source max-normalization in the affinity
+    composite scorer, only the high-``shared_count`` tail of each artist
+    contributes meaningful signal; the rest is noise that has to be paged
+    in from disk on cold cache, stalling the
+    ``/graph/artists/{id}/neighbors?type=affinity`` endpoint.
+
+    Args:
+        conn: SQLite connection. Caller commits / rolls back.
+        top_k: Per-artist neighbor cap (must be > 0).
+
+    Returns:
+        ``(rows_before, rows_after)`` count tuple for reporting.
+    """
+    return _prune_symmetric_edge_table(
+        conn,
+        table="shared_personnel",
+        weight_expr="shared_count",
+        top_k=top_k,
+    )
+
+
+def prune_label_family(
+    conn: sqlite3.Connection,
+    top_k: int,
+) -> tuple[int, int]:
+    """Prune ``label_family`` to top-K most-shared-labels edges per artist.
+
+    label_family has no scalar weight column — ranks by
+    ``json_array_length(shared_labels) DESC`` so two artists who share many
+    labels rank above pairs that share just one. Same either-side semantics
+    and transaction contract as :func:`prune_shared_personnel`.
+
+    Why: the table grows to ~13M rows (1.2 GB on disk including indexes) on
+    the WXYC graph for the same dense-cross-product reason as
+    shared_personnel.
+
+    Args:
+        conn: SQLite connection. Caller commits / rolls back.
+        top_k: Per-artist neighbor cap (must be > 0).
+
+    Returns:
+        ``(rows_before, rows_after)`` count tuple for reporting.
+    """
+    return _prune_symmetric_edge_table(
+        conn,
+        table="label_family",
+        weight_expr="json_array_length(shared_labels)",
+        top_k=top_k,
+    )

--- a/semantic_index/discogs_edges.py
+++ b/semantic_index/discogs_edges.py
@@ -6,7 +6,9 @@ All functions use inverted indexes for efficient pair generation.
 
 Also provides per-artist top-K prune for shared_personnel and label_family —
 without it both tables grow into the 10M+ row, 1 GB+ range on the WXYC graph
-and stall the affinity composite-edge endpoint on cold cache.
+and stall the affinity composite-edge endpoint on cold cache. Both wrappers
+delegate to :func:`semantic_index.edge_prune.prune_symmetric_edge_table`, which
+also backs :func:`semantic_index.acousticbrainz.prune_acoustic_similarity`.
 """
 
 import logging
@@ -14,6 +16,7 @@ import sqlite3
 from collections import defaultdict
 from itertools import combinations
 
+from semantic_index.edge_prune import prune_symmetric_edge_table
 from semantic_index.models import (
     ArtistEnrichment,
     CompilationEdge,
@@ -255,128 +258,20 @@ def extract_compilation_coappearance(
     return edges
 
 
-def _prune_symmetric_edge_table(
-    conn: sqlite3.Connection,
-    *,
-    table: str,
-    weight_expr: str,
-    top_k: int,
-) -> tuple[int, int]:
-    """Prune a symmetric ``(artist_a_id, artist_b_id)`` edge table to top-K per artist.
-
-    For each artist X, the K edges with the highest ``weight_expr`` value at X
-    are kept (either-side semantics: an edge survives if it appears in either
-    endpoint's top-K). The function does not commit; the caller owns the
-    transaction so it composes with dry-run wrappers.
-
-    Args:
-        conn: SQLite connection to the graph database.
-        table: Edge table name. Must have ``artist_a_id`` and ``artist_b_id``
-            columns with the canonical ``artist_a_id < artist_b_id`` invariant.
-        weight_expr: SQL expression evaluated against rows of ``table`` that
-            returns a sortable ranking key (higher = stronger edge). For
-            example ``"shared_count"`` for shared_personnel or
-            ``"json_array_length(shared_labels)"`` for label_family.
-        top_k: Per-artist neighbor cap (must be > 0).
-
-    Returns:
-        ``(rows_before, rows_after)`` count tuple for reporting.
-    """
-    if top_k <= 0:
-        raise ValueError(f"top_k must be positive, got {top_k}")
-
-    before = conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]  # noqa: S608
-    if before == 0:
-        return 0, 0
-
-    # _keep_<table> is a TEMP table holding (a,b) pairs to keep. For each artist
-    # X, rank ALL neighbors (regardless of canonical direction) by weight DESC
-    # with a tiebreaker on the other endpoint id. Then re-canonicalize via
-    # MIN/MAX so the kept pair set matches the ``a < b`` invariant.
-    #
-    # Use plain execute() rather than executescript(): the latter issues an
-    # implicit COMMIT which would break the "caller manages the transaction"
-    # contract documented above.
-    conn.execute(f"DROP TABLE IF EXISTS _keep_{table}")
-    conn.execute(
-        f"""
-        CREATE TEMP TABLE _keep_{table} (
-            artist_a_id INTEGER NOT NULL,
-            artist_b_id INTEGER NOT NULL,
-            PRIMARY KEY (artist_a_id, artist_b_id)
-        )
-        """  # noqa: S608
-    )
-    conn.execute(
-        f"""
-        INSERT OR IGNORE INTO _keep_{table} (artist_a_id, artist_b_id)
-        SELECT MIN(x_id, y_id), MAX(x_id, y_id) FROM (
-            SELECT x_id, y_id, ROW_NUMBER() OVER (
-                PARTITION BY x_id ORDER BY w DESC, y_id
-            ) AS rn
-            FROM (
-                SELECT artist_a_id AS x_id, artist_b_id AS y_id, ({weight_expr}) AS w
-                FROM {table}
-                UNION ALL
-                SELECT artist_b_id, artist_a_id, ({weight_expr})
-                FROM {table}
-            )
-        )
-        WHERE rn <= ?
-        """,  # noqa: S608
-        (top_k,),
-    )
-    conn.execute(
-        f"""
-        DELETE FROM {table}
-        WHERE NOT EXISTS (
-            SELECT 1 FROM _keep_{table} k
-            WHERE k.artist_a_id = {table}.artist_a_id
-              AND k.artist_b_id = {table}.artist_b_id
-        )
-        """  # noqa: S608
-    )
-    conn.execute(f"DROP TABLE _keep_{table}")
-
-    after = conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]  # noqa: S608
-    logger.info(
-        "%s prune: %d → %d edges (top_k=%d, kept %.1f%%)",
-        table,
-        before,
-        after,
-        top_k,
-        (after / before * 100) if before else 0,
-    )
-    return before, after
-
-
 def prune_shared_personnel(
     conn: sqlite3.Connection,
     top_k: int,
 ) -> tuple[int, int]:
     """Prune ``shared_personnel`` to top-K most-shared-personnel edges per artist.
 
-    Ranks per-artist edges by ``shared_count DESC`` with a deterministic
-    tiebreaker on the other endpoint id. An edge survives if it appears in
-    either endpoint's top-K — see :func:`_prune_symmetric_edge_table` for the
+    Ranks by ``shared_count DESC``. The unpruned table grows to ~12M rows
+    (1.3 GB on disk including indexes) because popular artists accumulate
+    8K–10K personnel neighbors each, and that fanout stalls the affinity
+    composite-edge endpoint on cold cache. See
+    :func:`semantic_index.edge_prune.prune_symmetric_edge_table` for the
     either-side semantics and transaction contract.
-
-    Why: on the WXYC graph the table grows to ~12M rows (1.3 GB on disk
-    including indexes) because popular artists accumulate 8K–10K personnel
-    neighbors each. After per-source max-normalization in the affinity
-    composite scorer, only the high-``shared_count`` tail of each artist
-    contributes meaningful signal; the rest is noise that has to be paged
-    in from disk on cold cache, stalling the
-    ``/graph/artists/{id}/neighbors?type=affinity`` endpoint.
-
-    Args:
-        conn: SQLite connection. Caller commits / rolls back.
-        top_k: Per-artist neighbor cap (must be > 0).
-
-    Returns:
-        ``(rows_before, rows_after)`` count tuple for reporting.
     """
-    return _prune_symmetric_edge_table(
+    return prune_symmetric_edge_table(
         conn,
         table="shared_personnel",
         weight_expr="shared_count",
@@ -390,23 +285,12 @@ def prune_label_family(
 ) -> tuple[int, int]:
     """Prune ``label_family`` to top-K most-shared-labels edges per artist.
 
-    label_family has no scalar weight column — ranks by
-    ``json_array_length(shared_labels) DESC`` so two artists who share many
-    labels rank above pairs that share just one. Same either-side semantics
-    and transaction contract as :func:`prune_shared_personnel`.
-
-    Why: the table grows to ~13M rows (1.2 GB on disk including indexes) on
-    the WXYC graph for the same dense-cross-product reason as
-    shared_personnel.
-
-    Args:
-        conn: SQLite connection. Caller commits / rolls back.
-        top_k: Per-artist neighbor cap (must be > 0).
-
-    Returns:
-        ``(rows_before, rows_after)`` count tuple for reporting.
+    Ranks by ``json_array_length(shared_labels) DESC`` (no scalar weight
+    column on this table). Same growth pattern and motivation as
+    :func:`prune_shared_personnel`: ~13M rows (1.2 GB) unpruned on the
+    WXYC graph.
     """
-    return _prune_symmetric_edge_table(
+    return prune_symmetric_edge_table(
         conn,
         table="label_family",
         weight_expr="json_array_length(shared_labels)",

--- a/semantic_index/edge_prune.py
+++ b/semantic_index/edge_prune.py
@@ -1,0 +1,113 @@
+"""Top-K-per-artist prune for symmetric ``(artist_a_id, artist_b_id)`` edge tables.
+
+Used by ``acousticbrainz.prune_acoustic_similarity``, ``discogs_edges.prune_shared_personnel``,
+and ``discogs_edges.prune_label_family``. Each table's public wrapper supplies its
+own ranking expression (``similarity``, ``shared_count``, ``json_array_length(shared_labels)``);
+the SQL shape — keep-set TEMP table, ROW_NUMBER per endpoint, canonical re-MIN/MAX,
+NOT EXISTS delete — is shared.
+
+The function is transaction-neutral: it neither commits nor rolls back, so it
+composes with dry-run wrappers and with multi-step pipeline transactions.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+
+logger = logging.getLogger(__name__)
+
+
+def prune_symmetric_edge_table(
+    conn: sqlite3.Connection,
+    *,
+    table: str,
+    weight_expr: str,
+    top_k: int,
+) -> tuple[int, int]:
+    """Prune ``table`` to top-K per artist by ``weight_expr``, keeping either-side hits.
+
+    For each artist X, rank every neighbor (regardless of canonical direction) by
+    ``weight_expr DESC`` with a deterministic tiebreaker on the other endpoint id.
+    An edge survives if it appears in *either* endpoint's top-K — so every artist
+    always keeps their best matches even when the other endpoint is heavily
+    connected. Kept pairs are re-canonicalized to ``artist_a_id < artist_b_id``.
+
+    Args:
+        conn: SQLite connection. The caller owns the transaction; this function
+            does not commit so it composes cleanly with dry-run wrappers.
+        table: Edge table name. Must have ``artist_a_id`` and ``artist_b_id``
+            columns with the canonical ``artist_a_id < artist_b_id`` invariant.
+        weight_expr: SQL expression evaluated against rows of ``table`` that
+            returns a sortable ranking key (higher = stronger edge). Examples:
+            ``"similarity"``, ``"shared_count"``,
+            ``"json_array_length(shared_labels)"``.
+        top_k: Per-artist neighbor cap (must be > 0).
+
+    Returns:
+        ``(rows_before, rows_after)`` count tuple for reporting.
+
+    Raises:
+        ValueError: If ``top_k <= 0``.
+    """
+    if top_k <= 0:
+        raise ValueError(f"top_k must be positive, got {top_k}")
+
+    before = conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]  # noqa: S608
+    if before == 0:
+        return 0, 0
+
+    # _keep_<table> TEMP table holds the (a,b) pairs to keep. Use plain execute()
+    # rather than executescript(): the latter issues an implicit COMMIT, which
+    # would silently break the "caller manages the transaction" contract.
+    conn.execute(f"DROP TABLE IF EXISTS _keep_{table}")
+    conn.execute(
+        f"""
+        CREATE TEMP TABLE _keep_{table} (
+            artist_a_id INTEGER NOT NULL,
+            artist_b_id INTEGER NOT NULL,
+            PRIMARY KEY (artist_a_id, artist_b_id)
+        )
+        """  # noqa: S608
+    )
+    conn.execute(
+        f"""
+        INSERT OR IGNORE INTO _keep_{table} (artist_a_id, artist_b_id)
+        SELECT MIN(x_id, y_id), MAX(x_id, y_id) FROM (
+            SELECT x_id, y_id, ROW_NUMBER() OVER (
+                PARTITION BY x_id ORDER BY w DESC, y_id
+            ) AS rn
+            FROM (
+                SELECT artist_a_id AS x_id, artist_b_id AS y_id, ({weight_expr}) AS w
+                FROM {table}
+                UNION ALL
+                SELECT artist_b_id, artist_a_id, ({weight_expr})
+                FROM {table}
+            )
+        )
+        WHERE rn <= ?
+        """,  # noqa: S608
+        (top_k,),
+    )
+    conn.execute(
+        f"""
+        DELETE FROM {table}
+        WHERE NOT EXISTS (
+            SELECT 1 FROM _keep_{table} k
+            WHERE k.artist_a_id = {table}.artist_a_id
+              AND k.artist_b_id = {table}.artist_b_id
+        )
+        """  # noqa: S608
+    )
+    conn.execute(f"DROP TABLE _keep_{table}")
+
+    after = conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]  # noqa: S608
+    logger.info(
+        "%s prune: %d → %d edges (top_k=%d, kept %.1f%%)",
+        table,
+        before,
+        after,
+        top_k,
+        (after / before * 100) if before else 0,
+    )
+    return before, after

--- a/semantic_index/nightly_sync.py
+++ b/semantic_index/nightly_sync.py
@@ -31,10 +31,10 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_DB_PATH = "data/wxyc_artist_graph.db"
 DEFAULT_MIN_COUNT = 2
-# Per-artist neighbor cap applied to enrichment edge tables on every sync.
-# shared_personnel and label_family grow into the 10M+ row range without it
-# (~1.3 GB / ~1.2 GB on disk) and stall the affinity composite-edge endpoint
-# on cold cache. Set the corresponding flag to 0 to disable.
+# Per-artist neighbor cap applied to shared_personnel and label_family on every
+# sync. Without it those tables grow into the 10M+ row range (~1.3 GB / ~1.2 GB
+# on disk) and stall the affinity composite-edge endpoint on cold cache. Set
+# the flag to 0 to disable.
 DEFAULT_ENRICHMENT_TOP_K = 50
 
 # Tables that are fully recomputed each run and must be cleared
@@ -118,36 +118,28 @@ def checkpoint_and_close(db_path: str) -> None:
     conn.close()
 
 
-def _prune_enrichment_edges(
-    db_path: str,
-    *,
-    shared_personnel_top_k: int,
-    label_family_top_k: int,
-) -> None:
+def _prune_enrichment_edges(db_path: str, *, top_k: int) -> None:
     """Apply per-artist top-K caps to the preserved enrichment edge tables.
 
-    Each ``top_k <= 0`` value disables the corresponding prune. Missing tables
-    are tolerated (fresh databases on first run will skip the prune cleanly).
-    The function commits its own changes so the next pipeline step sees the
-    pruned state.
+    ``top_k <= 0`` disables pruning. Missing tables are tolerated so first-run
+    fresh databases skip cleanly. Commits before returning so the next pipeline
+    step sees the pruned state.
     """
     from semantic_index.discogs_edges import prune_label_family, prune_shared_personnel
 
-    if shared_personnel_top_k <= 0 and label_family_top_k <= 0:
+    if top_k <= 0:
         return
 
     conn = sqlite3.connect(db_path)
     try:
-        if shared_personnel_top_k > 0:
+        for table_name, prune_fn in [
+            ("shared_personnel", prune_shared_personnel),
+            ("label_family", prune_label_family),
+        ]:
             try:
-                prune_shared_personnel(conn, top_k=shared_personnel_top_k)
+                prune_fn(conn, top_k=top_k)
             except sqlite3.OperationalError:
-                logger.info("shared_personnel table absent — skipping prune")
-        if label_family_top_k > 0:
-            try:
-                prune_label_family(conn, top_k=label_family_top_k)
-            except sqlite3.OperationalError:
-                logger.info("label_family table absent — skipping prune")
+                logger.info("%s table absent — skipping prune", table_name)
         conn.commit()
     finally:
         conn.close()
@@ -354,17 +346,17 @@ def nightly_sync(args: argparse.Namespace) -> None:
             )
 
         # --- Step 7c: Prune preserved enrichment edges ---
-        # Runs after dedup so per-artist neighbor counts reflect post-merge canonical IDs.
-        _prune_enrichment_edges(
-            str(temp_path),
-            shared_personnel_top_k=args.shared_personnel_top_k,
-            label_family_top_k=args.label_family_top_k,
-        )
+        # Snapshot the mapping and close pipeline_db before the prune opens its own
+        # connection — two write-capable handles to the same SQLite file under WAL
+        # are merely slow, but the prune commits inside its transaction and we
+        # don't want it racing pipeline_db's checkpoint.
+        name_to_id = pipeline_db.get_name_to_id_mapping()
+        pipeline_db.close()
+
+        _prune_enrichment_edges(str(temp_path), top_k=args.enrichment_top_k)
 
         # --- Step 8: Facet tables ---
         logger.info("Exporting facet tables...")
-        name_to_id = pipeline_db.get_name_to_id_mapping()
-
         export_facet_tables(
             db_path=str(temp_path),
             resolved_entries=resolved_entries,
@@ -375,7 +367,6 @@ def nightly_sync(args: argparse.Namespace) -> None:
         )
 
         # --- Step 9: Graph metrics ---
-        pipeline_db.close()
 
         logger.info("Computing graph metrics...")
         metrics = compute_and_persist(str(temp_path))
@@ -429,22 +420,13 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Minimum co-occurrence count for DJ transition edges (default: 2)",
     )
     parser.add_argument(
-        "--shared-personnel-top-k",
+        "--enrichment-top-k",
         type=int,
-        default=int(os.environ.get("SHARED_PERSONNEL_TOP_K", str(DEFAULT_ENRICHMENT_TOP_K))),
+        default=int(os.environ.get("ENRICHMENT_TOP_K", str(DEFAULT_ENRICHMENT_TOP_K))),
         help=(
-            f"Per-artist neighbor cap for shared_personnel (default: "
-            f"{DEFAULT_ENRICHMENT_TOP_K}, 0 disables). The unpruned table grows past "
-            "10M rows and stalls the affinity endpoint on cold cache."
-        ),
-    )
-    parser.add_argument(
-        "--label-family-top-k",
-        type=int,
-        default=int(os.environ.get("LABEL_FAMILY_TOP_K", str(DEFAULT_ENRICHMENT_TOP_K))),
-        help=(
-            f"Per-artist neighbor cap for label_family (default: "
-            f"{DEFAULT_ENRICHMENT_TOP_K}, 0 disables)."
+            f"Per-artist neighbor cap for shared_personnel and label_family "
+            f"(default: {DEFAULT_ENRICHMENT_TOP_K}, 0 disables). The unpruned tables "
+            "grow past 10M rows and stall the affinity endpoint on cold cache."
         ),
     )
     parser.add_argument(

--- a/semantic_index/nightly_sync.py
+++ b/semantic_index/nightly_sync.py
@@ -122,8 +122,11 @@ def _prune_enrichment_edges(db_path: str, *, top_k: int) -> None:
     """Apply per-artist top-K caps to the preserved enrichment edge tables.
 
     ``top_k <= 0`` disables pruning. Missing tables are tolerated so first-run
-    fresh databases skip cleanly. Commits before returning so the next pipeline
-    step sees the pruned state.
+    fresh databases skip cleanly — but only the "no such table" flavour of
+    ``OperationalError``. Other operational errors (locked database, disk full,
+    schema mismatch) propagate so the outer scheduler logs them with full
+    traceback instead of silently classifying them as "table absent".
+    Commits before returning so the next pipeline step sees the pruned state.
     """
     from semantic_index.discogs_edges import prune_label_family, prune_shared_personnel
 
@@ -138,7 +141,9 @@ def _prune_enrichment_edges(db_path: str, *, top_k: int) -> None:
         ]:
             try:
                 prune_fn(conn, top_k=top_k)
-            except sqlite3.OperationalError:
+            except sqlite3.OperationalError as e:
+                if "no such table" not in str(e).lower():
+                    raise
                 logger.info("%s table absent — skipping prune", table_name)
         conn.commit()
     finally:

--- a/semantic_index/nightly_sync.py
+++ b/semantic_index/nightly_sync.py
@@ -31,6 +31,11 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_DB_PATH = "data/wxyc_artist_graph.db"
 DEFAULT_MIN_COUNT = 2
+# Per-artist neighbor cap applied to enrichment edge tables on every sync.
+# shared_personnel and label_family grow into the 10M+ row range without it
+# (~1.3 GB / ~1.2 GB on disk) and stall the affinity composite-edge endpoint
+# on cold cache. Set the corresponding flag to 0 to disable.
+DEFAULT_ENRICHMENT_TOP_K = 50
 
 # Tables that are fully recomputed each run and must be cleared
 # before re-inserting to avoid stale data.  Facet tables and
@@ -111,6 +116,41 @@ def checkpoint_and_close(db_path: str) -> None:
     conn = sqlite3.connect(db_path)
     conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
     conn.close()
+
+
+def _prune_enrichment_edges(
+    db_path: str,
+    *,
+    shared_personnel_top_k: int,
+    label_family_top_k: int,
+) -> None:
+    """Apply per-artist top-K caps to the preserved enrichment edge tables.
+
+    Each ``top_k <= 0`` value disables the corresponding prune. Missing tables
+    are tolerated (fresh databases on first run will skip the prune cleanly).
+    The function commits its own changes so the next pipeline step sees the
+    pruned state.
+    """
+    from semantic_index.discogs_edges import prune_label_family, prune_shared_personnel
+
+    if shared_personnel_top_k <= 0 and label_family_top_k <= 0:
+        return
+
+    conn = sqlite3.connect(db_path)
+    try:
+        if shared_personnel_top_k > 0:
+            try:
+                prune_shared_personnel(conn, top_k=shared_personnel_top_k)
+            except sqlite3.OperationalError:
+                logger.info("shared_personnel table absent — skipping prune")
+        if label_family_top_k > 0:
+            try:
+                prune_label_family(conn, top_k=label_family_top_k)
+            except sqlite3.OperationalError:
+                logger.info("label_family table absent — skipping prune")
+        conn.commit()
+    finally:
+        conn.close()
 
 
 def atomic_swap(temp_path: Path, production_path: Path, *, dry_run: bool = False) -> None:
@@ -313,6 +353,14 @@ def nightly_sync(args: argparse.Namespace) -> None:
                 dedup_report.edges_rekeyed,
             )
 
+        # --- Step 7c: Prune preserved enrichment edges ---
+        # Runs after dedup so per-artist neighbor counts reflect post-merge canonical IDs.
+        _prune_enrichment_edges(
+            str(temp_path),
+            shared_personnel_top_k=args.shared_personnel_top_k,
+            label_family_top_k=args.label_family_top_k,
+        )
+
         # --- Step 8: Facet tables ---
         logger.info("Exporting facet tables...")
         name_to_id = pipeline_db.get_name_to_id_mapping()
@@ -379,6 +427,25 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         type=int,
         default=int(os.environ.get("MIN_COUNT", str(DEFAULT_MIN_COUNT))),
         help="Minimum co-occurrence count for DJ transition edges (default: 2)",
+    )
+    parser.add_argument(
+        "--shared-personnel-top-k",
+        type=int,
+        default=int(os.environ.get("SHARED_PERSONNEL_TOP_K", str(DEFAULT_ENRICHMENT_TOP_K))),
+        help=(
+            f"Per-artist neighbor cap for shared_personnel (default: "
+            f"{DEFAULT_ENRICHMENT_TOP_K}, 0 disables). The unpruned table grows past "
+            "10M rows and stalls the affinity endpoint on cold cache."
+        ),
+    )
+    parser.add_argument(
+        "--label-family-top-k",
+        type=int,
+        default=int(os.environ.get("LABEL_FAMILY_TOP_K", str(DEFAULT_ENRICHMENT_TOP_K))),
+        help=(
+            f"Per-artist neighbor cap for label_family (default: "
+            f"{DEFAULT_ENRICHMENT_TOP_K}, 0 disables)."
+        ),
     )
     parser.add_argument(
         "--dry-run",

--- a/tests/unit/test_api_routes.py
+++ b/tests/unit/test_api_routes.py
@@ -640,6 +640,86 @@ class TestBatchNeighbors:
                 assert bat_entry["detail"]["dimensions"] == ind_entry["detail"]["dimensions"]
 
 
+class TestAffinityPerSourceCap:
+    """Regression test for the SQL ``ROW_NUMBER`` per-source cap.
+
+    The affinity endpoint must bound how many rows it fetches per (source artist,
+    edge table) pair regardless of the source's in-degree. Without this guard a
+    hub artist who appears in thousands of *other* artists' top-K sets would
+    still return thousands of rows in the ``WHERE artist_b_id IN (hub)`` half of
+    the UNION ALL, regressing the cold-cache latency that motivated the cap.
+
+    The HTTP endpoint clamps ``limit`` at 100 so the assertion can't push the
+    limit above the cap. Instead, this test calls ``_neighbors_affinity_batch``
+    directly with the cap monkeypatched to a small value and checks that the
+    candidate neighbors surfaced to Python ranking are bounded by it.
+    """
+
+    @pytest.fixture
+    def hub_db(self, tmp_path) -> tuple[str, int, int]:
+        from tests.conftest import make_artist_stats
+
+        path = str(tmp_path / "hub.db")
+        n_neighbors = 200
+        stats = {"Hub": make_artist_stats("Hub", total_plays=100)}
+        for i in range(n_neighbors):
+            name = f"Neighbor{i:03d}"
+            stats[name] = make_artist_stats(name, total_plays=10)
+        export_sqlite(path, artist_stats=stats, pmi_edges=[], xref_edges=[], min_count=1)
+
+        conn = sqlite3.connect(path)
+        ids = {r[1]: r[0] for r in conn.execute("SELECT id, canonical_name FROM artist")}
+        hub_id = ids["Hub"]
+        # All leaves edge to the hub with strictly decreasing weight, so the cap's
+        # selection is deterministic (top-K leaves by descending shared_count).
+        for i in range(n_neighbors):
+            leaf_id = ids[f"Neighbor{i:03d}"]
+            a, b = sorted([hub_id, leaf_id])
+            conn.execute(
+                "INSERT INTO shared_personnel VALUES (?, ?, ?, ?)",
+                (a, b, n_neighbors - i, '["x"]'),
+            )
+        conn.commit()
+        conn.close()
+        return path, hub_id, n_neighbors
+
+    def test_cap_bounds_per_source_candidates(self, hub_db, monkeypatch) -> None:
+        from semantic_index.api import routes
+        from semantic_index.api.routes import _init_metrics_flag, _neighbors_affinity_batch
+
+        path, hub_id, n_neighbors = hub_db
+        # Shrink the cap to a value well below the seeded fanout so we can
+        # observe it as the binding constraint (not the request-side ``limit``).
+        cap = 25
+        monkeypatch.setattr(routes, "AFFINITY_PER_SOURCE_CAP", cap)
+
+        db = sqlite3.connect(path)
+        db.row_factory = sqlite3.Row
+        try:
+            _init_metrics_flag(db)
+            # ``limit`` deliberately > cap so the cap, not the request limit, is
+            # the bound exposed in the candidate set.
+            results = _neighbors_affinity_batch(db, [hub_id], limit=n_neighbors)
+        finally:
+            db.close()
+
+        neighbors = results.get(hub_id, [])
+        # The shared_personnel query returns ``cap`` rows from the hub-as-source
+        # half plus ``cap`` from the hub-as-target half. On this seed both halves
+        # touch overlapping (a,b) pairs, so per_source_edges dedups by neighbor
+        # id and the surfaced candidate count is bounded by 2*cap.
+        assert len(neighbors) <= 2 * cap, (
+            f"per-source SQL cap regressed: hub returned {len(neighbors)} neighbors, "
+            f"expected at most {2 * cap}"
+        )
+        # And the survivors are the highest-weight leaves: Neighbor000 has the
+        # largest shared_count and must be present.
+        names = {n.artist.canonical_name for n in neighbors}
+        assert "Neighbor000" in names, (
+            f"per-source cap dropped the highest-weight neighbor; survivors={sorted(names)[:10]}"
+        )
+
+
 class TestWikidataInfluenceNeighbors:
     @pytest.mark.asyncio
     async def test_influence_neighbors_outbound(

--- a/tests/unit/test_discogs_edges.py
+++ b/tests/unit/test_discogs_edges.py
@@ -1,10 +1,18 @@
 """Tests for Discogs-derived edge extraction functions."""
 
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
 from semantic_index.discogs_edges import (
     extract_compilation_coappearance,
     extract_label_family,
     extract_shared_personnel,
     extract_shared_styles,
+    prune_label_family,
+    prune_shared_personnel,
 )
 from semantic_index.models import CompilationAppearance, LabelInfo
 from tests.conftest import make_artist_enrichment, make_personnel_credit
@@ -626,3 +634,268 @@ class TestExtractCompilationCoappearance:
             "Artificial Intelligence",
             "Warp 20 (Recreated)",
         ]
+
+
+# ---------------------------------------------------------------------------
+# Top-K-per-artist prune for shared_personnel and label_family
+# ---------------------------------------------------------------------------
+#
+# These tables grow with the cross-product of artists who share any personnel
+# or any label. On the production graph, popular artists accumulate 8K–10K
+# neighbors in each table — heavy enough that cold-cache reads dominate the
+# /graph/artists/{id}/neighbors?type=affinity latency. Mirrors the existing
+# prune_acoustic_similarity contract: caller owns the transaction; rows are
+# kept if either endpoint considers the other a top-K neighbor.
+
+
+@pytest.fixture
+def personnel_db(tmp_path: Path) -> sqlite3.Connection:
+    """Fresh DB with the shared_personnel schema and indexes."""
+    conn = sqlite3.connect(str(tmp_path / "personnel.db"))
+    conn.row_factory = sqlite3.Row
+    conn.executescript(
+        """
+        CREATE TABLE shared_personnel (
+            artist_a_id INTEGER NOT NULL,
+            artist_b_id INTEGER NOT NULL,
+            shared_count INTEGER NOT NULL,
+            shared_names TEXT NOT NULL,
+            PRIMARY KEY (artist_a_id, artist_b_id)
+        );
+        CREATE INDEX idx_shared_personnel_a ON shared_personnel(artist_a_id);
+        CREATE INDEX idx_shared_personnel_b ON shared_personnel(artist_b_id);
+        """
+    )
+    return conn
+
+
+@pytest.fixture
+def label_db(tmp_path: Path) -> sqlite3.Connection:
+    """Fresh DB with the label_family schema and indexes."""
+    conn = sqlite3.connect(str(tmp_path / "label.db"))
+    conn.row_factory = sqlite3.Row
+    conn.executescript(
+        """
+        CREATE TABLE label_family (
+            artist_a_id INTEGER NOT NULL,
+            artist_b_id INTEGER NOT NULL,
+            shared_labels TEXT NOT NULL,
+            PRIMARY KEY (artist_a_id, artist_b_id)
+        );
+        CREATE INDEX idx_label_family_a ON label_family(artist_a_id);
+        CREATE INDEX idx_label_family_b ON label_family(artist_b_id);
+        """
+    )
+    return conn
+
+
+def _personnel_edges(conn: sqlite3.Connection) -> set[tuple[int, int]]:
+    return {
+        (r["artist_a_id"], r["artist_b_id"])
+        for r in conn.execute("SELECT artist_a_id, artist_b_id FROM shared_personnel")
+    }
+
+
+def _label_edges(conn: sqlite3.Connection) -> set[tuple[int, int]]:
+    return {
+        (r["artist_a_id"], r["artist_b_id"])
+        for r in conn.execute("SELECT artist_a_id, artist_b_id FROM label_family")
+    }
+
+
+def _seed_personnel_complete(conn: sqlite3.Connection, n: int) -> None:
+    """Insert the complete graph on artists 1..n with strictly decreasing
+    ``shared_count`` so the order of (a,b) by weight is reverse-lex on a, then b.
+
+    For n=5:
+      (1,2)=10 (1,3)=9 (1,4)=8 (1,5)=7
+      (2,3)=6 (2,4)=5 (2,5)=4
+      (3,4)=3 (3,5)=2
+      (4,5)=1
+    """
+    count = 10
+    for a in range(1, n + 1):
+        for b in range(a + 1, n + 1):
+            conn.execute(
+                "INSERT INTO shared_personnel VALUES (?, ?, ?, ?)",
+                (a, b, count, json.dumps([f"person-{count}"])),
+            )
+            count -= 1
+    conn.commit()
+
+
+def _seed_label_complete(conn: sqlite3.Connection, n: int) -> None:
+    """Insert the complete graph on artists 1..n with strictly decreasing
+    label count (= JSON array length) so the order of (a,b) by weight is
+    reverse-lex on a, then b.
+    """
+    count = 10
+    for a in range(1, n + 1):
+        for b in range(a + 1, n + 1):
+            conn.execute(
+                "INSERT INTO label_family VALUES (?, ?, ?)",
+                (a, b, json.dumps([f"label-{i}" for i in range(count)])),
+            )
+            count -= 1
+    conn.commit()
+
+
+class TestPruneSharedPersonnel:
+    """Top-K-per-artist (either-side) prune of shared_personnel, ranked by shared_count DESC."""
+
+    def test_top_k_keeps_top_neighbors_per_artist(self, personnel_db: sqlite3.Connection) -> None:
+        _seed_personnel_complete(personnel_db, 5)
+        # Same topology as the acoustic case: each artist's top-2 → union of 7 edges,
+        # the three (3,4)/(3,5)/(4,5) edges drop.
+        before, after = prune_shared_personnel(personnel_db, top_k=2)
+        assert before == 10
+        assert after == 7
+        assert _personnel_edges(personnel_db) == {
+            (1, 2),
+            (1, 3),
+            (2, 3),
+            (1, 4),
+            (2, 4),
+            (1, 5),
+            (2, 5),
+        }
+
+    def test_either_side_semantics(self, personnel_db: sqlite3.Connection) -> None:
+        """Edges in B's top-K but not A's top-K must still be kept."""
+        edges = [(1, 2, 99), (1, 3, 98), (1, 4, 97), (1, 5, 96)]
+        for a, b, c in edges:
+            personnel_db.execute(
+                "INSERT INTO shared_personnel VALUES (?, ?, ?, ?)",
+                (a, b, c, json.dumps(["x"])),
+            )
+        personnel_db.commit()
+        before, after = prune_shared_personnel(personnel_db, top_k=1)
+        assert before == 4
+        assert after == 4
+        assert _personnel_edges(personnel_db) == {(1, 2), (1, 3), (1, 4), (1, 5)}
+
+    def test_large_k_keeps_everything(self, personnel_db: sqlite3.Connection) -> None:
+        _seed_personnel_complete(personnel_db, 4)
+        before, after = prune_shared_personnel(personnel_db, top_k=100)
+        assert before == 6
+        assert after == 6
+
+    def test_empty_table_no_error(self, personnel_db: sqlite3.Connection) -> None:
+        before, after = prune_shared_personnel(personnel_db, top_k=10)
+        assert before == 0
+        assert after == 0
+
+    def test_invalid_top_k_raises(self, personnel_db: sqlite3.Connection) -> None:
+        _seed_personnel_complete(personnel_db, 3)
+        with pytest.raises(ValueError):
+            prune_shared_personnel(personnel_db, top_k=0)
+        with pytest.raises(ValueError):
+            prune_shared_personnel(personnel_db, top_k=-1)
+
+    def test_preserves_canonical_order(self, personnel_db: sqlite3.Connection) -> None:
+        _seed_personnel_complete(personnel_db, 6)
+        prune_shared_personnel(personnel_db, top_k=3)
+        bad = personnel_db.execute(
+            "SELECT COUNT(*) FROM shared_personnel WHERE artist_a_id >= artist_b_id"
+        ).fetchone()[0]
+        assert bad == 0
+
+    def test_does_not_commit_so_rollback_works(self, personnel_db: sqlite3.Connection) -> None:
+        _seed_personnel_complete(personnel_db, 5)
+        personnel_db.commit()
+        before, after = prune_shared_personnel(personnel_db, top_k=2)
+        assert before == 10
+        assert after == 7
+        personnel_db.rollback()
+        restored = personnel_db.execute("SELECT COUNT(*) FROM shared_personnel").fetchone()[0]
+        assert restored == 10
+
+    def test_preserves_non_key_columns(self, personnel_db: sqlite3.Connection) -> None:
+        """Surviving rows keep their shared_count and shared_names intact."""
+        _seed_personnel_complete(personnel_db, 5)
+        prune_shared_personnel(personnel_db, top_k=2)
+        row = personnel_db.execute(
+            "SELECT shared_count, shared_names FROM shared_personnel WHERE artist_a_id=1 AND artist_b_id=2"
+        ).fetchone()
+        # The (1,2) edge was seeded with the highest count (10).
+        assert row["shared_count"] == 10
+        assert json.loads(row["shared_names"]) == ["person-10"]
+
+
+class TestPruneLabelFamily:
+    """Top-K-per-artist (either-side) prune of label_family, ranked by label count DESC.
+
+    label_family has no scalar weight column — rank by ``json_array_length(shared_labels)``.
+    """
+
+    def test_top_k_keeps_top_neighbors_per_artist(self, label_db: sqlite3.Connection) -> None:
+        _seed_label_complete(label_db, 5)
+        before, after = prune_label_family(label_db, top_k=2)
+        assert before == 10
+        assert after == 7
+        assert _label_edges(label_db) == {
+            (1, 2),
+            (1, 3),
+            (2, 3),
+            (1, 4),
+            (2, 4),
+            (1, 5),
+            (2, 5),
+        }
+
+    def test_either_side_semantics(self, label_db: sqlite3.Connection) -> None:
+        for a, b, n_labels in [(1, 2, 9), (1, 3, 8), (1, 4, 7), (1, 5, 6)]:
+            label_db.execute(
+                "INSERT INTO label_family VALUES (?, ?, ?)",
+                (a, b, json.dumps([f"l{i}" for i in range(n_labels)])),
+            )
+        label_db.commit()
+        before, after = prune_label_family(label_db, top_k=1)
+        assert before == 4
+        assert after == 4
+        assert _label_edges(label_db) == {(1, 2), (1, 3), (1, 4), (1, 5)}
+
+    def test_large_k_keeps_everything(self, label_db: sqlite3.Connection) -> None:
+        _seed_label_complete(label_db, 4)
+        before, after = prune_label_family(label_db, top_k=100)
+        assert before == 6
+        assert after == 6
+
+    def test_empty_table_no_error(self, label_db: sqlite3.Connection) -> None:
+        before, after = prune_label_family(label_db, top_k=10)
+        assert before == 0
+        assert after == 0
+
+    def test_invalid_top_k_raises(self, label_db: sqlite3.Connection) -> None:
+        _seed_label_complete(label_db, 3)
+        with pytest.raises(ValueError):
+            prune_label_family(label_db, top_k=0)
+        with pytest.raises(ValueError):
+            prune_label_family(label_db, top_k=-1)
+
+    def test_preserves_canonical_order(self, label_db: sqlite3.Connection) -> None:
+        _seed_label_complete(label_db, 6)
+        prune_label_family(label_db, top_k=3)
+        bad = label_db.execute(
+            "SELECT COUNT(*) FROM label_family WHERE artist_a_id >= artist_b_id"
+        ).fetchone()[0]
+        assert bad == 0
+
+    def test_does_not_commit_so_rollback_works(self, label_db: sqlite3.Connection) -> None:
+        _seed_label_complete(label_db, 5)
+        label_db.commit()
+        before, after = prune_label_family(label_db, top_k=2)
+        assert before == 10
+        assert after == 7
+        label_db.rollback()
+        restored = label_db.execute("SELECT COUNT(*) FROM label_family").fetchone()[0]
+        assert restored == 10
+
+    def test_preserves_shared_labels_payload(self, label_db: sqlite3.Connection) -> None:
+        _seed_label_complete(label_db, 5)
+        prune_label_family(label_db, top_k=2)
+        row = label_db.execute(
+            "SELECT shared_labels FROM label_family WHERE artist_a_id=1 AND artist_b_id=2"
+        ).fetchone()
+        # (1,2) was seeded with the most labels (10).
+        assert json.loads(row["shared_labels"]) == [f"label-{i}" for i in range(10)]

--- a/tests/unit/test_nightly_sync.py
+++ b/tests/unit/test_nightly_sync.py
@@ -360,6 +360,8 @@ class TestNightlySyncDeduplication:
             db_path=str(tmp_path / "prod.db"),
             dsn="postgresql://fake",
             min_count=2,
+            shared_personnel_top_k=50,
+            label_family_top_k=50,
             dry_run=True,
         )
 

--- a/tests/unit/test_nightly_sync.py
+++ b/tests/unit/test_nightly_sync.py
@@ -360,8 +360,7 @@ class TestNightlySyncDeduplication:
             db_path=str(tmp_path / "prod.db"),
             dsn="postgresql://fake",
             min_count=2,
-            shared_personnel_top_k=50,
-            label_family_top_k=50,
+            enrichment_top_k=50,
             dry_run=True,
         )
 

--- a/tests/unit/test_nightly_sync.py
+++ b/tests/unit/test_nightly_sync.py
@@ -11,6 +11,8 @@ import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -474,3 +476,106 @@ class TestNightlySyncDeduplication:
         assert export_idx < dedup_idx < facet_idx, (
             f"Expected export < dedup < facets, got: {call_order}"
         )
+
+
+# ===========================================================================
+# _prune_enrichment_edges
+# ===========================================================================
+
+
+def _create_enrichment_test_db(path: Path) -> None:
+    """Create a DB with the two enrichment edge tables, seeded with the complete
+    graph on artists 1..5 (10 edges per table) so top-K=2 produces a
+    deterministic non-trivial survivor set."""
+    conn = sqlite3.connect(str(path))
+    conn.executescript("""
+        CREATE TABLE shared_personnel (
+            artist_a_id INTEGER NOT NULL,
+            artist_b_id INTEGER NOT NULL,
+            shared_count INTEGER NOT NULL,
+            shared_names TEXT NOT NULL,
+            PRIMARY KEY (artist_a_id, artist_b_id)
+        );
+        CREATE TABLE label_family (
+            artist_a_id INTEGER NOT NULL,
+            artist_b_id INTEGER NOT NULL,
+            shared_labels TEXT NOT NULL,
+            PRIMARY KEY (artist_a_id, artist_b_id)
+        );
+    """)
+    # Complete graph on 1..5 with strictly decreasing weights so the survivor
+    # set is the same shape as TestPruneSharedPersonnel.test_top_k_keeps_top_*:
+    # 10 edges -> 7 after top-K=2 (either-side prune).
+    count = 10
+    for a in range(1, 6):
+        for b in range(a + 1, 6):
+            conn.execute(
+                "INSERT INTO shared_personnel VALUES (?, ?, ?, ?)",
+                (a, b, count, '["x"]'),
+            )
+            conn.execute(
+                "INSERT INTO label_family VALUES (?, ?, ?)",
+                (a, b, '["' + '","'.join([f"l{i}" for i in range(count)]) + '"]'),
+            )
+            count -= 1
+    conn.commit()
+    conn.close()
+
+
+class TestPruneEnrichmentEdges:
+    def test_top_k_zero_is_no_op(self, tmp_path):
+        """``top_k <= 0`` returns before opening any connection."""
+        from semantic_index.nightly_sync import _prune_enrichment_edges
+
+        db = tmp_path / "nonexistent.db"
+        # File doesn't exist; if the function opened it, sqlite3.connect would
+        # create an empty file. With the early return there should be no file.
+        _prune_enrichment_edges(str(db), top_k=0)
+        assert not db.exists()
+
+    def test_tolerates_missing_tables(self, tmp_path):
+        """A fresh DB with no enrichment tables logs and continues."""
+        from semantic_index.nightly_sync import _prune_enrichment_edges
+
+        db = tmp_path / "empty.db"
+        conn = sqlite3.connect(str(db))
+        conn.execute("CREATE TABLE artist (id INTEGER PRIMARY KEY)")
+        conn.close()
+        # Should not raise — both prune calls hit "no such table" and skip.
+        _prune_enrichment_edges(str(db), top_k=50)
+
+    def test_actually_prunes_both_tables(self, tmp_path):
+        """Top-K=2 against the complete graph on 5 artists leaves 7 edges in each
+        table (same survivor set as TestPruneSharedPersonnel.test_top_k_*)."""
+        from semantic_index.nightly_sync import _prune_enrichment_edges
+
+        db = tmp_path / "seeded.db"
+        _create_enrichment_test_db(db)
+
+        _prune_enrichment_edges(str(db), top_k=2)
+
+        conn = sqlite3.connect(str(db))
+        try:
+            n_personnel = conn.execute("SELECT COUNT(*) FROM shared_personnel").fetchone()[0]
+            n_label = conn.execute("SELECT COUNT(*) FROM label_family").fetchone()[0]
+        finally:
+            conn.close()
+        assert n_personnel == 7, f"shared_personnel: expected 7, got {n_personnel}"
+        assert n_label == 7, f"label_family: expected 7, got {n_label}"
+
+    def test_non_missing_operational_error_propagates(self, tmp_path, monkeypatch):
+        """OperationalError that isn't 'no such table' propagates so the outer
+        scheduler logs it with full traceback instead of silently classifying it
+        as 'table absent'."""
+        from semantic_index.nightly_sync import _prune_enrichment_edges
+
+        db = tmp_path / "seeded.db"
+        _create_enrichment_test_db(db)
+
+        def boom(*_args, **_kwargs):
+            raise sqlite3.OperationalError("database is locked")
+
+        monkeypatch.setattr("semantic_index.discogs_edges.prune_shared_personnel", boom)
+
+        with pytest.raises(sqlite3.OperationalError, match="database is locked"):
+            _prune_enrichment_edges(str(db), top_k=50)

--- a/tests/unit/test_sync_scheduler.py
+++ b/tests/unit/test_sync_scheduler.py
@@ -192,6 +192,7 @@ class TestSchedulerLoopCrashHandling:
                 dsn="postgresql://localhost/test",
                 min_count=2,
                 hour_utc=9,
+                enrichment_top_k=50,
             )
 
         crash_records = [


### PR DESCRIPTION
Closes #327

## Summary

- **`prune_shared_personnel` + `prune_label_family`**: mirror `prune_acoustic_similarity`, factored through a `_prune_symmetric_edge_table` helper that ranks by `shared_count` for personnel and `json_array_length(shared_labels)` for labels. Wired into `nightly_sync.py` as new Step 7c so the tables don't regrow.
- **Per-source SQL cap in `_neighbors_affinity_batch`**: each direction of each affinity query is wrapped in `ROW_NUMBER() OVER (PARTITION BY source ORDER BY weight DESC)` and filtered to `rn <= AFFINITY_PER_SOURCE_CAP` (100). Bounds in-degree regardless of hub centrality — popular artists no longer return thousands of edges per source-side `IN (...)` lookup.
- **Sentry sub-spans in `_neighbors_affinity_batch`**: parent `affinity.batch` span with `artist_count` / `limit` / `heat` annotations; one `db.sqlite` child per edge table with `rows` set; one `affinity.score` child with `candidate_neighbors` / `returned_neighbors`; one `db.sqlite hydrate_artists` child. No-op when no transaction is active.

## Production-side action already taken

The unpruned tables were applied via a one-shot SQL replicating `_prune_symmetric_edge_table` against the live DB (`shared_personnel` 12.2M → 2.55M, `label_family` 13.3M → 2.59M, file 3.3 GB → 1.48 GB after VACUUM). A reflinked backup is in place at `/data/wxyc_artist_graph.db.preprune-20260525-212821`. Single-artist `GET /graph/artists/{id}/neighbors?type=affinity` for Yo La Tengo dropped from 5.21 s cold to 0.21 s warm immediately. The cap addresses the remaining 5–7 s on the depth-2 hub-heavy batch path.

## Test plan

- [x] `pytest tests/` (1037 passed; new prune tests + faceted single-artist baseline)
- [x] `ruff check . && ruff format --check .`
- [x] `mypy semantic_index/`
- [x] Single-artist top-N affinity for Yo La Tengo (id=64) — unchanged: Kurt Vile, Daniel Johnston, Lambchop, Guided by Voices, The Mountain Goats
- [x] Capped affinity SQL timing on live production DB (Bill Withers second-hop, 10 source artists): 6,562 rows total vs 119,862 unbounded
- [ ] After deploy: Sentry sub-spans visible on next `POST /graph/artists/neighbors/batch` slow trace
- [ ] After deploy: depth-2 batch latency under 1 s on hub-heavy neighborhoods (re-time https://explore.wxyc.org/?artist=Bill+Withers&edge=affinity)

## Follow-ups (not in this PR)

- Production `wxyc_artist_graph.db` hasn't been written since May 4, byte-identical to the orphan `wxyc_artist_graph.tmp.1.db` from the same minute. The nightly sync has been failing silently for ~22 days despite `SYNC_ENABLED=true`. Wants its own issue.
- If the cap doesn't deliver sub-second cold cache on the depth-2 path, add covering indexes `(col_a, weight DESC)` / `(col_b, weight DESC)` for `shared_personnel`, `label_family`, `acoustic_similarity` so `ROW_NUMBER` can run index-only.