### PR TITLE
deploy: revert --memory-swap to 1g after host-thrash incident

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -93,18 +93,27 @@ jobs:
             docker rm semantic-index || true
 
             echo "Starting new container..."
-            # WORKERS=1 + 1 GiB RAM + 2 GiB swap cgroup cap: post-2026-05-17 OOM-wedge
-            # hardening (BS#937) plus #329 nightly-sync mitigation. Pre-2026-05-17:
-            # 4 uvicorn workers x ~370 MB NetworkX + Essentia each = 1.48 GB peak,
-            # unbounded, global-OOM-killing the t3.small host. The RAM cap keeps API
-            # steady-state scoped; the 2 GiB swap headroom (separate from RAM because
-            # --memory-swap is total, not extra) lets the daily nightly_sync (#329)
-            # burst past the RAM cap during _load_from_pg without SIGKILL.
-            # 2026-05-27: bumped from 2g -> 3g total after the 2g cap still OOMed at
-            # total-vm=1.98 GiB during the flowsheet load. The pg_source.py chunked-
-            # load PR is the real fix; this is bridge headroom until that lands and
-            # we can tighten back down. Host (t3.small, 2 GiB RAM + 2 GiB swap) has
-            # 1.5 GiB free swap, so granting another 1 GiB to semantic-index is fine.
+            # WORKERS=1 + 1 GiB RAM, NO swap (--memory-swap == --memory) per-cgroup cap:
+            # post-2026-05-17 OOM-wedge hardening (BS#937) plus #329 nightly-sync
+            # containment. Pre-2026-05-17: 4 uvicorn workers x ~370 MB NetworkX +
+            # Essentia each = 1.48 GB peak, unbounded, global-OOM-killing the
+            # t3.small host. The RAM cap keeps API steady-state scoped and forces
+            # the cgroup OOM killer to fire CONTAINED if nightly_sync (#329) blows
+            # past 1 GiB -- which kills just the sync process, API survives, graph
+            # stays stale until #338's server-side cursor lands.
+            #
+            # IMPORTANT: do NOT raise --memory-swap above --memory on this host.
+            # Granting the container access to host swap converts a contained
+            # cgroup OOM into a host-wide swap-thrash death spiral: the sync
+            # exhausts the host's 2 GiB swap pool without hitting its cgroup cap,
+            # starves the OS + other 4 containers, and forces an EC2 status-check
+            # reboot of the whole instance. Observed 2026-05-27 with --memory-swap
+            # 3g (PR #335): host reboot at 16:28 UTC; sssd watchdog kills at
+            # 16:18 UTC; journald silent from 16:19 UTC; no cgroup OOM record
+            # (sync grew into host swap rather than hitting the cgroup cap).
+            # Reverted in this commit. The real fix is reducing sync's peak memory
+            # via #338 (server-side cursor + FlowsheetEntry slotting), not giving
+            # it more rope.
             docker run -d \
               --name semantic-index \
               -p 8083:8083 \
@@ -113,7 +122,7 @@ jobs:
               --env-file .env.semantic-index \
               -e WORKERS=1 \
               --memory 1g \
-              --memory-swap 3g \
+              --memory-swap 1g \
               $IMAGE_URI
 
             echo "Waiting for health check..."


### PR DESCRIPTION
Closes #339
Related to #329

## Summary

Reverts `--memory-swap 3g` (PR #335) AND `--memory-swap 2g` (PR #333) all the way back to `--memory-swap 1g` (no swap). Restores contained-cgroup-OOM behavior so sync's memory blowup kills only the sync process, not the whole host.

## Incident this PR addresses

2026-05-27: Manual `nightly_sync` re-trigger under the 3g swap cap drove the t3.small into swap-thrash; host force-rebooted at 16:28 UTC. No cgroup OOM-kill record (sync stayed under 3 GiB cgroup limit) but the host's 2 GiB swap pool was exhausted, starving the OS (sssd watchdog kills at 16:18) and the other 4 containers. Full chronology in #339.

## Why no swap is safer than some swap

Any `--memory-swap > --memory` lets the container consume host swap. On t3.small (2 GiB RAM + 2 GiB swap, 5 containers), giving one container access to 2 GiB swap is mechanically "this container can eat all host swap." When it does, the OS gets starved and the kernel/EC2 watchdog reboots the instance.

Contained cgroup OOM (this revert): sync dies cleanly, API survives, graph stays stale.
Host-wide swap thrash (3g cap): whole instance reboots, all 5 containers down for ~2 min.

The contained failure is strictly better as a holding pattern.

## Test plan

- [x] `actionlint .github/workflows/deploy.yml` (pre-commit ran clean)
- [ ] Merge + deploy lands before 2026-05-28 09:00 UTC
- [ ] After deploy: `ssh wxyc-ec2 'docker inspect semantic-index --format "{{.HostConfig.MemorySwap}}"'` returns `1073741824`
- [ ] 2026-05-28 09:00 UTC scheduled sync triggers a contained cgroup OOM (dmesg `Killed process.*python`) — NOT a host reboot
- [ ] `uptime` continues monotonically (no fresh boot from 16:28 onward)

## Risk

Zero risk to the host; revert restores known-good behavior (the 22-day status quo before the swap bumps). The cost is: sync still fails daily until #338 lands, so the graph stays stale. That's the same situation we were in on 2026-05-26 — the API has been serving stale data since 2026-05-04 and nobody noticed in that window because the staleness isn't user-visible at the timescales involved.

## Real fix tracker

#338 — server-side psycopg cursor + `FlowsheetEntry` slotting. Reduces sync's peak memory under 1 GiB so the cgroup OOM never fires and we can leave swap at 1g permanently.