### PR TITLE
deploy: bump container --memory-swap to 2g for nightly sync headroom

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -93,10 +93,15 @@ jobs:
             docker rm semantic-index || true
 
             echo "Starting new container..."
-            # WORKERS=1 + 1 GiB cgroup cap: post-2026-05-17 OOM-wedge hardening (BS#937).
-            # Pre-fix: 4 uvicorn workers x ~370 MB copy of NetworkX + Essentia each = 1.48 GB peak,
-            # unbounded, global-OOM-killing the t3.small host. cgroup cap keeps any future
-            # blowup scoped to this container so the global OOM-killer can't take the host down again.
+            # WORKERS=1 + 1 GiB RAM + 1 GiB swap cgroup cap: post-2026-05-17 OOM-wedge
+            # hardening (BS#937) plus #329 nightly-sync mitigation. Pre-2026-05-17:
+            # 4 uvicorn workers x ~370 MB NetworkX + Essentia each = 1.48 GB peak,
+            # unbounded, global-OOM-killing the t3.small host. The RAM cap keeps any
+            # blowup scoped to this container; the 1 GiB swap headroom (separate from
+            # the RAM cap because --memory-swap is total, not extra) lets the daily
+            # nightly_sync (#329) burst past the RAM cap during _load_from_pg / dedup /
+            # graph_metrics without the kernel killing the process. Host (t3.small,
+            # 2 GiB RAM + 2 GiB swap) has room: 5 containers, sync runs ~5 min/day.
             docker run -d \
               --name semantic-index \
               -p 8083:8083 \
@@ -105,7 +110,7 @@ jobs:
               --env-file .env.semantic-index \
               -e WORKERS=1 \
               --memory 1g \
-              --memory-swap 1g \
+              --memory-swap 2g \
               $IMAGE_URI
 
             echo "Waiting for health check..."

--- a/scripts/check_sync_profile.sh
+++ b/scripts/check_sync_profile.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Pull the [mem] profile from the latest nightly_sync run on production and
+# summarize whether sync succeeded or was OOM-killed. Designed to be run by
+# hand any time after ~09:10 UTC, or wired to an OS-level cron.
+#
+# Background: WXYC/semantic-index#329 -- the nightly sync was OOM-killed at
+# 09:00 UTC every day until per-phase RSS instrumentation (PR #331) and a
+# --memory-swap bump (PR #332) shipped. This script reads the resulting
+# [mem]<phase> current=N peak=N MiB log lines to identify which phase
+# allocates the most, so we can pick a targeted memory-reduction fix.
+#
+# Requirements: ssh access to wxyc-ec2 (works with the user's SSH config).
+
+set -euo pipefail
+
+SINCE="${1:-$(date -u -v-1H +%Y-%m-%dT%H:%M:%S 2>/dev/null || date -u --date='1 hour ago' +%Y-%m-%dT%H:%M:%S)}"
+
+echo "=== Container memory cap ==="
+ssh wxyc-ec2 'docker inspect semantic-index --format "{{.HostConfig.Memory}} bytes RAM / {{.HostConfig.MemorySwap}} bytes total (RAM+swap)"' \
+    | awk '{printf "%.2f GiB RAM / %.2f GiB total\n", $1/1073741824, $4/1073741824}'
+
+echo ""
+echo "=== [mem] profile since $SINCE UTC ==="
+PROFILE=$(ssh wxyc-ec2 "docker logs semantic-index --since $SINCE 2>&1 | grep -E '\[mem\]|Pipeline complete|Atomic swap'") || true
+echo "$PROFILE"
+
+LINE_COUNT=$(echo "$PROFILE" | grep -c '\[mem\]' || true)
+echo ""
+echo "[mem] lines emitted: $LINE_COUNT"
+if [ "$LINE_COUNT" = "12" ] && echo "$PROFILE" | grep -q "Atomic swap"; then
+    echo "STATUS: sync completed successfully"
+elif [ "$LINE_COUNT" = "0" ]; then
+    echo "STATUS: no [mem] lines found -- sync may not have started, or container restarted recently. Check 'docker logs semantic-index --since $SINCE | head -50'"
+else
+    echo "STATUS: sync killed mid-pipeline after $LINE_COUNT phase markers"
+fi
+
+echo ""
+echo "=== Production DB mtime ==="
+ssh wxyc-ec2 'stat -c "%y  %s bytes" /home/ec2-user/semantic-index-data/wxyc_artist_graph.db'
+echo "  (mtime today = swap succeeded; mtime stale = sync did not complete)"
+
+echo ""
+echo "=== Recent OOM kills (last 3) ==="
+ssh wxyc-ec2 'sudo dmesg -T 2>/dev/null | grep -iE "killed process.*uvicorn" | tail -3' || \
+    echo "  (need passwordless sudo for dmesg; skip)"
+
+echo ""
+echo "=== Peak phase ranking ==="
+echo "$PROFILE" | grep '\[mem\]' \
+    | awk -F'peak=' '{phase=$1; sub(/.*\[mem\] +/, "", phase); sub(/ +current.*/, "", phase); peak=$2; sub(/ +MiB.*/, "", peak); printf "  %s peak=%s MiB\n", phase, peak}' \
+    | sort -k3 -n -r \
+    | head -5
+
+cat <<EOF
+
+=== Next-step decision tree ===
+  If "after graph_metrics" is the peak: file PR to swap NetworkX for igraph
+    in semantic_index/graph_metrics.py (~5-10x memory reduction for Louvain /
+    betweenness / PageRank).
+  If "after _load_from_pg" is the peak: stream/chunk loaders in
+    semantic_index/pg_source.py via server-side cursors.
+  If "after dedup" is the peak: rewrite PipelineDB.deduplicate_by_qid() to
+    use SQL UPDATE rather than materializing edges in Python.
+  If no single phase dominant (peak grows steadily across many): split sync
+    into a one-shot container so it gets the full host's memory.
+  If sync succeeded and peak <= 1.5 GiB: swap bump is fine long-term; close
+    #329 and just add a CloudWatch alarm for "DB mtime > 36h" as a backstop.
+EOF


