### PR TITLE
sync: log per-phase RSS to attribute the daily OOM kill

### DIFF
--- a/semantic_index/nightly_sync.py
+++ b/semantic_index/nightly_sync.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import argparse
 import logging
 import os
+import resource
 import shutil
 import sqlite3
 import sys
@@ -47,6 +48,35 @@ _TABLES_TO_CLEAR = ("dj_transition", "cross_reference")
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _log_memory(phase: str) -> None:
+    """Log current and peak resident memory at a pipeline checkpoint.
+
+    Peak (``ru_maxrss``) is the high-water mark since process start, so it is
+    monotonically non-decreasing across calls — the phase whose line bumps the
+    peak is the phase that allocated. Current RSS comes from
+    ``/proc/self/status`` (Linux only); when absent we log peak alone.
+
+    Linux reports ``ru_maxrss`` in KiB, macOS in bytes.
+    """
+    raw = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    peak_mib = raw / (1024 * 1024) if sys.platform == "darwin" else raw / 1024
+
+    current_mib: float | None = None
+    try:
+        with open("/proc/self/status") as f:
+            for line in f:
+                if line.startswith("VmRSS:"):
+                    current_mib = int(line.split()[1]) / 1024
+                    break
+    except FileNotFoundError:
+        pass
+
+    if current_mib is not None:
+        logger.info("[mem] %-30s current=%6.0f MiB  peak=%6.0f MiB", phase, current_mib, peak_mib)
+    else:
+        logger.info("[mem] %-30s peak=%6.0f MiB", phase, peak_mib)
 
 
 def _validate_sqlite(path: Path) -> bool:
@@ -228,8 +258,11 @@ def nightly_sync(args: argparse.Namespace) -> None:
     production_path = Path(args.db_path)
     min_count = args.min_count
 
+    _log_memory("baseline")
+
     # --- Step 1: Prepare working copy ---
     temp_path = prepare_working_db(production_path)
+    _log_memory("after prepare_working_db")
     swap_ok = False
 
     try:
@@ -244,6 +277,7 @@ def nightly_sync(args: argparse.Namespace) -> None:
             artist_xrefs,
             release_xrefs,
         ) = _load_from_pg(args.dsn)
+        _log_memory("after _load_from_pg")
 
         if not entries:
             logger.error("No flowsheet entries loaded from PG — aborting")
@@ -279,6 +313,7 @@ def nightly_sync(args: argparse.Namespace) -> None:
             post_counts.get("raw", 0),
             raw_pct,
         )
+        _log_memory("after artist_resolve")
 
         # --- Step 4: Adjacency + PMI ---
         logger.info("Extracting adjacency pairs...")
@@ -288,6 +323,7 @@ def nightly_sync(args: argparse.Namespace) -> None:
         logger.info("Computing PMI...")
         pmi_edges = compute_pmi(pairs, resolved_entries)
         logger.info("  %d PMI edges", len(pmi_edges))
+        _log_memory("after PMI")
 
         # --- Step 5: Artist stats ---
         code_to_genre = {c.id: c.genre_id for c in codes}
@@ -305,6 +341,7 @@ def nightly_sync(args: argparse.Namespace) -> None:
             genre_for_release=genre_for_release,
         )
         logger.info("  %d unique artists", len(artist_stats))
+        _log_memory("after artist_stats")
 
         # --- Step 6: Cross-references ---
         code_names = {c.id: c.presentation_name for c in codes}
@@ -315,6 +352,7 @@ def nightly_sync(args: argparse.Namespace) -> None:
         rel_xrefs = xref_extractor.extract_release_xrefs(release_xrefs)
         xref_edges = lc_xrefs + rel_xrefs
         logger.info("  %d cross-reference edges", len(xref_edges))
+        _log_memory("after cross_references")
 
         # --- Step 7: Pipeline DB + export ---
         logger.info("Opening pipeline DB: %s", temp_path)
@@ -337,6 +375,7 @@ def nightly_sync(args: argparse.Namespace) -> None:
             min_count=min_count,
             pipeline_db=pipeline_db,
         )
+        _log_memory("after export_sqlite")
 
         # --- Step 7b: Entity deduplication ---
         logger.info("Running entity deduplication...")
@@ -349,6 +388,7 @@ def nightly_sync(args: argparse.Namespace) -> None:
                 dedup_report.artists_reassigned,
                 dedup_report.edges_rekeyed,
             )
