### PR TITLE
fix: stream catalog + xref loaders and slot catalog models (#345)

### DIFF
--- a/semantic_index/models.py
+++ b/semantic_index/models.py
@@ -32,15 +32,29 @@ class FlowsheetEntry:
     start_time: int | None = None
 
 
-class LibraryRelease(BaseModel):
-    """A row from LIBRARY_RELEASE — only the fields needed for Tier 1 resolution."""
+@dataclass(slots=True, frozen=True)
+class LibraryRelease:
+    """A row from LIBRARY_RELEASE — only the fields needed for Tier 1 resolution.
+
+    Slotted + frozen for the same reason as :class:`FlowsheetEntry`: ~196K
+    instances coexist at sync peak and stay resident through resolver
+    construction, so per-instance dict allocation would dominate resident heap.
+    Plain dataclass with no runtime type validation -- ``pg_source.load_catalog``
+    types every field via the SQL projection.
+    """
 
     id: int
     library_code_id: int
 
 
-class LibraryCode(BaseModel):
-    """A row from LIBRARY_CODE — canonical artist name and genre."""
+@dataclass(slots=True, frozen=True)
+class LibraryCode:
+    """A row from LIBRARY_CODE — canonical artist name and genre.
+
+    Slotted + frozen for the same reason as :class:`LibraryRelease`; ~462K
+    instances coexist at sync peak and are held by ``ArtistResolver`` through
+    graph_metrics.
+    """
 
     id: int
     genre_id: int

--- a/semantic_index/pg_source.py
+++ b/semantic_index/pg_source.py
@@ -20,6 +20,7 @@ Requires a psycopg connection with ``dict_row`` row factory.
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from typing import Any
 
 from semantic_index.models import FlowsheetEntry, LibraryCode, LibraryRelease
@@ -87,6 +88,37 @@ FROM wxyc_schema.artist_library_crossreference
 
 
 # ---------------------------------------------------------------------------
+# Streaming helper
+# ---------------------------------------------------------------------------
+
+
+def _stream_into_list[T](conn: Any, name: str, sql: str, build: Callable[[Any], T]) -> list[T]:
+    """Run ``sql`` through a named (server-side) cursor and build a list of rows.
+
+    libpq fetches rows in ``_ITERSIZE`` chunks rather than buffering the full
+    result set in C memory, and *build* is applied per row so only the built
+    objects are retained -- the dict rows are freed incrementally. This is the
+    memory-bounding pattern the high-cardinality loaders need to fit the sync
+    under the 1 GiB cgroup cap (WXYC/semantic-index#345).
+
+    A named cursor is used inside an explicit transaction because the
+    connection is autocommit=True (named cursors error outside a transaction on
+    autocommit connections), and ``WITHOUT HOLD`` is the psycopg3 default, so
+    iteration MUST complete inside the ``with`` block -- hence materialising
+    into a list here rather than yielding rows to the caller.
+
+    Centralising this means every high-cardinality loader gets the
+    ``itersize`` + transaction guarantee structurally; a caller can't forget
+    to set ``itersize`` (whose psycopg3 default of 100 would reintroduce
+    thousands of round-trips).
+    """
+    with conn.transaction(), conn.cursor(name=name) as cursor:
+        cursor.itersize = _ITERSIZE
+        cursor.execute(sql)
+        return [build(row) for row in cursor]
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -115,13 +147,10 @@ def load_catalog(conn: Any) -> tuple[list[LibraryCode], list[LibraryRelease]]:
     ``artist_genre_code``) is used. Artists without a genre entry get
     ``genre_id=0``.
 
