### PR TITLE
Out-of-process rebuild (2/3): CloudFormation stack + deploy script for the VPC build task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ data/*.tmp.*.db-wal
 
 wiki/
 slides
+
+# Out-of-process rebuild: per-environment AWS IDs (see infra/build-job.conf.example)
+infra/build-job.conf

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -56,7 +56,21 @@ Two classes of pin in `.github/workflows/*.yml` exist for supply-chain reasons (
 
 Run `actionlint .github/workflows/*.yml` locally before pushing workflow changes; it validates `permissions:` syntax, action-version pins, and shell-script blocks (via shellcheck), and catches the silent-mistake class of errors above before CI does. The current `deploy.yml` has 8 pre-existing SC2086 info-level shellcheck warnings that have been deferred — they're info, not error, and predate the pin work.
 
-## Nightly sync scheduler (in-process)
+## Nightly rebuild (out-of-process — current target state, #347)
+
+The nightly graph rebuild runs **out of the API process** as an on-demand ECS Fargate task in the Backend-Service VPC, and the rebuilt `wxyc_artist_graph.db` is shipped back to the serving host and atomically swapped in without an API restart. This replaces the in-process scheduler (below), which OOM-killed every night under the `--memory 1g` cap and took the API down with it (canary #50). Full design: `WXYC/wxyc-workspace plans/si-out-of-process-rebuild/plan.md`; infra + runbook: [`infra/README.md`](../infra/README.md).
+
+Flow (round-trip; the EC2 host's `scripts/ec2-build-conductor.sh` is the single nightly driver, fired by `deploy/semantic-index-build.timer`):
+
+1. The conductor snapshots the live prod DB (consistent `sqlite .backup`), records its enrichment row counts, and uploads the snapshot to `s3://wxyc-semantic-index-build/seed/` — the build **must** seed from current prod because `nightly_sync` is incremental (`copy2` carries the enrichment tables forward).
+2. It launches the Fargate task (`aws ecs run-task`), which downloads the seed, runs `nightly_sync` against the RDS private endpoint (≥4 GiB budget; first place the full `[mem]` profile past `after _load_from_pg` is observable, in CloudWatch `/ecs/semantic-index-build`), checkpoints, and uploads the result to `s3://.../build/`.
+3. The conductor downloads the artifact, runs the **fail-closed** validation gate (`scripts/validate_graph_db.py`: SQLite header + `artist` floor + enrichment row counts vs. the seed — a build that started empty and lost enrichment is rejected and **not** swapped), then clears stale `-wal`/`-shm` and `os.replace`s it into the live path. The per-request read-only open (`api/database.py`) picks up the new inode on the next request — no restart, no reopen.
+
+AWS: account `203767826763` (`wxyc-api`), us-east-1; the Fargate image is the same `semantic-index` ECR image with its command overridden to `scripts/run_build_job.py`. Cost ≈ $0.30/mo. The container image installs `.[api,build]` (adds boto3 for the S3 round-trip; no Essentia).
+
+**Cutover:** once the off-host path is proven for ≥2 nights, set `SYNC_ENABLED=false` and recreate the container so the API only serves. Until then the in-process scheduler is harmless (it dies in `load_flowsheet_entries` before ever writing the prod file) but keeps causing the nightly restart blip.
+
+## Nightly sync scheduler (in-process — legacy, disabled at cutover)
 
 The API service includes a built-in sync scheduler that runs `nightly_sync()` as a background daemon thread. Enable it by setting env vars in `.env.semantic-index`:
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,92 @@
+# infra — out-of-process nightly rebuild
+
+Implements [WXYC/semantic-index#347](https://github.com/WXYC/semantic-index/issues/347). The nightly graph rebuild no longer runs in the API container (where it OOM-killed under the `--memory 1g` cap, taking the API down — canary #50). Instead it runs as an on-demand **ECS Fargate task in the Backend-Service VPC** with an adequate memory budget, and the rebuilt `wxyc_artist_graph.db` is shipped back to the serving host and atomically swapped in **without an API restart**.
+
+See `plans/si-out-of-process-rebuild/plan.md` (in the `wxyc-workspace` meta-repo) for the full design.
+
+## Pieces
+
+| Where | What |
+|---|---|
+| `build-job.yaml` | CloudFormation: S3 transfer bucket, ECS cluster, run-to-completion Fargate task def (reuses the `semantic-index` image, command → `scripts/run_build_job.py`), IAM roles, egress SG, log group. |
+| `deploy.sh` | `aws cloudformation deploy` wrapper; reads `build-job.conf`. |
+| `build-job.conf.example` | Template for the BS-VPC IDs (`build-job.conf` is gitignored). |
+| `scripts/run_build_job.py` | Container entrypoint: S3 seed → `nightly_sync` → S3 build. |
+| `scripts/validate_graph_db.py` | Pre-swap validation gate (header + artist + enrichment-preservation). |
+| `scripts/ec2-build-conductor.sh` | Nightly driver on the EC2 host (snapshot → run-task → validate → swap). |
+| `deploy/semantic-index-build.{service,timer}` | systemd units that run the conductor. |
+
+## Account / region
+
+WXYC account **`203767826763`** (`AWS_PROFILE=wxyc-api`), **us-east-1** — the same account/VPC as the BS EC2 host and the `wxyc-db` RDS instance. **Not** the personal `503977661500` account.
+
+## Deploy
+
+```bash
+cp infra/build-job.conf.example infra/build-job.conf   # then fill in VPC_ID
+AWS_PROFILE=wxyc-api ./infra/deploy.sh
+```
+
+`deploy.sh` prints the stack outputs (`ClusterArn`, `TaskDefinitionArn`, `BuildSecurityGroupId`, `BucketName`, `TaskRoleArn`, `TaskExecutionRoleArn`) used by the out-of-band steps below.
+
+## Out-of-band, one-time setup
+
+These touch resources the stack does not own, so they are applied by hand (all `AWS_PROFILE=wxyc-api`).
+
+### 1. RDS security-group inbound rule — the single must-do networking step
+
+Without this the task connects nowhere. Find the RDS SG, then allow 5432 from `BuildSecurityGroupId`:
+
+```bash
+RDS_SG=$(aws rds describe-db-instances --db-instance-identifier wxyc-db \
+  --query 'DBInstances[0].VpcSecurityGroups[0].VpcSecurityGroupId' --output text)
+BUILD_SG=<BuildSecurityGroupId from stack outputs>
+aws ec2 authorize-security-group-ingress --group-id "$RDS_SG" \
+  --protocol tcp --port 5432 --source-group "$BUILD_SG"
+```
+
+### 2. Database DSN as a SecureString
+
+```bash
+aws ssm put-parameter --name /semantic-index/database-url-backend \
+  --type SecureString \
+  --value "postgresql://<user>:<pass>@wxyc-db.cc7ob5nnabjm.us-east-1.rds.amazonaws.com:5432/<db>"
+```
+
+Use the **private** RDS endpoint (the task is in-VPC). This is the value already in `.env.semantic-index` as `DATABASE_URL_BACKEND`.
+
+### 3. EC2 instance-profile additions (for the conductor)
+
+The conductor runs on the EC2 host under the `wxyc-ec2-backend` instance profile. Attach an inline policy granting it the S3 round-trip + `ecs:RunTask`/`DescribeTasks` + scoped `iam:PassRole`. Substitute the stack-output ARNs:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    { "Effect": "Allow",
+      "Action": ["s3:PutObject", "s3:GetObject"],
+      "Resource": "arn:aws:s3:::wxyc-semantic-index-build/*" },
+    { "Effect": "Allow", "Action": "s3:ListBucket",
+      "Resource": "arn:aws:s3:::wxyc-semantic-index-build" },
+    { "Effect": "Allow",
+      "Action": ["ecs:RunTask", "ecs:DescribeTasks"],
+      "Resource": "*",
+      "Condition": { "ArnEquals": { "ecs:cluster": "<ClusterArn>" } } },
+    { "Effect": "Allow", "Action": "iam:PassRole",
+      "Resource": ["<TaskRoleArn>", "<TaskExecutionRoleArn>"] }
+  ]
+}
+```
+
+## Proving + cutover
+
+1. **Dry run.** Launch the task by hand and watch CloudWatch Logs `/ecs/semantic-index-build` (this is the first time the full `[mem]` profile past `after _load_from_pg` is ever observed):
+   ```bash
+   aws ecs run-task --cluster semantic-index-build --task-definition semantic-index-build \
+     --launch-type FARGATE \
+     --network-configuration "awsvpcConfiguration={subnets=[<SUBNET>],securityGroups=[<BUILD_SG>],assignPublicIp=ENABLED}"
+   ```
+   Download `s3://wxyc-semantic-index-build/build/wxyc_artist_graph.db` and run `validate_graph_db.py` — **do not swap yet**.
+2. Install the conductor + timer on EC2 (see `deploy/`), let it run the full round-trip for ≥2 nights; confirm prod mtime advances and enrichment persists.
+3. Set `SYNC_ENABLED=false` in `.env.semantic-index` and **recreate** the container (`docker restart` does not re-read env).
+4. Over ≥2 further nights confirm mtime keeps advancing and canary #50 stops firing on the 09:00 window.

--- a/infra/build-job.conf.example
+++ b/infra/build-job.conf.example
@@ -1,0 +1,33 @@
+# Backend-Service VPC ID for the nightly-build CloudFormation stack
+# (infra/deploy.sh). Copy to build-job.conf (gitignored) and fill in VPC_ID.
+#
+# VPC_ID is the only value deploy.sh needs. The PUBLIC subnet id(s) and the
+# BuildSecurityGroup id go into the conductor's systemd unit
+# (deploy/semantic-index-build.service), NOT the stack — the task is
+# run-to-completion and gets its network config at `aws ecs run-task` time.
+#
+# Look the values up from the EC2 serving host (AWS_PROFILE=wxyc-api), which
+# lives in the same VPC as RDS:
+#
+#   INSTANCE=i-0685e373989cd5daa
+#   aws ec2 describe-instances --instance-ids "$INSTANCE" \
+#     --query 'Reservations[0].Instances[0].{VpcId:VpcId,SubnetId:SubnetId}'
+#   # then list public subnets in that VPC (MapPublicIpOnLaunch==true):
+#   aws ec2 describe-subnets --filters "Name=vpc-id,Values=<VPC_ID>" \
+#     --query 'Subnets[?MapPublicIpOnLaunch==`true`].SubnetId'
+#
+# The RDS security-group id (for the out-of-band inbound rule) comes from:
+#   aws rds describe-db-instances --db-instance-identifier wxyc-db \
+#     --query 'DBInstances[0].VpcSecurityGroups[0].VpcSecurityGroupId'
+
+VPC_ID=vpc-xxxxxxxx
+# Optional: pin a specific image instead of :latest
+# IMAGE_TAG=latest
+# Optional: Fargate task size. Set TASK_MEMORY to "dial down" once the [mem]
+# profile is known (deploy.sh passes these every run, so a tuned value sticks).
+# TASK_CPU=1024
+# TASK_MEMORY=8192
+
+# For the conductor's systemd unit (deploy/semantic-index-build.service), not deploy.sh:
+#   SUBNETS  = a public subnet id in VPC_ID (from the describe-subnets lookup above)
+#   BUILD_SG = the BuildSecurityGroupId from the CloudFormation stack outputs

--- a/infra/build-job.yaml
+++ b/infra/build-job.yaml
@@ -1,0 +1,226 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  Out-of-process nightly rebuild for semantic-index (WXYC/semantic-index#347).
+  Defines an on-demand ECS Fargate task that rebuilds wxyc_artist_graph.db in
+  the Backend-Service VPC (reaching the RDS private endpoint), with an adequate
+  memory budget, and round-trips the DB through S3. The EC2 serving host's
+  conductor (scripts/ec2-build-conductor.sh) seeds the build, launches this task
+  with `aws ecs run-task`, then validates and atomically swaps the result in.
+
+  This stack creates ONLY the runnable task + supporting resources. Three steps
+  touch resources this stack does not own and are applied out of band (see
+  infra/README.md): (1) an inbound rule on the RDS security group allowing 5432
+  from BuildSecurityGroup; (2) the DATABASE_URL_BACKEND SecureString SSM
+  parameter; (3) the S3 + ecs:RunTask + iam:PassRole additions to the EC2
+  instance profile.
+
+# ---------------------------------------------------------------------------
+# Parameters — VPC/subnet IDs are Backend-Service's; look them up from the EC2
+# host (see infra/README.md). The task MUST be in the RDS VPC.
+# ---------------------------------------------------------------------------
+Parameters:
+  VpcId:
+    Type: AWS::EC2::VPC::Id
+    Description: >
+      The Backend-Service VPC (the one the RDS instance lives in). Used for the
+      build task's security group. Subnets are NOT a stack input — the task is
+      run-to-completion, so its network config (subnets + this SG +
+      AssignPublicIp=ENABLED) is supplied at `aws ecs run-task` time by the
+      conductor (SUBNETS in deploy/semantic-index-build.service). Use PUBLIC
+      subnets in this VPC: the IGW gives egress to ECR/S3/Logs while RDS is
+      reached on its private IP via in-VPC routing.
+
+  ImageTag:
+    Type: String
+    Default: latest
+    Description: semantic-index ECR image tag to run (deploy.yml pushes :latest and :sha-*).
+
+  DatabaseUrlSsmParam:
+    Type: String
+    Default: /semantic-index/database-url-backend
+    Description: >
+      Name of the SecureString SSM parameter holding DATABASE_URL_BACKEND (the
+      RDS private-endpoint DSN). Created out of band; see infra/README.md.
+
+  BucketName:
+    Type: String
+    Default: wxyc-semantic-index-build
+    Description: S3 bucket for the seed/ and build/ DB transfer objects.
+
+  TaskCpu:
+    Type: String
+    Default: "1024"
+    Description: Fargate task vCPU units (1024 = 1 vCPU).
+
+  TaskMemory:
+    Type: String
+    Default: "8192"
+    Description: >
+      Fargate task memory (MiB). Start at 8192 — graph_metrics has never run to
+      completion under load, so its peak is unmeasured. Dial down to 4096 once a
+      couple of nights of the [mem] profile are observed in CloudWatch Logs.
+
+Resources:
+  # =========================================================================
+  # S3 — transient seed/ + build/ DB transfer. Private; lifecycle-expired.
+  # =========================================================================
+  BuildBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Ref BucketName
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      LifecycleConfiguration:
+        Rules:
+          - Id: expire-transient-db-objects
+            Status: Enabled
+            ExpirationInDays: 3
+          - Id: abort-incomplete-multipart
+            Status: Enabled
+            AbortIncompleteMultipartUpload:
+              DaysAfterInitiation: 1
+
+  # =========================================================================
+  # ECS — cluster, task definition (run-to-completion; NO standing service)
+  # =========================================================================
+  LogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: /ecs/semantic-index-build
+      RetentionInDays: 14
+
+  Cluster:
+    Type: AWS::ECS::Cluster
+    Properties:
+      ClusterName: semantic-index-build
+
+  BuildSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: semantic-index nightly build task - egress only
+      VpcId: !Ref VpcId
+      SecurityGroupEgress:
+        - IpProtocol: "-1"
+          CidrIp: 0.0.0.0/0
+          Description: Allow all outbound (RDS 5432 in-VPC, S3/ECR/Logs via IGW)
+
+  # Execution role: ECR pull + CloudWatch Logs + read the DSN SecureString.
+  TaskExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: semantic-index-build-exec
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+      Policies:
+        - PolicyName: ReadDatabaseUrlSecret
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ssm:GetParameters
+                Resource: !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${DatabaseUrlSsmParam}"
+              # SecureString uses the AWS-managed alias/aws/ssm key; ECS can
+              # decrypt it with the GetParameters grant above. If the parameter
+              # is ever re-created under a customer-managed KMS key, add a
+              # kms:Decrypt statement scoped to that key ARN here.
+
+  # Task role: the running container downloads the seed and uploads the build.
+  TaskRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: semantic-index-build-task
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: S3RoundTrip
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action: s3:GetObject
+                Resource: !Sub "${BuildBucket.Arn}/seed/*"
+              - Effect: Allow
+                Action: s3:PutObject
+                Resource: !Sub "${BuildBucket.Arn}/build/*"
+              # No s3:ListBucket — run_build_job.py only does get_object/put_object
+              # on known keys. (The conductor lists via the EC2 instance profile,
+              # not this task role.)
+
+  TaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: semantic-index-build
+      NetworkMode: awsvpc
+      RequiresCompatibilities: [FARGATE]
+      Cpu: !Ref TaskCpu
+      Memory: !Ref TaskMemory
+      # Default 20 GiB ephemeral storage covers the ~3 GB working set (seed copy
+      # + nightly_sync's copy2 temp); no EphemeralStorage override needed.
+      ExecutionRoleArn: !GetAtt TaskExecutionRole.Arn
+      TaskRoleArn: !GetAtt TaskRole.Arn
+      ContainerDefinitions:
+        - Name: build
+          Image: !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/semantic-index:${ImageTag}"
+          Essential: true
+          # Reuse the serving image; override CMD to run the build wrapper.
+          Command: ["python", "scripts/run_build_job.py"]
+          Environment:
+            - Name: DB_PATH
+              Value: /data/wxyc_artist_graph.db
+            - Name: SEED_S3_URI
+              Value: !Sub "s3://${BucketName}/seed/wxyc_artist_graph.db"
+            - Name: BUILD_S3_URI
+              Value: !Sub "s3://${BucketName}/build/wxyc_artist_graph.db"
+            - Name: SYNC_MIN_COUNT
+              Value: "2"
+            - Name: ENRICHMENT_TOP_K
+              Value: "50"
+          Secrets:
+            - Name: DATABASE_URL_BACKEND
+              ValueFrom: !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${DatabaseUrlSsmParam}"
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Ref LogGroup
+              awslogs-region: !Ref "AWS::Region"
+              awslogs-stream-prefix: build
+
+# ---------------------------------------------------------------------------
+# Outputs — consumed by infra/README.md (RDS SG rule, instance-profile policy)
+# and by scripts/ec2-build-conductor.sh (cluster / task-def / subnets / SG).
+# ---------------------------------------------------------------------------
+Outputs:
+  ClusterArn:
+    Description: ECS cluster to run the task in.
+    Value: !GetAtt Cluster.Arn
+  TaskDefinitionArn:
+    Description: Task definition to pass to `aws ecs run-task`.
+    Value: !Ref TaskDefinition
+  BuildSecurityGroupId:
+    Description: Add an inbound 5432 rule on the RDS SG FROM this SG.
+    Value: !GetAtt BuildSecurityGroup.GroupId
+  BucketName:
+    Description: S3 bucket for seed/ + build/ transfer.
+    Value: !Ref BucketName
+  TaskRoleArn:
+    Description: Scope the instance profile's iam:PassRole to this (and the exec role).
+    Value: !GetAtt TaskRole.Arn
+  TaskExecutionRoleArn:
+    Description: Scope the instance profile's iam:PassRole to this (and the task role).
+    Value: !GetAtt TaskExecutionRole.Arn

--- a/infra/deploy.sh
+++ b/infra/deploy.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+#
+# Deploy the out-of-process nightly-rebuild CloudFormation stack
+# (infra/build-job.yaml) into the WXYC account (203767826763 / us-east-1).
+#
+# Usage:
+#   AWS_PROFILE=wxyc-api ./infra/deploy.sh
+#
+# Reads infra/build-job.conf (gitignored) for the BS-VPC-specific IDs. Copy
+# infra/build-job.conf.example and fill it in first (see infra/README.md for how
+# to look the values up from the EC2 host).
+#
+# The semantic-index image itself is built and pushed by the repo's deploy.yml
+# on push to main; this script only deploys/updates the stack against an
+# existing :latest (or :sha-*) image tag.
+
+set -euo pipefail
+
+REGION="${AWS_REGION:-us-east-1}"
+STACK_NAME="${STACK_NAME:-semantic-index-build}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEMPLATE="$SCRIPT_DIR/build-job.yaml"
+CONF="$SCRIPT_DIR/build-job.conf"
+
+if [[ ! -f "$CONF" ]]; then
+  echo "ERROR: $CONF not found. Copy build-job.conf.example and fill in VPC_ID." >&2
+  exit 1
+fi
+# shellcheck source=/dev/null
+source "$CONF"
+
+: "${VPC_ID:?set VPC_ID in build-job.conf}"
+IMAGE_TAG="${IMAGE_TAG:-latest}"
+# TaskCpu/TaskMemory are passed through every deploy so a tuned value STICKS:
+# `cloudformation deploy` resets any parameter omitted from --parameter-overrides
+# back to the template default, so to "dial down" memory (per the template's
+# guidance) set TASK_MEMORY here rather than editing the live task def.
+TASK_CPU="${TASK_CPU:-1024}"
+TASK_MEMORY="${TASK_MEMORY:-8192}"
+# SUBNET_IDS is consumed by the conductor's systemd unit (run-task time), not by
+# the stack — see infra/README.md.
+
+echo "Validating template..."
+aws cloudformation validate-template --region "$REGION" --template-body "file://$TEMPLATE" >/dev/null
+
+echo "Deploying stack '$STACK_NAME' (region $REGION, image tag $IMAGE_TAG)..."
+aws cloudformation deploy \
+  --region "$REGION" \
+  --stack-name "$STACK_NAME" \
+  --template-file "$TEMPLATE" \
+  --capabilities CAPABILITY_NAMED_IAM \
+  --no-fail-on-empty-changeset \
+  --parameter-overrides \
+    "VpcId=$VPC_ID" \
+    "ImageTag=$IMAGE_TAG" \
+    "TaskCpu=$TASK_CPU" \
+    "TaskMemory=$TASK_MEMORY"
+
+echo "Stack outputs:"
+aws cloudformation describe-stacks \
+  --region "$REGION" \
+  --stack-name "$STACK_NAME" \
+  --query "Stacks[0].Outputs" \
+  --output table
+
+cat <<'NOTE'
+
+Next (one-time, out of band — see infra/README.md):
+  1. Add an inbound rule on the RDS security group: TCP 5432 FROM BuildSecurityGroupId.
+  2. Put the DSN: aws ssm put-parameter --name /semantic-index/database-url-backend \
+       --type SecureString --value "<rds-private-dsn>"
+  3. Extend the EC2 instance profile (wxyc-ec2-backend) with S3 + ecs:RunTask +
+     ecs:DescribeTasks + iam:PassRole (scoped to the task/exec role ARNs above).
+NOTE


### PR DESCRIPTION
Second of three chained PRs for WXYC/semantic-index#347. **Base is `si-rebuild-code` (#349)** — review/merge that first; this diff is only the infra layer. Plan: `plans/si-out-of-process-rebuild/plan.md`.

## What this PR adds (the infra half)

`infra/build-job.yaml` — CloudFormation for an on-demand ECS Fargate task (run-to-completion, **no** standing service) in the Backend-Service VPC, so it reaches the RDS private endpoint that vanilla GitHub Actions runners cannot. Resources: an S3 transfer bucket (3-day lifecycle), an ECS cluster, a task definition that **reuses the `semantic-index` image** with its command overridden to `scripts/run_build_job.py`, least-privilege exec/task roles, an egress-only security group, and a log group. The DSN is read from an SSM SecureString, not baked into the task def. Sized 1 vCPU / 8 GiB to start (graph_metrics has never run to completion under load — dial down to 4 GiB once the `[mem]` profile is observed in CloudWatch).

Subnets are deliberately **not** a stack parameter: a run-to-completion task gets its network config at `aws ecs run-task` time (from the conductor), so only `VpcId` (for the security group) is an input. cfn-lint flagged the unused param and I removed it.

`infra/deploy.sh` + `infra/build-job.conf.example` — a `cloudformation deploy` wrapper reading per-environment IDs from a gitignored conf.

`infra/README.md` — the runbook, including the three out-of-band steps the stack cannot own: the RDS security-group inbound rule (the single must-do networking step), the DSN SSM parameter, and the EC2 instance-profile additions for the conductor.

`docs/deployment.md` — an out-of-process rebuild section; the in-process scheduler is marked legacy/disabled-at-cutover.

## Account

WXYC account `203767826763` (`wxyc-api`), us-east-1 — same account/VPC as the BS EC2 host and `wxyc-db` RDS. Not the personal account. Cost ~= $0.30/mo.

Validated with `cfn-lint` (clean) and `shellcheck` (clean). Part 2 of 3 — the conductor PR follows and closes #347.