### PR TITLE
Out-of-process rebuild (1/3): S3 build wrapper + pre-swap validation gate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,12 @@ WORKDIR /app
 
 ENV PYTHONUNBUFFERED=1
 
+# `build` adds boto3 for the out-of-process nightly rebuild's S3 round-trip
+# (scripts/run_build_job.py); the same image serves the API and runs the VPC
+# build task (command overridden in infra/build-job.yaml). No Essentia —
+# nightly_sync needs none of the audio modules. See plans/si-out-of-process-rebuild.
 COPY pyproject.toml .
-RUN pip install --no-cache-dir ".[api]"
+RUN pip install --no-cache-dir ".[api,build]"
 
 COPY semantic_index/ semantic_index/
 COPY generated/ generated/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,13 @@ archive = [
     "boto3>=1.28",
     "essentia-tensorflow>=2.1b6",
 ]
+# Out-of-process nightly rebuild (scripts/run_build_job.py): the Fargate task
+# image installs `.[api,build]` — base + API deps + boto3 for the S3 round-trip,
+# WITHOUT Essentia (nightly_sync imports none of the audio modules). See
+# plans/si-out-of-process-rebuild.
+build = [
+    "boto3>=1.28",
+]
 rust = [
     "wxyc-etl>=0.5.0",
 ]