-    Each of the three queries (genre xref, artists, releases) streams through
-    its own named (server-side) cursor inside an explicit transaction so libpq
-    fetches rows in ``_ITERSIZE`` chunks rather than buffering the full result
-    set, and the target objects are built during iteration so the dict rows are
-    freed incrementally. This is the loader the nightly sync OOM-died in
-    (WXYC/semantic-index#345). See ``load_flowsheet_entries`` for the full
-    transaction / WITHOUT HOLD rationale.
+    All three queries (genre xref, artists, releases) stream through named
+    (server-side) cursors via :func:`_stream_into_list` so libpq fetches in
+    ``_ITERSIZE`` chunks rather than buffering each full result set. This is
+    the loader the nightly sync OOM-died in (WXYC/semantic-index#345).
 
     Args:
         conn: psycopg connection (dict_row factory, autocommit=True).
@@ -129,7 +158,9 @@ def load_catalog(conn: Any) -> tuple[list[LibraryCode], list[LibraryRelease]]:
     Returns:
         Tuple of (codes, releases).
     """
-    # Build artist_id → genre_id mapping (first genre wins).
+    # Build artist_id → genre_id mapping (first genre wins). Inlined rather
+    # than via _stream_into_list because it accumulates a dedup dict, not a
+    # list, but uses the same named-cursor / itersize streaming discipline.
     artist_genre: dict[int, int] = {}
     with conn.transaction(), conn.cursor(name="catalog_genre_xref") as cursor:
         cursor.itersize = _ITERSIZE
@@ -139,27 +170,23 @@ def load_catalog(conn: Any) -> tuple[list[LibraryCode], list[LibraryRelease]]:
             if artist_id not in artist_genre:
                 artist_genre[artist_id] = row["genre_id"]
 
-    # Build LibraryCode list from artists.
-    codes: list[LibraryCode] = []
-    with conn.transaction(), conn.cursor(name="catalog_artists") as cursor:
-        cursor.itersize = _ITERSIZE
-        cursor.execute(_ARTISTS_SQL)
-        for row in cursor:
-            codes.append(
-                LibraryCode(
-                    id=row["id"],
-                    genre_id=artist_genre.get(row["id"], 0),
-                    presentation_name=row["artist_name"],
-                )
-            )
+    codes = _stream_into_list(
+        conn,
+        "catalog_artists",
+        _ARTISTS_SQL,
+        lambda row: LibraryCode(
+            id=row["id"],
+            genre_id=artist_genre.get(row["id"], 0),
+            presentation_name=row["artist_name"],
+        ),
+    )
 
-    # Build LibraryRelease list from library.
-    releases: list[LibraryRelease] = []
-    with conn.transaction(), conn.cursor(name="catalog_library") as cursor:
-        cursor.itersize = _ITERSIZE
-        cursor.execute(_LIBRARY_SQL)
-        for row in cursor:
-            releases.append(LibraryRelease(id=row["id"], library_code_id=row["artist_id"]))
+    releases = _stream_into_list(
+        conn,
+        "catalog_library",
+        _LIBRARY_SQL,
+        lambda row: LibraryRelease(id=row["id"], library_code_id=row["artist_id"]),
+    )
 
     logger.info("Loaded catalog: %d artists, %d releases", len(codes), len(releases))
     return codes, releases
@@ -176,13 +203,9 @@ def load_flowsheet_entries(conn: Any) -> list[FlowsheetEntry]:
     - ``add_time`` timestamptz → epoch seconds int (via EXTRACT(EPOCH ...))
     - ``entry_type`` enum 'track' → ``entry_type_code = 1``
 
-    Uses a named (server-side) cursor inside an explicit transaction so
-    libpq fetches rows in ``itersize`` chunks rather than buffering the
-    full result set in C memory. The transaction is required because
-    the connection is autocommit=True (named cursors error outside a
-    transaction on autocommit connections), and ``WITHOUT HOLD`` is the
-    psycopg3 default, so iteration MUST complete inside the ``with``
-    block -- hence materialising into a list rather than yielding.
+    Streams through a named (server-side) cursor via :func:`_stream_into_list`
+    so libpq fetches in ``_ITERSIZE`` chunks rather than buffering the full
+    ~1M-row result set in C memory.
 
     Args:
         conn: psycopg connection (dict_row factory, autocommit=True).
@@ -190,32 +213,34 @@ def load_flowsheet_entries(conn: Any) -> list[FlowsheetEntry]:
     Returns:
         List of FlowsheetEntry, ordered by (show_id, play_order).
     """
-    entries: list[FlowsheetEntry] = []
-    with conn.transaction(), conn.cursor(name="flowsheet_load") as cursor:
-        cursor.itersize = _ITERSIZE
-        cursor.execute(_FLOWSHEET_SQL)
-        for row in cursor:
-            album_id = row["album_id"]
-            add_time_epoch = row["add_time_epoch"]
-
-            entries.append(
-                FlowsheetEntry(
-                    id=row["id"],
-                    artist_name=row["artist_name"] or "",
-                    song_title=row["track_title"] or "",
-                    release_title=row["album_title"] or "",
-                    label_name=row["record_label"] or "",
-                    show_id=row["show_id"] if row["show_id"] is not None else 0,
-                    sequence=row["play_order"],
-                    library_release_id=album_id if isinstance(album_id, int) else 0,
-                    entry_type_code=1,  # all rows are 'track' (filtered in SQL)
-                    request_flag=1 if row["request_flag"] else 0,
-                    start_time=int(add_time_epoch) if add_time_epoch is not None else None,
-                )
-            )
-
+    entries = _stream_into_list(conn, "flowsheet_load", _FLOWSHEET_SQL, _build_flowsheet_entry)
     logger.info("Loaded %d flowsheet track entries", len(entries))
     return entries
+
+
+def _build_flowsheet_entry(row: Any) -> FlowsheetEntry:
+    """Map one ``wxyc_schema.flowsheet`` dict row to a FlowsheetEntry.
+
+    - ``album_id`` → ``library_release_id`` (NULL → 0)
+    - ``request_flag`` boolean → int (0 or 1)
+    - ``add_time`` timestamptz → epoch seconds int (via EXTRACT(EPOCH ...))
+    - ``entry_type`` enum 'track' → ``entry_type_code = 1``
+    """
+    album_id = row["album_id"]
+    add_time_epoch = row["add_time_epoch"]
+    return FlowsheetEntry(
+        id=row["id"],
+        artist_name=row["artist_name"] or "",
+        song_title=row["track_title"] or "",
+        release_title=row["album_title"] or "",
+        label_name=row["record_label"] or "",
+        show_id=row["show_id"] if row["show_id"] is not None else 0,
+        sequence=row["play_order"],
+        library_release_id=album_id if isinstance(album_id, int) else 0,
+        entry_type_code=1,  # all rows are 'track' (filtered in SQL)
+        request_flag=1 if row["request_flag"] else 0,
+        start_time=int(add_time_epoch) if add_time_epoch is not None else None,
+    )
 
 
 def load_shows(conn: Any) -> tuple[dict[int, int | str], dict[int, str]]:
@@ -263,9 +288,9 @@ def load_cross_references(
 
     The PG tables don't have a row ID, so a synthetic ``0`` is used.
 
-    Both queries stream through named (server-side) cursors inside an explicit
-    transaction (see ``load_catalog`` / ``load_flowsheet_entries``) rather than
-    ``.fetchall()``-ing each table under ``dict_row`` (WXYC/semantic-index#345).
+    Both queries stream through named (server-side) cursors via
+    :func:`_stream_into_list` rather than ``.fetchall()``-ing each table under
+    ``dict_row`` (WXYC/semantic-index#345).
 
     Args:
         conn: psycopg connection (dict_row factory, autocommit=True).
@@ -273,21 +298,19 @@ def load_cross_references(
     Returns:
         Tuple of (artist_xrefs, release_xrefs).
     """
-    artist_xrefs: list[tuple] = []
-    with conn.transaction(), conn.cursor(name="artist_xref") as cursor:
-        cursor.itersize = _ITERSIZE
-        cursor.execute(_ARTIST_XREF_SQL)
-        for row in cursor:
-            artist_xrefs.append(
-                (0, row["source_artist_id"], row["target_artist_id"], row.get("comment"))
-            )
+    artist_xrefs = _stream_into_list(
+        conn,
+        "artist_xref",
+        _ARTIST_XREF_SQL,
+        lambda row: (0, row["source_artist_id"], row["target_artist_id"], row.get("comment")),
+    )
 
-    release_xrefs: list[tuple] = []
-    with conn.transaction(), conn.cursor(name="release_xref") as cursor:
-        cursor.itersize = _ITERSIZE
-        cursor.execute(_RELEASE_XREF_SQL)
-        for row in cursor:
-            release_xrefs.append((0, row["artist_id"], row["library_id"], row.get("comment")))
+    release_xrefs = _stream_into_list(
+        conn,
+        "release_xref",
+        _RELEASE_XREF_SQL,
+        lambda row: (0, row["artist_id"], row["library_id"], row.get("comment")),
+    )
 
     logger.info(
         "Loaded cross-references: %d artist, %d release",

--- a/semantic_index/pg_source.py
+++ b/semantic_index/pg_source.py
@@ -26,6 +26,11 @@ from semantic_index.models import FlowsheetEntry, LibraryCode, LibraryRelease
 
 logger = logging.getLogger(__name__)
 
+# Rows fetched per libpq round-trip for the high-cardinality server-side
+# cursors (catalog, flowsheet, cross-references). ~10K bounds the libpq buffer
+# to a few MiB while amortising network round-trips over the ~462K-row catalog.
+_ITERSIZE = 10_000
+
 # ---------------------------------------------------------------------------
 # SQL queries
 # ---------------------------------------------------------------------------
@@ -110,36 +115,51 @@ def load_catalog(conn: Any) -> tuple[list[LibraryCode], list[LibraryRelease]]:
     ``artist_genre_code``) is used. Artists without a genre entry get
     ``genre_id=0``.
 
+    Each of the three queries (genre xref, artists, releases) streams through
+    its own named (server-side) cursor inside an explicit transaction so libpq
+    fetches rows in ``_ITERSIZE`` chunks rather than buffering the full result
+    set, and the target objects are built during iteration so the dict rows are
+    freed incrementally. This is the loader the nightly sync OOM-died in
+    (WXYC/semantic-index#345). See ``load_flowsheet_entries`` for the full
+    transaction / WITHOUT HOLD rationale.
+
     Args:
-        conn: psycopg connection (dict_row factory).
+        conn: psycopg connection (dict_row factory, autocommit=True).
 
     Returns:
         Tuple of (codes, releases).
     """
-    # Build artist_id → genre_id mapping (first genre wins)
-    genre_xref_rows = conn.execute(_GENRE_ARTIST_XREF_SQL).fetchall()
+    # Build artist_id → genre_id mapping (first genre wins).
     artist_genre: dict[int, int] = {}
-    for row in genre_xref_rows:
-        artist_id = row["artist_id"]
-        if artist_id not in artist_genre:
-            artist_genre[artist_id] = row["genre_id"]
+    with conn.transaction(), conn.cursor(name="catalog_genre_xref") as cursor:
+        cursor.itersize = _ITERSIZE
+        cursor.execute(_GENRE_ARTIST_XREF_SQL)
+        for row in cursor:
+            artist_id = row["artist_id"]
+            if artist_id not in artist_genre:
+                artist_genre[artist_id] = row["genre_id"]
 
-    # Build LibraryCode list from artists
-    artist_rows = conn.execute(_ARTISTS_SQL).fetchall()
-    codes = [
-        LibraryCode(
-            id=row["id"],
-            genre_id=artist_genre.get(row["id"], 0),
-            presentation_name=row["artist_name"],
-        )
-        for row in artist_rows
-    ]
+    # Build LibraryCode list from artists.
+    codes: list[LibraryCode] = []
+    with conn.transaction(), conn.cursor(name="catalog_artists") as cursor:
+        cursor.itersize = _ITERSIZE
+        cursor.execute(_ARTISTS_SQL)
+        for row in cursor:
+            codes.append(
+                LibraryCode(
+                    id=row["id"],
+                    genre_id=artist_genre.get(row["id"], 0),
+                    presentation_name=row["artist_name"],
+                )
+            )
 
-    # Build LibraryRelease list from library
-    library_rows = conn.execute(_LIBRARY_SQL).fetchall()
-    releases = [
-        LibraryRelease(id=row["id"], library_code_id=row["artist_id"]) for row in library_rows
-    ]
+    # Build LibraryRelease list from library.
+    releases: list[LibraryRelease] = []
+    with conn.transaction(), conn.cursor(name="catalog_library") as cursor:
+        cursor.itersize = _ITERSIZE
+        cursor.execute(_LIBRARY_SQL)
+        for row in cursor:
+            releases.append(LibraryRelease(id=row["id"], library_code_id=row["artist_id"]))
 
     logger.info("Loaded catalog: %d artists, %d releases", len(codes), len(releases))
     return codes, releases
@@ -172,7 +192,7 @@ def load_flowsheet_entries(conn: Any) -> list[FlowsheetEntry]:
     """
     entries: list[FlowsheetEntry] = []
     with conn.transaction(), conn.cursor(name="flowsheet_load") as cursor:
-        cursor.itersize = 10_000
+        cursor.itersize = _ITERSIZE
         cursor.execute(_FLOWSHEET_SQL)
         for row in cursor:
             album_id = row["album_id"]
@@ -243,22 +263,31 @@ def load_cross_references(
 
     The PG tables don't have a row ID, so a synthetic ``0`` is used.
 
+    Both queries stream through named (server-side) cursors inside an explicit
+    transaction (see ``load_catalog`` / ``load_flowsheet_entries``) rather than
+    ``.fetchall()``-ing each table under ``dict_row`` (WXYC/semantic-index#345).
+
     Args:
-        conn: psycopg connection (dict_row factory).
+        conn: psycopg connection (dict_row factory, autocommit=True).
 
     Returns:
         Tuple of (artist_xrefs, release_xrefs).
     """
-    artist_rows = conn.execute(_ARTIST_XREF_SQL).fetchall()
-    artist_xrefs = [
-        (0, row["source_artist_id"], row["target_artist_id"], row.get("comment"))
-        for row in artist_rows
-    ]
+    artist_xrefs: list[tuple] = []
+    with conn.transaction(), conn.cursor(name="artist_xref") as cursor:
+        cursor.itersize = _ITERSIZE
+        cursor.execute(_ARTIST_XREF_SQL)
+        for row in cursor:
+            artist_xrefs.append(
+                (0, row["source_artist_id"], row["target_artist_id"], row.get("comment"))
+            )
 
-    release_rows = conn.execute(_RELEASE_XREF_SQL).fetchall()
-    release_xrefs = [
-        (0, row["artist_id"], row["library_id"], row.get("comment")) for row in release_rows
-    ]
+    release_xrefs: list[tuple] = []
+    with conn.transaction(), conn.cursor(name="release_xref") as cursor:
+        cursor.itersize = _ITERSIZE
+        cursor.execute(_RELEASE_XREF_SQL)
+        for row in cursor:
+            release_xrefs.append((0, row["artist_id"], row["library_id"], row.get("comment")))
 
     logger.info(
         "Loaded cross-references: %d artist, %d release",

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,7 +1,9 @@
 """Structural regression tests for pipeline data models.
 
 `FlowsheetEntry` and `ResolvedEntry` are instantiated ~1M times each during a
-nightly sync. They MUST be slotted dataclasses (no per-instance `__dict__`)
+nightly sync. `LibraryCode` (~462K) and `LibraryRelease` (~196K) are the next
+highest-cardinality types and stay resident through resolver construction and
+graph_metrics. All MUST be slotted dataclasses (no per-instance `__dict__`)
 to fit the production cgroup memory cap.
 """
 
@@ -11,8 +13,13 @@ from dataclasses import FrozenInstanceError
 
 import pytest
 
-from semantic_index.models import FlowsheetEntry, ResolvedEntry
-from tests.conftest import make_flowsheet_entry, make_resolved_entry
+from semantic_index.models import FlowsheetEntry, LibraryCode, LibraryRelease, ResolvedEntry
+from tests.conftest import (
+    make_flowsheet_entry,
+    make_library_code,
+    make_library_release,
+    make_resolved_entry,
+)
 
 
 class TestFlowsheetEntrySlots:
@@ -58,6 +65,58 @@ class TestFlowsheetEntrySlots:
         assert entry.show_id == 1
         assert entry.sequence == 1
         assert entry.entry_type_code == 1
+
+
+class TestLibraryCodeSlots:
+    def test_instance_has_no_dict(self):
+        code = make_library_code()
+        assert not hasattr(code, "__dict__"), (
+            "LibraryCode instances must NOT have __dict__ -- ~462K coexist at "
+            "sync peak and stay resident through resolver + graph_metrics"
+        )
+
+    def test_slots_excludes_dict(self):
+        assert "__dict__" not in LibraryCode.__slots__
+
+    def test_is_frozen(self):
+        code = make_library_code()
+        with pytest.raises(FrozenInstanceError):
+            code.presentation_name = "Stereolab"
+
+    def test_attribute_access_preserved(self):
+        code = make_library_code()
+        assert code.id == 200
+        assert code.genre_id == 15
+        assert code.presentation_name == "Autechre"
+
+    def test_equality_and_hashable(self):
+        # frozen dataclass: value equality + hashable, relied on by tests/sets.
+        a = LibraryCode(id=1, genre_id=2, presentation_name="Autechre")
+        b = LibraryCode(id=1, genre_id=2, presentation_name="Autechre")
+        assert a == b
+        assert {a, b} == {a}
+
+
+class TestLibraryReleaseSlots:
+    def test_instance_has_no_dict(self):
+        release = make_library_release()
+        assert not hasattr(release, "__dict__"), (
+            "LibraryRelease instances must NOT have __dict__ -- ~196K coexist at sync peak"
+        )
+
+    def test_slots_excludes_dict(self):
+        assert "__dict__" not in LibraryRelease.__slots__
+
+    def test_is_frozen(self):
+        release = make_library_release()
+        with pytest.raises(FrozenInstanceError):
+            release.library_code_id = 999
+
+    def test_attribute_access_and_equality(self):
+        release = make_library_release()
+        assert release.id == 100
+        assert release.library_code_id == 200
+        assert release == LibraryRelease(id=100, library_code_id=200)
 
 
 class TestResolvedEntrySlots:

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -90,7 +90,9 @@ class TestLibraryCodeSlots:
         assert code.presentation_name == "Autechre"
 
     def test_equality_and_hashable(self):
-        # frozen dataclass: value equality + hashable, relied on by tests/sets.
+        # frozen dataclass gives value equality + hashability (the old pydantic
+        # BaseModel was unhashable). No production code dedups these yet; this
+        # pins the property so a future set()/dict-key use is intentional.
         a = LibraryCode(id=1, genre_id=2, presentation_name="Autechre")
         b = LibraryCode(id=1, genre_id=2, presentation_name="Autechre")
         assert a == b

--- a/tests/unit/test_pg_source.py
+++ b/tests/unit/test_pg_source.py
@@ -55,22 +55,64 @@ def _mock_conn_with_rows(rows: list[dict]) -> MagicMock:
 
 
 def _mock_conn_with_queries(query_results: dict[str, list[dict]]) -> MagicMock:
-    """Create a mock connection that returns different results based on query substring.
+    """Create a mock connection that routes results by query substring.
 
-    *query_results* maps a substring of the SQL query to the rows it should return.
+    *query_results* maps a substring of the SQL query to the rows it should
+    return. Supports BOTH cursor patterns (like ``_mock_conn_with_rows``):
+
+    1. **Client-side** -- ``conn.execute(SQL).fetchall()`` (small-table
+       loaders: genres, shows).
+    2. **Server-side** -- ``with conn.transaction(): with conn.cursor(name=...)
+       as cur: cur.execute(SQL); for row in cur`` (the high-cardinality
+       loaders: catalog, cross-references).
+
+    Each server-side cursor created during the call is recorded on
+    ``conn.created_cursors`` so discipline tests can assert no ``.fetchall()``
+    was called and ``itersize`` was set.
     """
     mock_conn = MagicMock()
+    created_cursors: list[MagicMock] = []
 
-    def _execute(query, params=None):
-        cursor = MagicMock()
+    def _rows_for(query: str) -> list[dict]:
         for key, rows in query_results.items():
             if key in query:
-                cursor.fetchall.return_value = rows
-                return cursor
-        cursor.fetchall.return_value = []
+                return rows
+        return []
+
+    # Client-side cursor pattern
+    def _conn_execute(query, params=None):
+        cursor = MagicMock()
+        rows = _rows_for(query)
+        cursor.fetchall.return_value = rows
+        cursor.__iter__.side_effect = lambda: iter(rows)
         return cursor
 
-    mock_conn.execute.side_effect = _execute
+    mock_conn.execute.side_effect = _conn_execute
+
+    # Server-side cursor pattern: a fresh named cursor per conn.cursor() call,
+    # whose iterated rows are determined by the query passed to cursor.execute().
+    def _make_named_cursor(*args, **kwargs):
+        cur = MagicMock()
+        cur.__enter__.return_value = cur
+        cur.__exit__.return_value = None
+        holder: dict[str, list[dict]] = {"rows": []}
+
+        def _cursor_execute(query, params=None):
+            holder["rows"] = _rows_for(query)
+
+        cur.execute.side_effect = _cursor_execute
+        cur.__iter__.side_effect = lambda: iter(holder["rows"])
+        created_cursors.append(cur)
+        return cur
+
+    mock_conn.cursor.side_effect = _make_named_cursor
+
+    tx = MagicMock()
+    tx.__enter__.return_value = tx
+    tx.__exit__.return_value = None
+    mock_conn.transaction.return_value = tx
+
+    mock_conn.created_cursors = created_cursors
     return mock_conn
 
 
@@ -221,6 +263,66 @@ class TestLoadCatalog:
 
         assert codes == []
         assert releases == []
+
+
+# ===========================================================================
+# load_catalog -- server-side cursor lifecycle
+# ===========================================================================
+
+
+class TestLoadCatalogServerSideCursor:
+    """``load_catalog`` loads ~462K artists + ~196K releases and is the phase
+    the nightly sync OOM-dies in (WXYC/semantic-index#345). It MUST stream via
+    server-side cursors -- one per query -- rather than buffering each full
+    result set with ``.fetchall()`` under ``dict_row``.
+    """
+
+    _QUERIES = {
+        "genre_artist_crossreference": [{"artist_id": 1, "genre_id": 15}],
+        "artists": [{"id": 1, "artist_name": "Autechre"}],
+        "library": [{"id": 10, "artist_id": 1}],
+    }
+
+    def test_does_not_buffer_with_fetchall_or_conn_execute(self):
+        from semantic_index.pg_source import load_catalog
+
+        conn = _mock_conn_with_queries(self._QUERIES)
+
+        load_catalog(conn)
+
+        conn.execute.assert_not_called()
+        for cur in conn.created_cursors:
+            cur.fetchall.assert_not_called()
+
+    def test_opens_named_cursors_inside_transaction(self):
+        from semantic_index.pg_source import load_catalog
+
+        conn = _mock_conn_with_queries(self._QUERIES)
+
+        load_catalog(conn)
+
+        assert conn.transaction.called, "catalog cursors must run inside a transaction"
+        # Three queries (genre xref, artists, library) -> three named cursors.
+        assert conn.cursor.call_count == 3
+        for call in conn.cursor.call_args_list:
+            assert call.kwargs.get("name"), (
+                "every catalog cursor must be named -- a name is what makes it "
+                "server-side in psycopg3"
+            )
+
+    def test_sets_itersize_to_bound_libpq_buffer(self):
+        from semantic_index.pg_source import load_catalog
+
+        conn = _mock_conn_with_queries(self._QUERIES)
+
+        load_catalog(conn)
+
+        assert conn.created_cursors, "expected server-side cursors to be created"
+        for cur in conn.created_cursors:
+            assert cur.itersize >= 1000, (
+                f"itersize must be >=1000 to amortize round-trips over the "
+                f"~462K-row catalog; got {cur.itersize}"
+            )
 
 
 # ===========================================================================
@@ -648,3 +750,70 @@ class TestLoadCrossReferences:
 
         assert artist_xrefs == []
         assert release_xrefs == []
+
+
+# ===========================================================================
+# load_cross_references -- server-side cursor lifecycle
+# ===========================================================================
+
+
+class TestLoadCrossReferencesServerSideCursor:
+    """``load_cross_references`` fetchall'd both xref tables under ``dict_row``;
+    it must stream them via named server-side cursors like ``load_catalog``
+    (WXYC/semantic-index#345).
+    """
+
+    _QUERIES = {
+        "artist_crossreference": [
+            {"source_artist_id": 1, "target_artist_id": 2, "comment": "see also"}
+        ],
+        "artist_library_crossreference": [
+            {"artist_id": 10, "library_id": 20, "comment": "compilation"}
+        ],
+    }
+
+    def test_does_not_buffer_with_fetchall_or_conn_execute(self):
+        from semantic_index.pg_source import load_cross_references
+
+        conn = _mock_conn_with_queries(self._QUERIES)
+
+        load_cross_references(conn)
+
+        conn.execute.assert_not_called()
+        for cur in conn.created_cursors:
+            cur.fetchall.assert_not_called()
+
+    def test_opens_named_cursors_inside_transaction(self):
+        from semantic_index.pg_source import load_cross_references
+
+        conn = _mock_conn_with_queries(self._QUERIES)
+
+        load_cross_references(conn)
+
+        assert conn.transaction.called
+        # Two queries (artist xref, release xref) -> two named cursors.
+        assert conn.cursor.call_count == 2
+        for call in conn.cursor.call_args_list:
+            assert call.kwargs.get("name"), "every xref cursor must be named (server-side)"
+
+    def test_sets_itersize_to_bound_libpq_buffer(self):
+        from semantic_index.pg_source import load_cross_references
+
+        conn = _mock_conn_with_queries(self._QUERIES)
+
+        load_cross_references(conn)
+
+        assert conn.created_cursors, "expected server-side cursors to be created"
+        for cur in conn.created_cursors:
+            assert cur.itersize >= 1000, f"itersize must be >=1000; got {cur.itersize}"
+
+    def test_still_maps_columns_correctly_when_streamed(self):
+        """Behavioural guard: streaming must not change the returned tuple shape."""
+        from semantic_index.pg_source import load_cross_references
+
+        conn = _mock_conn_with_queries(self._QUERIES)
+
+        artist_xrefs, release_xrefs = load_cross_references(conn)
+
+        assert artist_xrefs == [(0, 1, 2, "see also")]
+        assert release_xrefs == [(0, 10, 20, "compilation")]

--- a/tests/unit/test_pg_source.py
+++ b/tests/unit/test_pg_source.py
@@ -121,6 +121,47 @@ def _mock_conn_with_queries(query_results: dict[str, list[dict]]) -> MagicMock:
     return mock_conn
 
 
+def _instrument_cursor_transaction_depth(conn: MagicMock) -> list[int]:
+    """Record, per ``conn.cursor(name=...)`` call, how many ``conn.transaction()``
+    contexts are active at that moment.
+
+    Returns a list (one entry per cursor opened) the caller inspects AFTER
+    running the loader. Every entry must be ``>= 1``: a named (server-side)
+    cursor opened with no active transaction raises on a real autocommit
+    connection.
+
+    This expresses the actual invariant -- "each cursor is opened inside a
+    transaction" -- without baking in HOW MANY transactions there are, so it
+    passes whether the loader opens one transaction per cursor or wraps several
+    cursors in a single transaction, while still catching a cursor opened
+    outside any transaction (e.g. the inlined genre-xref cursor losing its
+    ``conn.transaction()``).
+    """
+    depth = {"n": 0}
+    depths: list[int] = []
+    tx = conn.transaction.return_value
+
+    def _enter(*args, **kwargs):
+        depth["n"] += 1
+        return tx
+
+    def _exit(*args, **kwargs):
+        depth["n"] -= 1
+        return None
+
+    tx.__enter__.side_effect = _enter
+    tx.__exit__.side_effect = _exit
+
+    inner_cursor_factory = conn.cursor.side_effect
+
+    def _record(*args, **kwargs):
+        depths.append(depth["n"])
+        return inner_cursor_factory(*args, **kwargs)
+
+    conn.cursor.side_effect = _record
+    return depths
+
+
 # ===========================================================================
 # load_genres
 # ===========================================================================
@@ -303,23 +344,26 @@ class TestLoadCatalogServerSideCursor:
         from semantic_index.pg_source import load_catalog
 
         conn = _mock_conn_with_queries(self._QUERIES)
+        cursor_open_depths = _instrument_cursor_transaction_depth(conn)
 
         load_catalog(conn)
 
-        # Three queries (genre xref, artists, library) -> three named cursors,
-        # each in its OWN transaction. Assert the transaction COUNT, not just
-        # .called: a truthy-only check is satisfied by the helper-routed
-        # cursors and would mask the inlined genre-xref cursor being opened
-        # outside a transaction (which raises on a real autocommit connection).
+        # Three queries (genre xref, artists, library) -> three named cursors.
         assert conn.cursor.call_count == 3
-        assert conn.transaction.call_count == 3, (
-            "every catalog cursor must run in its own transaction"
-        )
         for call in conn.cursor.call_args_list:
             assert call.kwargs.get("name"), (
                 "every catalog cursor must be named -- a name is what makes it "
                 "server-side in psycopg3"
             )
+        # Each cursor MUST be opened inside an active transaction (named cursors
+        # error outside one on an autocommit connection). Asserting the depth at
+        # open time -- not the transaction count -- catches the inlined
+        # genre-xref cursor being opened outside a transaction while still
+        # allowing a future single-transaction-for-all-reads refactor.
+        assert all(d >= 1 for d in cursor_open_depths), (
+            f"every catalog cursor must be opened inside a transaction; "
+            f"open-time transaction depths were {cursor_open_depths}"
+        )
 
     def test_sets_itersize_to_bound_libpq_buffer(self):
         from semantic_index.pg_source import load_catalog
@@ -798,15 +842,20 @@ class TestLoadCrossReferencesServerSideCursor:
         from semantic_index.pg_source import load_cross_references
 
         conn = _mock_conn_with_queries(self._QUERIES)
+        cursor_open_depths = _instrument_cursor_transaction_depth(conn)
 
         load_cross_references(conn)
 
-        # Two queries (artist xref, release xref) -> two named cursors, each in
-        # its own transaction. Assert the transaction count, not just .called.
+        # Two queries (artist xref, release xref) -> two named cursors, each
+        # opened inside an active transaction (see the catalog test for why this
+        # asserts open-time depth rather than transaction count).
         assert conn.cursor.call_count == 2
-        assert conn.transaction.call_count == 2, "every xref cursor must run in its own transaction"
         for call in conn.cursor.call_args_list:
             assert call.kwargs.get("name"), "every xref cursor must be named (server-side)"
+        assert all(d >= 1 for d in cursor_open_depths), (
+            f"every xref cursor must be opened inside a transaction; "
+            f"open-time transaction depths were {cursor_open_depths}"
+        )
 
     def test_sets_itersize_to_bound_libpq_buffer(self):
         from semantic_index.pg_source import load_cross_references

--- a/tests/unit/test_pg_source.py
+++ b/tests/unit/test_pg_source.py
@@ -18,10 +18,15 @@ def _mock_conn_with_rows(rows: list[dict]) -> MagicMock:
     """Create a mock psycopg connection supporting both cursor patterns.
 
     1. **Client-side** (``conn.execute(SQL).fetchall()`` or iteration):
-       used by small-table loaders (genres, catalog, shows, xrefs).
+       used by the small-table loaders ``load_genres`` and ``load_shows``.
     2. **Server-side** (``with conn.transaction(): with conn.cursor(name=...)
        as cur: cur.execute(SQL); for row in cur``): used by
        ``load_flowsheet_entries`` to bound libpq's row buffer.
+
+    The high-cardinality loaders (``load_catalog``, ``load_cross_references``)
+    are also server-side but run multiple distinct queries, so their tests use
+    ``_mock_conn_with_queries`` (which routes rows by query substring) rather
+    than this single-row-set helper.
 
     Each row is a dict (simulating psycopg's dict_row factory). ``__iter__``
     uses ``side_effect`` (not ``return_value``) so each call returns a fresh
@@ -301,9 +306,15 @@ class TestLoadCatalogServerSideCursor:
 
         load_catalog(conn)
 
-        assert conn.transaction.called, "catalog cursors must run inside a transaction"
-        # Three queries (genre xref, artists, library) -> three named cursors.
+        # Three queries (genre xref, artists, library) -> three named cursors,
+        # each in its OWN transaction. Assert the transaction COUNT, not just
+        # .called: a truthy-only check is satisfied by the helper-routed
+        # cursors and would mask the inlined genre-xref cursor being opened
+        # outside a transaction (which raises on a real autocommit connection).
         assert conn.cursor.call_count == 3
+        assert conn.transaction.call_count == 3, (
+            "every catalog cursor must run in its own transaction"
+        )
         for call in conn.cursor.call_args_list:
             assert call.kwargs.get("name"), (
                 "every catalog cursor must be named -- a name is what makes it "
@@ -790,9 +801,10 @@ class TestLoadCrossReferencesServerSideCursor:
 
         load_cross_references(conn)
 
-        assert conn.transaction.called
-        # Two queries (artist xref, release xref) -> two named cursors.
+        # Two queries (artist xref, release xref) -> two named cursors, each in
+        # its own transaction. Assert the transaction count, not just .called.
         assert conn.cursor.call_count == 2
+        assert conn.transaction.call_count == 2, "every xref cursor must run in its own transaction"
         for call in conn.cursor.call_args_list:
             assert call.kwargs.get("name"), "every xref cursor must be named (server-side)"
 


### PR DESCRIPTION
## Problem

The nightly sync has OOM-killed every night under the 1 GiB cgroup cap, leaving production `wxyc_artist_graph.db` stale (23 days as of 2026-06-18 — see [#329's verification comment](https://github.com/WXYC/semantic-index/issues/329#issuecomment-4742934418)). PR #341 (via #338) converted only `load_flowsheet_entries` to a server-side cursor; the `[mem]` profile shows the kill relocated *inside* `_load_from_pg` — the process dies before `after _load_from_pg` ever prints, in the loaders #341 didn't touch.

At `503b985`, `load_catalog` (462K artists + 196K releases, three `.fetchall()`s) and `load_cross_references` (two more) still buffered the full result set under `row_factory=dict_row`, so the buffered dict rows and the objects built from them coexisted at peak.

## What changed

- **Stream both loaders** (`semantic_index/pg_source.py`) — `load_catalog` and `load_cross_references` now read through named server-side cursors inside `conn.transaction()`, building the target objects during iteration so dict rows are freed incrementally. Mirrors the pattern (and the documented WITHOUT-HOLD / autocommit rationale) already in `load_flowsheet_entries`. Chunk size factored into a shared `_ITERSIZE = 10_000`.
- **Slot the two catalog models** (`semantic_index/models.py`) — `LibraryCode` and `LibraryRelease` go from pydantic `BaseModel` to `@dataclass(slots=True, frozen=True)`, matching `FlowsheetEntry`/`ResolvedEntry`. These are the highest-cardinality types and stay resident through `ArtistResolver` construction **and** `graph_metrics`, so dropping per-instance `__dict__` compounds across every downstream phase, not just the loader. Construction is keyword-only and consumption is attribute-only everywhere, so it's a clean swap; `BaseModel` stays imported for the ~25 other models.

## Tests (TDD — red → green)

- `tests/unit/test_models.py` — slotting regression tests for both catalog models, mirroring `TestFlowsheetEntrySlots` (no `__dict__`, `__slots__` excludes `__dict__`, frozen, value-equality/hashable).
- `tests/unit/test_pg_source.py` — server-side-cursor discipline tests for both loaders, mirroring `TestLoadFlowsheetEntriesServerSideCursor` (no `fetchall`/`conn.execute`, named cursors inside a transaction, `itersize` bound), plus a behavioural guard that streaming preserves the returned tuple shape. `_mock_conn_with_queries` upgraded to support the server-side pattern and record created cursors.

## Verification

- `pytest` — 1086 passed, 13 deselected (pg/slow)
- `ruff check` — clean · `ruff format --check` — clean · `mypy` — clean (49 files)

## Scope / what this does NOT claim

This clears the **loader** wall, where the process currently dies. It does not prove the whole sync fits under 1 GiB: `graph_metrics` (NetworkX Louvain + betweenness + PageRank on a 462K-node graph) is the suspected next wall and has never been measured, because no run has gotten past the loader. The gating signal is the first post-deploy `[mem]` profile:

```
docker logs semantic-index | grep '\[mem\]' | tail -20
stat /home/ec2-user/semantic-index-data/wxyc_artist_graph.db   # mtime should advance past 2026-05-26
dmesg | grep -i killed
```

If `graph_metrics` blows the cap, the out-of-process-rebuild follow-up discussed in #329 (separate one-shot cgroup, or build off-host and ship the DB) is the durable fix — out of scope here.

## Related

- Part of #345 — intentionally NOT an auto-closing keyword: #345 stays open until the first post-deploy 09:00 UTC sync clears `_load_from_pg` (the `[mem]` profile advances past `after _load_from_pg`) and the production DB mtime moves. This is the second fix attempt for #345, so it is verified in prod before closing.
- Continues #329 (parent OOM bug) after #341; same pattern as the closed flowsheet predecessors #336 / #338.
- Relies on the `[mem]` instrumentation from #331 for post-deploy verification.
- WXYC/wxyc-canary#50 — the nightly canary blip is the same OOM-restart event.