+        _log_memory("after dedup")
 
         # --- Step 7c: Prune preserved enrichment edges ---
         # Snapshot the mapping and close pipeline_db before the prune opens its own
@@ -359,6 +399,7 @@ def nightly_sync(args: argparse.Namespace) -> None:
         pipeline_db.close()
 
         _prune_enrichment_edges(str(temp_path), top_k=args.enrichment_top_k)
+        _log_memory("after enrichment_prune")
 
         # --- Step 8: Facet tables ---
         logger.info("Exporting facet tables...")
@@ -370,6 +411,7 @@ def nightly_sync(args: argparse.Namespace) -> None:
             show_dj_names=show_dj_names,
             adjacency_pairs=pairs,
         )
+        _log_memory("after facet_export")
 
         # --- Step 9: Graph metrics ---
 
@@ -380,9 +422,11 @@ def nightly_sync(args: argparse.Namespace) -> None:
             metrics.community_count,
             metrics.artists_scored,
         )
+        _log_memory("after graph_metrics")
 
         # --- Step 10: Checkpoint + swap ---
         checkpoint_and_close(str(temp_path))
+        _log_memory("after checkpoint")
 
         size_mb = temp_path.stat().st_size / (1024 * 1024)
         elapsed = time.time() - t0

--- a/semantic_index/nightly_sync.py
+++ b/semantic_index/nightly_sync.py
@@ -54,14 +54,16 @@ def _log_memory(phase: str) -> None:
     """Log current and peak resident memory at a pipeline checkpoint.
 
     Peak (``ru_maxrss``) is the high-water mark since process start, so it is
-    monotonically non-decreasing across calls — the phase whose line bumps the
+    monotonically non-decreasing across calls -- the phase whose line bumps the
     peak is the phase that allocated. Current RSS comes from
     ``/proc/self/status`` (Linux only); when absent we log peak alone.
 
-    Linux reports ``ru_maxrss`` in KiB, macOS in bytes.
+    Linux reports ``ru_maxrss`` in KiB; macOS/BSD report bytes. We branch on
+    "Linux = KiB" rather than "Darwin = bytes" so BSD-family dev hosts get
+    the right divisor (production is Linux either way).
     """
     raw = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
-    peak_mib = raw / (1024 * 1024) if sys.platform == "darwin" else raw / 1024
+    peak_mib = raw / 1024 if sys.platform.startswith("linux") else raw / (1024 * 1024)
 
     current_mib: float | None = None
     try:

--- a/semantic_index/nightly_sync.py
+++ b/semantic_index/nightly_sync.py
@@ -61,6 +61,10 @@ def _log_memory(phase: str) -> None:
     Linux reports ``ru_maxrss`` in KiB; macOS/BSD report bytes. We branch on
     "Linux = KiB" rather than "Darwin = bytes" so BSD-family dev hosts get
     the right divisor (production is Linux either way).