@@ -40,6 +47,7 @@ dev = [
     "pytest-cov>=4.0.0",
     "pytest-asyncio>=0.23",
     "httpx>=0.25",
+    "moto>=4.0",
     "ruff>=0.4.0",
     "mypy>=1.0.0",
     "types-networkx>=3.0",

--- a/scripts/run_build_job.py
+++ b/scripts/run_build_job.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Fargate entrypoint for the out-of-process nightly graph rebuild.
+
+Runs as the container command of the VPC build task (see
+``plans/si-out-of-process-rebuild`` and ``infra/build-job.yaml``). It round-trips
+the rebuild through S3 so the heavy ``nightly_sync`` work happens off the API
+serving host, with an adequate memory budget:
+
+  1. Download the *seed* (current production graph) from ``SEED_S3_URI`` to
+     ``DB_PATH``. ``nightly_sync`` is incremental — it ``shutil.copy2``-es this
+     file forward and layers fresh PG-derived tables on top, so seeding from prod
+     is what preserves the Discogs/Wikidata/AcousticBrainz enrichment tables.
+  2. Run ``nightly_sync`` against Backend-Service PG (reachable here because the
+     task runs in the VPC). It reads ~2M flowsheet rows, resolves artists,
+     computes PMI + graph metrics, checkpoints, and atomically swaps the result
+     into ``DB_PATH`` locally.
+  3. Upload the rebuilt ``DB_PATH`` to ``BUILD_S3_URI``.
+
+A failure in any step propagates and the process exits non-zero **without**
+uploading, so the EC2 conductor's exit-code check is meaningful and a failed
+build never ships. The conductor validates the artifact (``validate_graph_db``)
+before swapping it into the live serving path.
+
+Environment:
+    DATABASE_URL_BACKEND   Backend-Service PG DSN (RDS private endpoint). Required.
+    SEED_S3_URI            s3:// URI of the seed (current prod) DB. Required.
+    BUILD_S3_URI           s3:// URI to upload the rebuilt DB to. Required.
+    DB_PATH                Local working path (default /data/wxyc_artist_graph.db).
+    SYNC_MIN_COUNT         Min co-occurrence for DJ-transition edges (default 2).
+    ENRICHMENT_TOP_K       Per-artist neighbor cap for shared_personnel/label_family
+                           (default 50, 0 disables).
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+from wxyc_etl.logger import init_logger
+
+from semantic_index.nightly_sync import nightly_sync
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_DB_PATH = "/data/wxyc_artist_graph.db"
+DEFAULT_MIN_COUNT = 2
+DEFAULT_ENRICHMENT_TOP_K = 50
+
+
+def _parse_s3_uri(uri: str) -> tuple[str, str]:
+    """Split an ``s3://bucket/key`` URI into ``(bucket, key)``.
+
+    Raises ``ValueError`` for anything that is not a well-formed S3 URI with a
+    non-empty bucket and key.
+    """
+    parsed = urlparse(uri)
+    key = parsed.path.lstrip("/")
+    if parsed.scheme != "s3" or not parsed.netloc or not key:
+        raise ValueError(f"not a valid s3:// URI: {uri!r}")
+    return parsed.netloc, key
+
+
+def _require_env(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise SystemExit(f"required environment variable {name} is not set")
+    return value
+
+
+def run(
+    *,
+    db_path: str,
+    dsn: str,
+    seed_uri: str,
+    build_uri: str,
+    min_count: int,
+    enrichment_top_k: int,
+    s3_client: Any,
+) -> None:
+    """Download seed → run ``nightly_sync`` → upload result. Raises on failure."""
+    seed_bucket, seed_key = _parse_s3_uri(seed_uri)
+    build_bucket, build_key = _parse_s3_uri(build_uri)
+
+    Path(db_path).parent.mkdir(parents=True, exist_ok=True)
+    logger.info("Downloading seed %s -> %s", seed_uri, db_path)
+    s3_client.download_file(seed_bucket, seed_key, db_path)
+
+    logger.info("Running nightly_sync against Backend-Service PG...")
+    # Mirror sync_scheduler._run_sync: invoke the orchestrator directly with a
+    # Namespace rather than re-parsing argv. dry_run=False so the pipeline does
+    # its local checkpoint + atomic swap into db_path; we upload that file.
+    args = argparse.Namespace(
+        db_path=db_path,
+        dsn=dsn,
+        min_count=min_count,
+        enrichment_top_k=enrichment_top_k,
+        dry_run=False,
+        verbose=True,
+    )
+    nightly_sync(args)
+
+    logger.info("Uploading rebuilt graph %s -> %s", db_path, build_uri)
+    s3_client.upload_file(db_path, build_bucket, build_key)
+    logger.info("Build job complete.")
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Container entrypoint: wire env → :func:`run`. Non-zero exit on failure."""
+    init_logger(repo="semantic-index", tool="semantic-index build-job", level=logging.INFO)
+
+    import boto3  # imported here so the module imports without boto3 in tests
+
+    run(
+        db_path=os.environ.get("DB_PATH", DEFAULT_DB_PATH),
+        dsn=_require_env("DATABASE_URL_BACKEND"),
+        seed_uri=_require_env("SEED_S3_URI"),
+        build_uri=_require_env("BUILD_S3_URI"),
+        min_count=int(os.environ.get("SYNC_MIN_COUNT", str(DEFAULT_MIN_COUNT))),
+        enrichment_top_k=int(os.environ.get("ENRICHMENT_TOP_K", str(DEFAULT_ENRICHMENT_TOP_K))),
+        s3_client=boto3.client("s3"),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_graph_db.py
+++ b/scripts/validate_graph_db.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Validate a freshly-built ``wxyc_artist_graph.db`` before swapping it into production.
+
+The out-of-process nightly rebuild (see ``plans/si-out-of-process-rebuild``)
+builds the graph in a VPC Fargate job and ships it back to the serving host.
+Before the conductor atomically swaps the new file into place, it runs this
+gate. The gate is **fail-closed**: if validation raises, the conductor keeps
+serving the previous (stale-but-enriched) database rather than shipping a
+regression.
+
+The most important check is enrichment preservation. ``nightly_sync`` is
+*incremental* — it ``shutil.copy2``-es the current production DB forward and
+layers fresh PG-derived tables on top, so the Discogs/Wikidata/AcousticBrainz
+enrichment tables survive **only** because they are copied from the seed. A
+build that started from an empty ``DB_PATH`` would ship a graph with
+DJ-transition + cross-reference edges and zero enrichment. We catch that by
+comparing the build's enrichment row counts against the seed's.
+
+Note on table names: issue #347 refers to a ``discogs_edges`` table, but that
+is a *module* name (``semantic_index/discogs_edges.py``), not a table. Discogs
+enrichment materializes into ``shared_personnel`` / ``shared_style`` /
+``label_family`` / ``compilation``. The list below is grounded in the actual
+SQLite schema (``semantic_index/sqlite_export.py``,
+``semantic_index/acousticbrainz.py``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sqlite3
+import sys
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Enrichment tables produced by separate ``run_pipeline.py`` enrichment runs and
+# carried forward across ``nightly_sync`` via ``shutil.copy2`` (NOT recomputed
+# from Backend-Service PG each night). If any of these collapses to ~zero in a
+# build, the build almost certainly did not start from the seeded production DB.
+ENRICHMENT_TABLES: tuple[str, ...] = (
+    "shared_personnel",  # Discogs personnel overlap
+    "shared_style",  # Discogs style overlap
+    "label_family",  # Discogs shared-label
+    "compilation",  # Discogs compilation co-appearance
+    "wikidata_influence",  # Wikidata P737
+    "label_hierarchy",  # Wikidata P749/P355
+    "audio_profile",  # AcousticBrainz per-artist profile
+    "acoustic_similarity",  # AcousticBrainz pairwise similarity
+)
+
+# A build whose enrichment table shrinks below ``fraction * seed_count`` rows is
+# treated as a regression. Lenient enough to tolerate the per-artist top-K prune
+# applied to ``shared_personnel`` / ``label_family`` on every sync (which can
+# legitimately cut an unpruned seed by up to ~an order of magnitude on first
+# run), strict enough to catch a build that started empty (count → 0).
+DEFAULT_COLLAPSE_FRACTION = 0.1
+
+
+class ValidationError(Exception):
+    """Raised when a built graph DB fails a pre-swap validation check."""
+
+
+# The full 16-byte SQLite header. We check the whole magic (not just the
+# ``b"SQLite"`` prefix) so a truncated/corrupt artifact is rejected here with a
+# clean ValidationError rather than slipping through to raise sqlite3.DatabaseError
+# from a later query (which `validate` also defends against as a backstop).
+_SQLITE_MAGIC = b"SQLite format 3\x00"
+
+
+def _is_sqlite(path: Path) -> bool:
+    """True if *path* exists and begins with the full 16-byte SQLite magic header."""
+    try:
+        with open(path, "rb") as f:
+            return f.read(len(_SQLITE_MAGIC)) == _SQLITE_MAGIC
+    except OSError:
+        return False
+
+
+def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (table,)
+    ).fetchone()
+    return row is not None
+
+
+def count_rows(
+    db_path: str | Path, tables: tuple[str, ...] = ENRICHMENT_TABLES
+) -> dict[str, int]:
+    """Return ``{table: row_count}`` for each named table that exists.
+
+    Tables absent from the database are omitted from the result (rather than
+    reported as ``0``) so a caller can distinguish "table missing" from "table
+    present but empty" when it needs to. The rebuild conductor calls this on the
+    *seed* to capture the baseline it later validates the build against.
+    """
+    counts: dict[str, int] = {}
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    try:
+        for table in tables:
+            if _table_exists(conn, table):
+                counts[table] = conn.execute(
+                    f"SELECT COUNT(*) FROM {table}"  # noqa: S608 — table name guarded by _table_exists above
+                ).fetchone()[0]
+    finally:
+        conn.close()
+    return counts
+
+
+def validate(
+    db_path: str | Path,
+    *,
+    seed_counts: dict[str, int] | None = None,
+    min_artists: int = 1,
+    collapse_fraction: float = DEFAULT_COLLAPSE_FRACTION,
+) -> None:
+    """Validate a built graph DB. Raise :class:`ValidationError` on any failure.
+
+    Checks, in order:
+
+    1. The file is a SQLite database (magic header) — catches a truncated or
+       non-DB artifact from a failed download/build.
+    2. The ``artist`` table exists and has at least ``min_artists`` rows — catches
+       an empty or half-written graph. The conductor passes the live artist count
+       (scaled down) so a graph that shrank dramatically is rejected.
+    3. For each enrichment table that was **non-empty in the seed**, the build
+       retains at least ``collapse_fraction * seed_count`` rows (and > 0) — the
+       core enrichment-preservation guard (acceptance criterion #2 of #347).
+
+    Args:
+        db_path: Path to the candidate (just-built) graph database.
+        seed_counts: Enrichment row counts captured from the seed DB (see
+            :func:`count_rows`). When ``None``, only checks 1–2 run.
+        min_artists: Minimum acceptable ``artist`` row count.
+        collapse_fraction: Per-table floor as a fraction of the seed count.
+    """
+    path = Path(db_path)
+    if not _is_sqlite(path):
+        raise ValidationError(
+            f"{db_path} is not a SQLite database (bad or missing magic header)"
+        )
+
+    try:
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        try:
+            if not _table_exists(conn, "artist"):
+                raise ValidationError("missing `artist` table")
+            n_artists = conn.execute("SELECT COUNT(*) FROM artist").fetchone()[0]
+        finally:
+            conn.close()
+    except sqlite3.DatabaseError as exc:
+        # Header check passed but the body is corrupt/unreadable. Convert the raw
+        # sqlite error into ValidationError so callers that catch only
+        # ValidationError (e.g. the CLI in main) stay fail-closed instead of
+        # crashing with a traceback.
+        raise ValidationError(f"{db_path} is not a valid SQLite database: {exc}") from exc
+
+    if n_artists < min_artists:
+        raise ValidationError(
+            f"artist count {n_artists} is below the required minimum {min_artists}"
+        )
+    logger.info("artist count: %d (minimum %d)", n_artists, min_artists)
+
+    if seed_counts:
+        required = {t: n for t, n in seed_counts.items() if n > 0}
+        if not required:
+            # The guard compares the build against a seed baseline; with an
+            # all-zero seed there is nothing to compare, so it cannot catch an
+            # enrichment-collapse regression this run. Make that visible rather
+            # than silently passing — an all-empty seed usually means the live
+            # graph was already enrichment-empty (e.g. a prior bad swap), which
+            # is exactly when the next empty build must NOT sail through unnoticed.
+            logger.warning(
+                "enrichment guard INACTIVE: seed reported zero enrichment rows for "
+                "every table (%s); cannot detect an enrichment-collapse regression "
+                "this run — verify the seed was the enriched production graph",
+                ", ".join(seed_counts) or "none",
+            )
+        build_counts = count_rows(db_path, tuple(required))
+        problems: list[str] = []
+        for table, seed_n in required.items():
+            build_n = build_counts.get(table, 0)
+            floor = max(1, int(seed_n * collapse_fraction))
+            logger.info(
+                "enrichment %-20s build=%d seed=%d floor=%d", table, build_n, seed_n, floor
+            )
+            if build_n < floor:
+                problems.append(f"{table}: build={build_n} seed={seed_n} (floor {floor})")
+        if problems:
+            raise ValidationError(
+                "enrichment collapsed vs seed (build likely did not start from "
+                "the production DB): " + "; ".join(problems)
+            )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI: validate a graph DB, exit 0 on success, 1 on validation failure.
+
+    Invoked by the EC2 conductor against the downloaded build artifact.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("db_path", help="Path to the graph DB to validate or count")
+    parser.add_argument(
+        "--emit-counts",
+        action="store_true",
+        help=(
+            "Print enrichment row counts of db_path as JSON and exit (no validation). "
+            "The conductor uses this on the seed DB to capture the baseline it later "
+            "passes back via --seed-counts."
+        ),
+    )
+    parser.add_argument(
+        "--seed-counts",
+        help="Path to a JSON file of {table: row_count} captured from the seed DB",
+    )
+    parser.add_argument("--min-artists", type=int, default=1)
+    parser.add_argument(
+        "--collapse-fraction", type=float, default=DEFAULT_COLLAPSE_FRACTION
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+
+    if args.emit_counts:
+        print(json.dumps(count_rows(args.db_path)))
+        return 0
+
+    seed_counts = None
+    if args.seed_counts:
+        seed_counts = json.loads(Path(args.seed_counts).read_text())
+
+    try:
+        validate(
+            args.db_path,
+            seed_counts=seed_counts,
+            min_artists=args.min_artists,
+            collapse_fraction=args.collapse_fraction,
+        )
+    except ValidationError as exc:
+        logger.error("VALIDATION FAILED: %s", exc)
+        return 1
+    logger.info("validation passed: %s", args.db_path)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_run_build_job.py
+++ b/tests/unit/test_run_build_job.py
@@ -1,0 +1,117 @@
+"""Tests for the Fargate build-job entrypoint (out-of-process nightly rebuild).
+
+``scripts/run_build_job.py`` is the container command for the VPC build task:
+download the seed (current production graph) from S3, run ``nightly_sync``, and
+upload the rebuilt graph back to S3. The build itself (``nightly_sync``) is
+stubbed here — these tests pin the S3 round-trip wiring and the "don't upload a
+failed build" contract.
+"""
+
+import boto3
+import pytest
+from moto import mock_aws
+
+import scripts.run_build_job as rbj
+
+BUCKET = "wxyc-semantic-index-build"
+
+
+@pytest.fixture(autouse=True)
+def _aws_creds(monkeypatch):
+    """Dummy credentials/region so moto's intercept doesn't trip boto3's
+    credential lookup."""
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+
+
+@mock_aws
+def test_run_round_trips_seed_then_build_through_s3(tmp_path, monkeypatch):
+    s3 = boto3.client("s3", region_name="us-east-1")
+    s3.create_bucket(Bucket=BUCKET)
+    s3.put_object(Bucket=BUCKET, Key="seed/graph.db", Body=b"SEED-DB-BYTES")
+
+    db_path = tmp_path / "data" / "wxyc_artist_graph.db"
+    captured = {}
+
+    def fake_nightly_sync(args):
+        # The seed must already be downloaded to db_path before the build runs.
+        assert db_path.read_bytes() == b"SEED-DB-BYTES"
+        captured["args"] = args
+        db_path.write_bytes(b"BUILT-DB-BYTES")  # simulate the rebuild output
+
+    monkeypatch.setattr(rbj, "nightly_sync", fake_nightly_sync)
+
+    rbj.run(
+        db_path=str(db_path),
+        dsn="postgresql://u@host/db",
+        seed_uri=f"s3://{BUCKET}/seed/graph.db",
+        build_uri=f"s3://{BUCKET}/build/graph.db",
+        min_count=2,
+        enrichment_top_k=50,
+        s3_client=s3,
+    )
+
+    # nightly_sync invoked with the expected Namespace (the sync_scheduler shape).
+    args = captured["args"]
+    assert args.dsn == "postgresql://u@host/db"
+    assert args.db_path == str(db_path)
+    assert args.min_count == 2
+    assert args.enrichment_top_k == 50
+    assert args.dry_run is False
+    # verbose is read by nightly_sync; assert it so a dropped field is caught here.
+    assert args.verbose is True
+
+    # The rebuilt graph (not the seed) is what gets uploaded.
+    body = s3.get_object(Bucket=BUCKET, Key="build/graph.db")["Body"].read()
+    assert body == b"BUILT-DB-BYTES"
+
+
+@mock_aws
+def test_run_does_not_upload_when_build_fails(tmp_path, monkeypatch):
+    s3 = boto3.client("s3", region_name="us-east-1")
+    s3.create_bucket(Bucket=BUCKET)
+    s3.put_object(Bucket=BUCKET, Key="seed/graph.db", Body=b"SEED")
+
+    db_path = tmp_path / "graph.db"
+
+    def boom(args):
+        raise RuntimeError("pipeline OOM")
+
+    monkeypatch.setattr(rbj, "nightly_sync", boom)
+
+    with pytest.raises(RuntimeError, match="pipeline OOM"):
+        rbj.run(
+            db_path=str(db_path),
+            dsn="x",
+            seed_uri=f"s3://{BUCKET}/seed/graph.db",
+            build_uri=f"s3://{BUCKET}/build/graph.db",
+            min_count=2,
+            enrichment_top_k=50,
+            s3_client=s3,
+        )
+
+    # A failed build must never ship: no object at the build key.
+    with pytest.raises(s3.exceptions.NoSuchKey):
+        s3.get_object(Bucket=BUCKET, Key="build/graph.db")
+
+
+def test_parse_s3_uri_ok():
+    assert rbj._parse_s3_uri("s3://bucket/a/b/c.db") == ("bucket", "a/b/c.db")
+
+
+@pytest.mark.parametrize("bad", ["http://x/y", "s3://bucket", "s3:///key", "not-a-uri", ""])
+def test_parse_s3_uri_rejects_bad(bad):
+    with pytest.raises(ValueError):
+        rbj._parse_s3_uri(bad)
+
+
+def test_require_env_raises_when_missing(monkeypatch):
+    monkeypatch.delenv("DEFINITELY_NOT_SET", raising=False)
+    with pytest.raises(SystemExit):
+        rbj._require_env("DEFINITELY_NOT_SET")
+
+
+def test_require_env_returns_value(monkeypatch):
+    monkeypatch.setenv("PRESENT", "value")
+    assert rbj._require_env("PRESENT") == "value"

--- a/tests/unit/test_validate_graph_db.py
+++ b/tests/unit/test_validate_graph_db.py
@@ -1,0 +1,232 @@
+"""Tests for the pre-swap graph-DB validation gate.
+
+Used by the out-of-process nightly rebuild conductor (see
+``plans/si-out-of-process-rebuild``) as a fail-closed guard: a build that
+started from an empty DB (and lost the carried-forward enrichment tables) or
+produced an empty/corrupt artist graph must not be swapped into production.
+"""
+
+import json
+import sqlite3
+
+import pytest
+
+from scripts.validate_graph_db import (
+    ENRICHMENT_TABLES,
+    ValidationError,
+    count_rows,
+    main,
+    validate,
+)
+
+# WXYC-representative artists (per the org test-data convention).
+WXYC_ARTISTS = [
+    "Stereolab",
+    "Autechre",
+    "Father John Misty",
+    "Juana Molina",
+    "Jessica Pratt",
+]
+
+
+def _make_graph_db(path, *, artists=WXYC_ARTISTS, enrichment=None):
+    """Create a minimal graph DB: an ``artist`` table plus every enrichment
+    table (each a single nullable column — the validator only counts rows and
+    checks table existence, so realistic columns add nothing).
+
+    ``enrichment`` maps a table name to the number of filler rows to insert;
+    omitted enrichment tables exist but stay empty.
+    """
+    conn = sqlite3.connect(str(path))
+    try:
+        conn.execute(
+            "CREATE TABLE artist ("
+            "  id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            "  canonical_name TEXT NOT NULL UNIQUE,"
+            "  total_plays INTEGER NOT NULL DEFAULT 0)"
+        )
+        for table in ENRICHMENT_TABLES:
+            conn.execute(f"CREATE TABLE {table} (a INTEGER)")  # noqa: S608
+        conn.executemany("INSERT INTO artist (canonical_name) VALUES (?)", [(a,) for a in artists])
+        for table, n in (enrichment or {}).items():
+            conn.executemany(
+                f"INSERT INTO {table} (a) VALUES (?)",  # noqa: S608
+                [(i,) for i in range(n)],
+            )
+        conn.commit()
+    finally:
+        conn.close()
+    return path
+
+
+def test_valid_db_passes(tmp_path):
+    db = _make_graph_db(
+        tmp_path / "graph.db",
+        enrichment={"shared_personnel": 50, "wikidata_influence": 10, "audio_profile": 5},
+    )
+    # No seed_counts: only header + artist checks.
+    validate(db)
+    # Equal enrichment counts vs seed pass.
+    validate(db, seed_counts={"shared_personnel": 50, "wikidata_influence": 10})
+
+
+def test_non_sqlite_file_fails(tmp_path):
+    p = tmp_path / "junk.db"
+    p.write_bytes(b"definitely not a sqlite database")
+    with pytest.raises(ValidationError, match="SQLite"):
+        validate(p)
+
+
+def test_missing_db_file_fails(tmp_path):
+    with pytest.raises(ValidationError):
+        validate(tmp_path / "nope.db")
+
+
+def test_empty_artist_table_fails(tmp_path):
+    db = _make_graph_db(tmp_path / "graph.db", artists=[])
+    with pytest.raises(ValidationError, match="artist count"):
+        validate(db)
+
+
+def test_missing_artist_table_fails(tmp_path):
+    db = tmp_path / "graph.db"
+    conn = sqlite3.connect(str(db))
+    conn.execute("CREATE TABLE foo (x INTEGER)")
+    conn.commit()
+    conn.close()
+    with pytest.raises(ValidationError, match="artist"):
+        validate(db)
+
+
+def test_min_artists_floor(tmp_path):
+    db = _make_graph_db(tmp_path / "graph.db", artists=WXYC_ARTISTS)  # 5 artists
+    validate(db, min_artists=5)
+    with pytest.raises(ValidationError, match="minimum"):
+        validate(db, min_artists=6)
+
+
+def test_enrichment_collapse_to_zero_fails(tmp_path):
+    # Build lost shared_personnel entirely; seed had 100 rows -> regression.
+    db = _make_graph_db(tmp_path / "graph.db", enrichment={"wikidata_influence": 10})
+    with pytest.raises(ValidationError, match="shared_personnel"):
+        validate(db, seed_counts={"shared_personnel": 100})
+
+
+def test_enrichment_prune_tolerated(tmp_path):
+    # Seed had 100; build pruned to 20 (top-K). Floor = max(1, 100*0.1)=10; 20>=10 passes.
+    db = _make_graph_db(tmp_path / "graph.db", enrichment={"shared_personnel": 20})
+    validate(db, seed_counts={"shared_personnel": 100})
+
+
+def test_enrichment_just_below_floor_fails(tmp_path):
+    # Seed 100, floor 10, build 9 -> fail.
+    db = _make_graph_db(tmp_path / "graph.db", enrichment={"shared_personnel": 9})
+    with pytest.raises(ValidationError, match="shared_personnel"):
+        validate(db, seed_counts={"shared_personnel": 100})
+
+
+def test_seed_zero_count_tables_ignored(tmp_path):
+    # A table that was empty in the seed imposes no requirement on the build.
+    db = _make_graph_db(tmp_path / "graph.db", enrichment={"shared_personnel": 5})
+    validate(db, seed_counts={"label_hierarchy": 0, "shared_personnel": 5})
+
+
+def test_count_rows_omits_missing_tables(tmp_path):
+    db = tmp_path / "graph.db"
+    conn = sqlite3.connect(str(db))
+    conn.executescript(
+        "CREATE TABLE artist (id INTEGER PRIMARY KEY, canonical_name TEXT);"
+        "CREATE TABLE shared_personnel (a INTEGER);"
+    )
+    conn.execute("INSERT INTO shared_personnel (a) VALUES (1)")
+    conn.commit()
+    conn.close()
+    # Only the enrichment table that exists is reported.
+    assert count_rows(db) == {"shared_personnel": 1}
+
+
+def test_cli_emit_counts(tmp_path, capsys):
+    db = _make_graph_db(
+        tmp_path / "graph.db",
+        enrichment={"shared_personnel": 7, "audio_profile": 3},
+    )
+    rc = main([str(db), "--emit-counts"])
+    assert rc == 0
+    printed = json.loads(capsys.readouterr().out)
+    assert printed["shared_personnel"] == 7
+    assert printed["audio_profile"] == 3
+
+
+def test_cli_returns_1_on_validation_failure(tmp_path):
+    db = _make_graph_db(tmp_path / "graph.db", artists=[])  # empty artist table
+    assert main([str(db)]) == 1
+
+
+def test_cli_passes_with_seed_counts_file(tmp_path):
+    db = _make_graph_db(tmp_path / "graph.db", enrichment={"shared_personnel": 40})
+    seed_file = tmp_path / "seed.json"
+    seed_file.write_text(json.dumps({"shared_personnel": 50}))
+    assert main([str(db), "--seed-counts", str(seed_file)]) == 0
+
+
+def test_enrichment_table_entirely_missing_fails(tmp_path):
+    # The real "build started from an empty DB" failure mode: the enrichment
+    # table doesn't exist at all (distinct from existing-but-empty). count_rows
+    # omits a missing table, so build_counts.get(table, 0) -> 0 -> collapse.
+    db = _make_graph_db(tmp_path / "graph.db", enrichment={"wikidata_influence": 10})
+    conn = sqlite3.connect(str(db))
+    conn.execute("DROP TABLE shared_personnel")
+    conn.commit()
+    conn.close()
+    with pytest.raises(ValidationError, match="shared_personnel"):
+        validate(db, seed_counts={"shared_personnel": 100})
+
+
+def test_enrichment_exactly_at_floor_passes(tmp_path):
+    # Boundary: seed=100 -> floor = max(1, int(100*0.1)) = 10; build == floor
+    # passes because the guard is `build_n < floor` (strict). Pins the off-by-one.
+    db = _make_graph_db(tmp_path / "graph.db", enrichment={"shared_personnel": 10})
+    validate(db, seed_counts={"shared_personnel": 100})
+
+
+def test_corrupt_body_with_valid_header_raises_validation_error(tmp_path):
+    # A file with the real SQLite magic header but a corrupt body passes the
+    # header precheck, then the query raises sqlite3.DatabaseError — which
+    # validate() must convert to ValidationError (not let it escape as a
+    # traceback), so a caller catching only ValidationError stays fail-closed.
+    db = tmp_path / "graph.db"
+    db.write_bytes(b"SQLite format 3\x00" + b"\xde\xad\xbe\xef" * 64)
+    with pytest.raises(ValidationError, match="not a valid SQLite database"):
+        validate(db)
+
+
+def test_inactive_guard_warns_when_seed_all_zero(tmp_path, caplog):
+    # When the seed had zero enrichment everywhere, the collapse guard can't run.
+    # Validation still passes on artist count, but it must WARN (not silently
+    # disarm), so an empty-seed -> empty-build chain is visible in the logs.
+    import logging
+
+    db = _make_graph_db(tmp_path / "graph.db", enrichment={})
+    with caplog.at_level(logging.WARNING):
+        validate(db, seed_counts={"shared_personnel": 0, "wikidata_influence": 0})
+    assert any("enrichment guard INACTIVE" in r.message for r in caplog.records)
+
+
+def test_enrichment_table_names_match_real_schema():
+    # Guards ENRICHMENT_TABLES against drifting from the actual SQLite schema
+    # (the #347 'discogs_edges' module-vs-table confusion): every name must be a
+    # real `CREATE TABLE` somewhere in semantic_index, or its preservation guard
+    # silently does nothing in production.
+    import re
+    from pathlib import Path
+
+    si_dir = Path(__file__).resolve().parents[2] / "semantic_index"
+    sources = "\n".join(p.read_text() for p in si_dir.rglob("*.py"))
+    created = {
+        name.lower()
+        for name in re.findall(r"CREATE TABLE (?:IF NOT EXISTS )?(\w+)", sources, re.IGNORECASE)
+    }
+    missing = [t for t in ENRICHMENT_TABLES if t.lower() not in created]
+    assert not missing, (
+        f"ENRICHMENT_TABLES not found as a CREATE TABLE in semantic_index: {missing}"
+    )


### PR DESCRIPTION
First of three chained PRs implementing the out-of-process nightly rebuild from WXYC/semantic-index#347 (durable fix for #329; resolves the availability half of WXYC/wxyc-canary#50). Plan: `plans/si-out-of-process-rebuild/plan.md` in the wxyc-workspace meta-repo.

## What this PR adds (the code half)

`scripts/run_build_job.py` — the Fargate container entrypoint. Downloads the seed (current production graph) from S3, runs the existing `nightly_sync` against Backend-Service PG, and uploads the rebuilt DB back to S3. It invokes the orchestrator the same way `sync_scheduler` already does (a programmatic `argparse.Namespace`, not argv re-parsing), and fails closed: a failed build exits non-zero **without** uploading, so a broken graph never ships.

`scripts/validate_graph_db.py` — the fail-closed pre-swap gate. Checks the SQLite magic header, an `artist`-count floor, and enrichment preservation by comparing the build's enrichment row counts against the seed's. This catches the one regression that matters: a build that started from an empty DB and lost the enrichment tables that `nightly_sync` only carries forward via `shutil.copy2`. `--emit-counts` lets the conductor capture the seed baseline through the same code path.

`pyproject.toml` / `Dockerfile` — a lean `build` extra adds boto3 for the S3 round-trip (and `moto` to `dev` for the tests); the image installs `.[api,build]`. No Essentia — `nightly_sync` imports none of the audio modules.

## Note: there is no `discogs_edges` table

The issue's acceptance list names a `discogs_edges` table; that is a *module* name (`semantic_index/discogs_edges.py`), not a table. Discogs enrichment materializes into `shared_personnel` / `shared_style` / `label_family` / `compilation`. The validator's `ENRICHMENT_TABLES` is grounded in the real schema (`sqlite_export.py`, `acousticbrainz.py`).

## Tests

`tests/unit/test_run_build_job.py` (moto) pins the S3 round-trip wiring and the no-upload-on-failure contract; `tests/unit/test_validate_graph_db.py` covers every validation branch plus the CLI. Full suite green (1110 passed), ruff/format/mypy clean.

## Safe to merge independently

This PR only adds two scripts that nothing invokes yet, plus boto3 in the image. No behavior change to the running API. The infra that runs these (CloudFormation task + EC2 conductor) lands in the next two PRs; nothing activates until an operator deploys the stack and installs the timer.

Part 1 of 3 — followed by the infra PR, then the conductor PR (which closes #347).