### PR TITLE
pg_source: iterate flowsheet cursor instead of fetchall (real fix for #329)

### DIFF
--- a/semantic_index/pg_source.py
+++ b/semantic_index/pg_source.py
@@ -156,16 +156,24 @@ def load_flowsheet_entries(conn: Any) -> list[FlowsheetEntry]:
     - ``add_time`` timestamptz → epoch seconds int (via EXTRACT(EPOCH ...))
     - ``entry_type`` enum 'track' → ``entry_type_code = 1``
 
+    Iterates the cursor directly instead of calling ``.fetchall()``: for the
+    ~1M-row production flowsheet, ``.fetchall()`` materialises every
+    ``dict_row`` in Python before the loop even starts, doubling peak heap
+    with the ``FlowsheetEntry`` list that comes after. Iterating builds each
+    ``FlowsheetEntry`` from a single transient dict, dropping peak by
+    hundreds of MiB. See WXYC/semantic-index#329 -- the 2026-05-27 cgroup
+    OOM kill at total-vm=1.98 GiB landed inside this function.
+
     Args:
         conn: psycopg connection (dict_row factory).
 
     Returns:
         List of FlowsheetEntry, ordered by (show_id, play_order).
     """
-    rows = conn.execute(_FLOWSHEET_SQL).fetchall()
+    cursor = conn.execute(_FLOWSHEET_SQL)
     entries: list[FlowsheetEntry] = []
 
-    for row in rows:
+    for row in cursor:
         album_id = row["album_id"]
         add_time_epoch = row["add_time_epoch"]
 

--- a/semantic_index/pg_source.py
+++ b/semantic_index/pg_source.py
@@ -156,12 +156,16 @@ def load_flowsheet_entries(conn: Any) -> list[FlowsheetEntry]:
     - ``add_time`` timestamptz → epoch seconds int (via EXTRACT(EPOCH ...))
     - ``entry_type`` enum 'track' → ``entry_type_code = 1``
 
-    Iterates the cursor directly instead of calling ``.fetchall()``: for the
-    ~1M-row production flowsheet, ``.fetchall()`` materialises every
-    ``dict_row`` in Python before the loop even starts, doubling peak heap
-    with the ``FlowsheetEntry`` list that comes after. Iterating builds each
-    ``FlowsheetEntry`` from a single transient dict, dropping peak by
-    hundreds of MiB. See WXYC/semantic-index#329 -- the 2026-05-27 cgroup
+    Iterates the cursor directly instead of calling ``.fetchall()``. With
+    psycopg3's default client-side cursor, ``.execute()`` still buffers the
+    full result inside libpq's C memory either way -- the savings here are
+    Python-heap only: we avoid building the intermediate ``list[dict_row]``
+    that would otherwise coexist with the ``FlowsheetEntry`` list at peak.
+    For the ~1M-row production flowsheet that's tens of MiB of list
+    overhead plus the avoided dict-vs-FlowsheetEntry overlap during the
+    loop. Freeing libpq's buffer requires a true server-side cursor
+    (``conn.cursor(name=...)`` inside an explicit transaction) -- tracked
+    as a follow-up to WXYC/semantic-index#329, where the 2026-05-27 cgroup
     OOM kill at total-vm=1.98 GiB landed inside this function.
 
     Args:

--- a/tests/unit/test_pg_source.py
+++ b/tests/unit/test_pg_source.py
@@ -22,11 +22,16 @@ def _mock_conn_with_rows(rows: list[dict]) -> MagicMock:
     supports both shapes because some loaders use ``.fetchall()`` (small
     tables) and ``load_flowsheet_entries`` iterates the cursor directly to
     avoid materialising all rows at peak (see #329).
+
+    ``__iter__`` uses ``side_effect`` (not ``return_value``) so each call
+    returns a fresh iterator -- a test that iterates the cursor twice (or
+    calls ``.fetchall()`` and iterates) won't see a silently-exhausted
+    sequence on the second pass.
     """
     mock_conn = MagicMock()
     mock_cursor = MagicMock()
     mock_cursor.fetchall.return_value = rows
-    mock_cursor.__iter__.return_value = iter(rows)
+    mock_cursor.__iter__.side_effect = lambda: iter(rows)
     mock_conn.execute.return_value = mock_cursor
     return mock_conn
 
@@ -397,7 +402,7 @@ class TestLoadFlowsheetEntries:
         mock_cursor.fetchall.side_effect = AssertionError(
             "load_flowsheet_entries must iterate the cursor, not fetchall (#329)"
         )
-        mock_cursor.__iter__.return_value = iter([row])
+        mock_cursor.__iter__.side_effect = lambda: iter([row])
         mock_conn.execute.return_value = mock_cursor
 
         entries = load_flowsheet_entries(mock_conn)

--- a/tests/unit/test_pg_source.py
+++ b/tests/unit/test_pg_source.py
@@ -15,13 +15,18 @@ from semantic_index.models import LibraryRelease
 
 
 def _mock_conn_with_rows(rows: list[dict]) -> MagicMock:
-    """Create a mock psycopg connection whose execute().fetchall() returns *rows*.
+    """Create a mock psycopg connection whose execute() returns a cursor
+    that *both* ``.fetchall()``s and iterates to *rows*.
 
-    Each row is a dict (simulating psycopg's dict_row factory).
+    Each row is a dict (simulating psycopg's dict_row factory). Cursor
+    supports both shapes because some loaders use ``.fetchall()`` (small
+    tables) and ``load_flowsheet_entries`` iterates the cursor directly to
+    avoid materialising all rows at peak (see #329).
     """
     mock_conn = MagicMock()
     mock_cursor = MagicMock()
     mock_cursor.fetchall.return_value = rows
+    mock_cursor.__iter__.return_value = iter(rows)
     mock_conn.execute.return_value = mock_cursor
     return mock_conn
 
@@ -363,6 +368,43 @@ class TestLoadFlowsheetEntries:
         conn = _mock_conn_with_rows([])
 
         assert load_flowsheet_entries(conn) == []
+
+    def test_iterates_cursor_does_not_call_fetchall(self):
+        """The cursor must be iterated, never ``.fetchall()``-ed. Holding all
+        dict_row rows in memory before constructing FlowsheetEntry instances
+        roughly doubles peak heap; for the production ~1M-row flowsheet that
+        was the difference between a clean sync and the 2026-05-27 cgroup
+        OOM kill. Pinned for WXYC/semantic-index#329 -- this property must
+        not regress even when someone "simplifies" the function later."""
+        from semantic_index.pg_source import load_flowsheet_entries
+
+        row = {
+            "id": 1,
+            "artist_name": "Juana Molina",
+            "track_title": "la paradoja",
+            "album_title": "DOGA",
+            "record_label": "Sonamos",
+            "show_id": 100,
+            "play_order": 1,
+            "album_id": None,
+            "request_flag": False,
+            "add_time_epoch": 1577836800,
+            "legacy_entry_id": None,
+        }
+
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_cursor.fetchall.side_effect = AssertionError(
+            "load_flowsheet_entries must iterate the cursor, not fetchall (#329)"
+        )
+        mock_cursor.__iter__.return_value = iter([row])
+        mock_conn.execute.return_value = mock_cursor
+
+        entries = load_flowsheet_entries(mock_conn)
+
+        assert len(entries) == 1
+        assert entries[0].artist_name == "Juana Molina"
+        mock_cursor.fetchall.assert_not_called()
 
 
 # ===========================================================================


### PR DESCRIPTION
Closes #336
Related to #329

## Summary

Replaces `rows = conn.execute(_FLOWSHEET_SQL).fetchall()` with `for row in conn.execute(_FLOWSHEET_SQL):` in `load_flowsheet_entries`. Same return shape, no downstream API changes. Cuts peak Python heap by hundreds of MiB on the ~1M-row production flowsheet because the dict_row list no longer coexists with the FlowsheetEntry list at peak.

This is the real fix for the daily OOM kills documented in #329. Once deployed and validated, the bridge swap bump (#334 / PR #335) can tighten back down to `--memory-swap 1g`.

## Why scoped to flowsheet only

The 2026-05-27 OOM kill landed inside `_load_from_pg` between `Loaded catalog` and `[mem] after _load_from_pg`. Catalog is 24K artists + 64K releases — modest. Flowsheet is ~1M rows. The other loaders (`load_genres`, `load_catalog`, `load_shows`, `load_cross_references`) load tables 1-3 orders of magnitude smaller; their `.fetchall()` is fine. Surgical fix > broad rewrite.

## Test plan

- [x] `pytest tests/unit/test_pg_source.py` — 21 passed (20 existing + 1 new regression test)
- [x] `pytest tests/unit/` — 1022 passed, 1 deselected, no regressions
- [x] `ruff format` + `ruff check` + `mypy` clean
- [ ] After merge + deploy + manual sync re-trigger: log shows `[mem] after _load_from_pg` with peak < 800 MiB, sync completes all 12 phases + `Atomic swap complete`
- [ ] After validation: file follow-up PR to tighten `--memory-swap` back to 1g

## Regression guard

New `test_iterates_cursor_does_not_call_fetchall` makes `.fetchall()` raise an AssertionError; the test still passes because the function only iterates the cursor. A future "simplification" that reverts to `.fetchall()` will fail this test loudly.

## Files changed

```
semantic_index/pg_source.py    | 12 ++++++++----
tests/unit/test_pg_source.py   | 46 ++++++++++++++++++++++++++++++++++++++++++--
2 files changed, 54 insertions(+), 4 deletions(-)
```