+
+    This helper is diagnostic — it must never crash the sync it is diagnosing.
+    Any failure reading ``/proc/self/status`` (missing file, permission denied,
+    malformed content) degrades silently to peak-only.
     """
     raw = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
     peak_mib = raw / 1024 if sys.platform.startswith("linux") else raw / (1024 * 1024)
@@ -72,7 +76,9 @@ def _log_memory(phase: str) -> None:
                 if line.startswith("VmRSS:"):
                     current_mib = int(line.split()[1]) / 1024
                     break
-    except FileNotFoundError:
+    except (OSError, ValueError, IndexError):
+        # OSError: /proc absent (macOS) or unreadable (hardened containers,
+        # AppArmor). ValueError/IndexError: VmRSS line truncated or malformed.
         pass
 
     if current_mib is not None:

--- a/tests/unit/test_nightly_sync.py
+++ b/tests/unit/test_nightly_sync.py
@@ -579,3 +579,81 @@ class TestPruneEnrichmentEdges:
 
         with pytest.raises(sqlite3.OperationalError, match="database is locked"):
             _prune_enrichment_edges(str(db), top_k=50)
+
+
+# ===========================================================================
+# _log_memory (per-phase RSS instrumentation for WXYC/semantic-index#329)
+# ===========================================================================
+
+
+class TestLogMemory:
+    """``_log_memory`` is the diagnostic hook used to attribute the daily OOM
+    kill to a phase. The output is grep-able — production log analysis searches
+    for ``[mem]`` — so the format is a stable contract."""
+
+    def test_emits_grep_marker_and_peak_value(self, caplog):
+        import logging
+
+        from semantic_index.nightly_sync import _log_memory
+
+        with caplog.at_level(logging.INFO, logger="semantic_index.nightly_sync"):
+            _log_memory("phase-under-test")
+
+        messages = [r.getMessage() for r in caplog.records]
+        assert any(
+            "[mem] phase-under-test" in m and "peak=" in m and "MiB" in m for m in messages
+        ), f"missing structured mem line: {messages!r}"
+
+    def test_includes_current_when_proc_status_available(self, caplog, monkeypatch):
+        """When ``/proc/self/status`` is readable (real Linux or a stub on
+        macOS), the log line also reports ``current=`` so per-phase reclamation
+        is visible, not just the high-water mark."""
+        import builtins
+        import logging
+        from io import StringIO
+
+        from semantic_index.nightly_sync import _log_memory
+
+        original_open = builtins.open
+
+        def fake_open(path, *args, **kwargs):
+            if str(path) == "/proc/self/status":
+                return StringIO("VmPeak:\t  500000 kB\nVmRSS:\t  102400 kB\n")
+            return original_open(path, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "open", fake_open)
+
+        with caplog.at_level(logging.INFO, logger="semantic_index.nightly_sync"):
+            _log_memory("with-vmrss")
+
+        messages = [r.getMessage() for r in caplog.records]
+        assert any(
+            "[mem] with-vmrss" in m and "current=" in m and "peak=" in m for m in messages
+        ), f"expected current+peak line: {messages!r}"
+
+    def test_falls_back_to_peak_only_when_proc_missing(self, caplog, monkeypatch):
+        """On macOS / FreeBSD / containers without /proc, the helper degrades to
+        peak-only rather than crashing the sync."""
+        import builtins
+        import logging
+
+        from semantic_index.nightly_sync import _log_memory
+
+        original_open = builtins.open
+
+        def fake_open(path, *args, **kwargs):
+            if str(path) == "/proc/self/status":
+                raise FileNotFoundError(path)
+            return original_open(path, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "open", fake_open)
+
+        with caplog.at_level(logging.INFO, logger="semantic_index.nightly_sync"):
+            _log_memory("no-proc")
+
+        messages = [r.getMessage() for r in caplog.records]
+        peak_only = [m for m in messages if "[mem] no-proc" in m]
+        assert peak_only, f"no [mem] line at all: {messages!r}"
+        assert all("current=" not in m for m in peak_only), (
+            f"unexpected current= when /proc unavailable: {peak_only!r}"
+        )

--- a/tests/unit/test_nightly_sync.py
+++ b/tests/unit/test_nightly_sync.py
@@ -657,3 +657,105 @@ class TestLogMemory:
         assert all("current=" not in m for m in peak_only), (
             f"unexpected current= when /proc unavailable: {peak_only!r}"
         )
+
+    @pytest.mark.parametrize(
+        ("platform", "raw_value", "expected_mib"),
+        [
+            # Linux: ru_maxrss is KiB. 1 GiB ru_maxrss = 1024 MiB.
+            ("linux", 1024 * 1024, 1024.0),
+            ("linux2", 512 * 1024, 512.0),
+            # macOS / BSD: ru_maxrss is bytes. 1 GiB ru_maxrss = 1024 MiB.
+            ("darwin", 1024 * 1024 * 1024, 1024.0),
+            ("freebsd14", 512 * 1024 * 1024, 512.0),
+        ],
+    )
+    def test_unit_conversion_branches_on_platform(
+        self, caplog, monkeypatch, platform, raw_value, expected_mib
+    ):
+        """Regression test for the KiB-vs-bytes split. ``ru_maxrss`` is in KiB on
+        Linux and bytes on BSD-family (Darwin included); a refactor that
+        collapses the branch would render incorrect peak values in production."""
+        import builtins
+        import logging
+        from io import StringIO
+
+        import semantic_index.nightly_sync as ns
+
+        monkeypatch.setattr(ns.sys, "platform", platform)
+        monkeypatch.setattr(
+            ns.resource,
+            "getrusage",
+            lambda _who: type("Rusage", (), {"ru_maxrss": raw_value})(),
+        )
+
+        # Stub /proc so the test focuses on peak conversion regardless of host.
+        original_open = builtins.open
+
+        def fake_open(path, *args, **kwargs):
+            if str(path) == "/proc/self/status":
+                return StringIO("VmRSS:\t  0 kB\n")
+            return original_open(path, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "open", fake_open)
+
+        with caplog.at_level(logging.INFO, logger="semantic_index.nightly_sync"):
+            ns._log_memory("unit-test")
+
+        messages = [r.getMessage() for r in caplog.records if "[mem] unit-test" in r.getMessage()]
+        assert messages, f"no [mem] line emitted: {[r.getMessage() for r in caplog.records]!r}"
+        assert f"peak={expected_mib:6.0f} MiB" in messages[0], (
+            f"expected peak={expected_mib} MiB on {platform!r}, got: {messages[0]!r}"
+        )
+
+    def test_falls_back_to_peak_only_when_proc_unreadable(self, caplog, monkeypatch):
+        """Hardened containers / AppArmor can make ``/proc/self/status``
+        unreadable (PermissionError). The helper must degrade silently — a
+        diagnostic helper crashing the sync would mask the OOM signal we're
+        trying to capture."""
+        import builtins
+        import logging
+
+        from semantic_index.nightly_sync import _log_memory
+
+        original_open = builtins.open
+
+        def fake_open(path, *args, **kwargs):
+            if str(path) == "/proc/self/status":
+                raise PermissionError(path)
+            return original_open(path, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "open", fake_open)
+
+        with caplog.at_level(logging.INFO, logger="semantic_index.nightly_sync"):
+            _log_memory("perm-denied")
+
+        peak_only = [
+            r.getMessage() for r in caplog.records if "[mem] perm-denied" in r.getMessage()
+        ]
+        assert peak_only, "PermissionError should not crash the helper"
+        assert all("current=" not in m for m in peak_only)
+
+    def test_falls_back_to_peak_only_when_proc_malformed(self, caplog, monkeypatch):
+        """A truncated or otherwise non-integer VmRSS value must not crash the
+        sync — degrade to peak-only instead."""
+        import builtins
+        import logging
+        from io import StringIO
+
+        from semantic_index.nightly_sync import _log_memory
+
+        original_open = builtins.open
+
+        def fake_open(path, *args, **kwargs):
+            if str(path) == "/proc/self/status":
+                return StringIO("VmRSS:\tnot-a-number kB\n")
+            return original_open(path, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "open", fake_open)
+
+        with caplog.at_level(logging.INFO, logger="semantic_index.nightly_sync"):
+            _log_memory("malformed")
+
+        peak_only = [r.getMessage() for r in caplog.records if "[mem] malformed" in r.getMessage()]
+        assert peak_only, "malformed VmRSS should not crash the helper"
+        assert all("current=" not in m for m in peak_only)


### PR DESCRIPTION
Closes #330

## Summary

Adds `_log_memory(phase)` to `nightly_sync.py` and sprinkles 12 call sites covering every pipeline phase. Each call emits a single grep-able `[mem]` log line with current and peak RSS, so reading the production log for one sync run will pinpoint which phase blows past the 1 GiB cgroup cap and triggers the daily SIGKILL documented in #329.

Stdlib only — `resource.getrusage` for peak, `/proc/self/status` for current. Handles the KiB/bytes unit difference between Linux and macOS; degrades to peak-only when `/proc` isn't available (macOS dev).

## Why this and not a fix yet

The five candidate mitigations (bump memory-swap, NetworkX→igraph, stream dedup, separate sync container, drop intermediates) all cost different amounts of work for different amounts of margin. Without per-phase RSS, we can't tell whether the peak lives in `_load_from_pg` (suggests streaming), `graph_metrics` (suggests igraph), or somewhere unexpected.

## Test plan

- [x] `pytest tests/unit/test_nightly_sync.py` — 26 passed (3 new + 23 existing)
- [x] `pytest tests/unit/` — 1015 passed, 1 deselected, no regressions
- [x] `ruff format` + `ruff check` + `mypy` clean
- [ ] After merge + deploy, capture the 09:00 UTC log; one run produces the first profile

## Sample expected output

```
[mem] baseline                       current=    65 MiB  peak=    72 MiB
[mem] after _load_from_pg            current=   480 MiB  peak=   495 MiB
[mem] after artist_resolve           current=   720 MiB  peak=   735 MiB
[mem] after PMI                      current=   780 MiB  peak=   810 MiB
[mem] after graph_metrics            current=  1020 MiB  peak=  1024 MiB   <-- the suspect
```