### PR DESCRIPTION
Closes #332
Related to #329

## Summary

Bumps the production container from `--memory-swap 1g` (zero swap, since `--memory-swap` is the *total* of RAM + swap, not extra) to `--memory-swap 2g` (1 GiB of swap). Same `--memory 1g` RAM cap so API steady-state is unchanged; only the daily nightly sync's transient burst gets the extra space.

This is an interim mitigation for the daily 09:00 UTC OOM kill documented in #329. After this deploys, tomorrow's sync should complete and produce the first full 12-line `[mem]` profile from PR #331's instrumentation — that profile tells us where to attack memory long-term (NetworkX→igraph in `graph_metrics`, chunked `_load_from_pg`, or splitting sync into a separate one-shot container).

Also adds `scripts/check_sync_profile.sh` — pulls the profile from production after the next sync and prints a phase ranking + decision tree.

## Why now

Without the swap headroom, the sync still gets SIGKILLed at minute ~6 every day and we only see 3-4 `[mem]` lines before the kill (the helper-formatted output for phases up to `_load_from_pg`, maybe `artist_resolve`). With the swap, the sync completes and we see all 12 lines, plus we get a successful DB swap and the graph is current again for the first time in 22 days.

## Test plan

- [x] `actionlint .github/workflows/deploy.yml` (pre-commit hook ran clean)
- [ ] After merge + deploy lands before 09:00 UTC tomorrow, observe container starts with `--memory-swap 2g`: `ssh wxyc-ec2 'docker inspect semantic-index --format "{{.HostConfig.MemorySwap}}"'` returns `2147483648`
- [ ] After 09:00 UTC sync window: `./scripts/check_sync_profile.sh` reports "sync completed successfully" with 12 `[mem]` lines
- [ ] Production DB mtime moves to within the last 24 h

## Risk

Low. Host (t3.small, 2 GiB RAM + 2 GiB swap, 5 containers) has 1.6 GiB free swap currently. Granting 1 GiB of that to semantic-index leaves 600 MiB headroom for the other containers' burstable swap. Reversible by re-pinning swap back to 1g.