### PR TITLE
Out-of-process rebuild (3/3): EC2 conductor + systemd units

### DIFF
--- a/deploy/semantic-index-build.service
+++ b/deploy/semantic-index-build.service
@@ -1,0 +1,34 @@
+# Out-of-process nightly graph rebuild conductor (WXYC/semantic-index#347).
+# Oneshot service invoked by semantic-index-build.timer. Drives the round-trip:
+# snapshot prod DB -> S3 seed -> Fargate build -> validate -> atomic swap.
+#
+# Install on the BS EC2 host:
+#   sudo cp deploy/semantic-index-build.service /etc/systemd/system/
+#   sudo cp deploy/semantic-index-build.timer   /etc/systemd/system/
+#   sudo cp scripts/ec2-build-conductor.sh /home/ec2-user/
+#   # edit the Environment= lines below with the stack-output SUBNETS / BUILD_SG
+#   sudo systemctl daemon-reload
+#   sudo systemctl enable --now semantic-index-build.timer
+#
+# One-off manual run:  sudo systemctl start semantic-index-build.service
+# Logs:                journalctl -u semantic-index-build.service -f
+[Unit]
+Description=semantic-index out-of-process nightly graph rebuild
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+User=ec2-user
+# Fill these from the CloudFormation stack outputs (infra/build-job.yaml):
+Environment=SUBNETS=subnet-xxxxxxxx
+Environment=BUILD_SG=sg-xxxxxxxx
+Environment=AWS_REGION=us-east-1
+# Optional overrides (defaults shown in scripts/ec2-build-conductor.sh):
+# Environment=DATA_DIR=/home/ec2-user/semantic-index-data
+# Environment=IMAGE=semantic-index:latest
+# Environment=MIN_ARTISTS=1000
+ExecStart=/home/ec2-user/ec2-build-conductor.sh
+# Comfortably above the conductor's BUILD_WAIT_CEILING_SECS (2700s) plus the
+# snapshot/upload/download/validate I/O on the ~1.5 GB DB.
+TimeoutStartSec=3600

--- a/deploy/semantic-index-build.timer
+++ b/deploy/semantic-index-build.timer
@@ -1,0 +1,14 @@
+# Fires the nightly rebuild conductor (WXYC/semantic-index#347).
+# 08:50 UTC: a little before the old in-process SYNC_HOUR_UTC=9 window, so the
+# new path is the one that produces the day's graph. Persistent=true catches up
+# a missed run if the host was down at the trigger time.
+[Unit]
+Description=Nightly trigger for the semantic-index out-of-process graph rebuild
+
+[Timer]
+OnCalendar=*-*-* 08:50:00 UTC
+Persistent=true
+Unit=semantic-index-build.service
+
+[Install]
+WantedBy=timers.target

--- a/scripts/ec2-build-conductor.sh
+++ b/scripts/ec2-build-conductor.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+#
+# Nightly conductor for the out-of-process graph rebuild (WXYC/semantic-index#347).
+# Runs on the Backend-Service EC2 serving host (installed via the systemd units
+# in deploy/). It is the single driver of the round-trip:
+#
+#   1. snapshot the live production DB and capture its enrichment row counts
+#   2. upload the snapshot to S3 as the build's SEED
+#   3. launch the Fargate build task (aws ecs run-task) and wait for it
+#   4. download the build artifact; validate it (fail-closed gate)
+#   5. atomically swap it into the live serving path (no API restart)
+#
+# All heavy work (the ~4 GiB rebuild) happens in Fargate; the conductor only does
+# light, low-memory I/O. Every step is logged; any failure leaves the currently
+# serving DB untouched and exits non-zero.
+#
+# Requires (on the host): aws CLI + instance-profile creds (see infra/README.md
+# step 3), docker, and the semantic-index image locally (the serving image).
+#
+# Config via environment (systemd unit sets these; defaults below):
+#   DATA_DIR        /home/ec2-user/semantic-index-data
+#   DB_NAME         wxyc_artist_graph.db
+#   IMAGE           semantic-index image ref used for sqlite backup + validation
+#   BUCKET          wxyc-semantic-index-build
+#   CLUSTER         semantic-index-build
+#   TASK_DEF        semantic-index-build
+#   SUBNETS         comma-separated subnet ids (public, BS VPC)
+#   BUILD_SG        BuildSecurityGroup id
+#   AWS_REGION      us-east-1
+#   MIN_ARTISTS     artist-count floor for validation (default 1000)
+
+set -euo pipefail
+
+DATA_DIR="${DATA_DIR:-/home/ec2-user/semantic-index-data}"
+DB_NAME="${DB_NAME:-wxyc_artist_graph.db}"
+IMAGE="${IMAGE:-semantic-index:latest}"
+BUCKET="${BUCKET:-wxyc-semantic-index-build}"
+CLUSTER="${CLUSTER:-semantic-index-build}"
+TASK_DEF="${TASK_DEF:-semantic-index-build}"
+AWS_REGION="${AWS_REGION:-us-east-1}"
+MIN_ARTISTS="${MIN_ARTISTS:-1000}"
+# Ceiling for waiting on the Fargate build. Must exceed the build's worst case
+# (graph_metrics is unmeasured under load) but stay under the systemd unit's
+# TimeoutStartSec. NOT `aws ecs wait tasks-stopped`, whose botocore waiter is
+# fixed at 100x6s = 600s (10 min) and would abort a longer build without
+# swapping — the unit budgets 40+ min precisely because runs exceed 10 min.
+BUILD_WAIT_CEILING_SECS="${BUILD_WAIT_CEILING_SECS:-2700}"
+BUILD_POLL_INTERVAL_SECS="${BUILD_POLL_INTERVAL_SECS:-15}"
+export AWS_REGION
+
+PROD_DB="$DATA_DIR/$DB_NAME"
+SEED_DB="$DATA_DIR/${DB_NAME}.seed"
+SEED_COUNTS="$DATA_DIR/${DB_NAME}.seed-counts.json"
+INCOMING_DB="$DATA_DIR/${DB_NAME}.incoming"
+SEED_KEY="seed/$DB_NAME"
+BUILD_KEY="build/$DB_NAME"
+
+log() { echo "[conductor $(date -u +%FT%TZ)] $*"; }
+fail() { log "ERROR: $*"; exit 1; }
+
+cleanup() { rm -f "$SEED_DB" "$SEED_COUNTS" "$INCOMING_DB" 2>/dev/null || true; }
+trap cleanup EXIT
+
+: "${SUBNETS:?set SUBNETS (comma-separated public subnet ids)}"
+: "${BUILD_SG:?set BUILD_SG (BuildSecurityGroup id)}"
+
+# Run a one-shot python in the semantic-index image against the mounted data dir.
+in_image() { docker run --rm -v "$DATA_DIR:/data" "$IMAGE" "$@"; }
+
+# --- 1. Consistent snapshot of the live DB + capture enrichment baseline ------
+[[ -f "$PROD_DB" ]] || fail "production DB not found: $PROD_DB"
+log "Snapshotting live DB -> $SEED_DB (sqlite .backup, consistent under concurrent reads)"
+in_image python -c "import sqlite3,sys; src=sqlite3.connect('/data/$DB_NAME'); dst=sqlite3.connect('/data/${DB_NAME}.seed'); src.backup(dst); dst.close(); src.close()" \
+  || fail "snapshot failed"
+
+log "Capturing seed enrichment counts -> $SEED_COUNTS"
+in_image python scripts/validate_graph_db.py "/data/${DB_NAME}.seed" --emit-counts > "$SEED_COUNTS" \
+  || fail "seed count capture failed"
+log "seed counts: $(cat "$SEED_COUNTS")"
+
+# --- 2. Upload seed ----------------------------------------------------------
+log "Uploading seed -> s3://$BUCKET/$SEED_KEY"
+aws s3 cp "$SEED_DB" "s3://$BUCKET/$SEED_KEY" --only-show-errors || fail "seed upload failed"
+
+# --- 3. Launch the Fargate build and wait ------------------------------------
+log "Launching Fargate build task..."
+TASK_ARN="$(aws ecs run-task \
+  --cluster "$CLUSTER" \
+  --task-definition "$TASK_DEF" \
+  --launch-type FARGATE \
+  --count 1 \
+  --network-configuration "awsvpcConfiguration={subnets=[$SUBNETS],securityGroups=[$BUILD_SG],assignPublicIp=ENABLED}" \
+  --query 'tasks[0].taskArn' --output text)"
+[[ -n "$TASK_ARN" && "$TASK_ARN" != "None" ]] || fail "run-task did not return a task ARN"
+log "task: $TASK_ARN — polling for completion (ceiling ${BUILD_WAIT_CEILING_SECS}s)..."
+
+# Poll describe-tasks until STOPPED with a ceiling matching the build's real
+# runtime (see BUILD_WAIT_CEILING_SECS above). A single `aws ecs wait
+# tasks-stopped` would cap at 10 min and abort the build mid-flight.
+elapsed=0
+while :; do
+  # Tolerate a transient describe-tasks failure (API throttle/blip) over the long
+  # poll window: treat it as "not STOPPED yet" and retry on the next tick rather
+  # than letting set -e abort the whole night's rebuild on one failed call. A
+  # persistent failure still trips the ceiling below and fails closed.
+  STATUS="$(aws ecs describe-tasks --cluster "$CLUSTER" --tasks "$TASK_ARN" \
+    --query 'tasks[0].lastStatus' --output text 2>/dev/null)" || STATUS="DESCRIBE_FAILED"
+  [[ "$STATUS" == "STOPPED" ]] && break
+  if (( elapsed >= BUILD_WAIT_CEILING_SECS )); then
+    fail "build task still '$STATUS' after ${BUILD_WAIT_CEILING_SECS}s ($TASK_ARN) — NOT swapping"
+  fi
+  sleep "$BUILD_POLL_INTERVAL_SECS"
+  elapsed=$(( elapsed + BUILD_POLL_INTERVAL_SECS ))
+done
+
+# Fetch exit code + reason once STOPPED. Capture into a var first (with set -e
+# tolerance) so a describe failure surfaces as a clear 'fail' instead of a silent
+# EOF-abort of `read`. Empty/None exitCode -> the guard below fails closed.
+DESC="$(aws ecs describe-tasks --cluster "$CLUSTER" --tasks "$TASK_ARN" \
+  --query 'tasks[0].[containers[0].exitCode, stoppedReason]' --output text 2>/dev/null)" || DESC=""
+read -r EXIT_CODE STOP_REASON <<<"$DESC" || true
+log "task stopped: exitCode=${EXIT_CODE:-<none>} reason=${STOP_REASON:-<none>}"
+[[ "$EXIT_CODE" == "0" ]] || fail "build task exit '${EXIT_CODE:-<none>}' (${STOP_REASON:-no reason}) — NOT swapping"
+
+# --- 4. Download + validate (fail-closed) ------------------------------------
+log "Downloading build artifact -> $INCOMING_DB"
+aws s3 cp "s3://$BUCKET/$BUILD_KEY" "$INCOMING_DB" --only-show-errors || fail "build download failed"
+
+log "Validating build artifact (header + artist>=$MIN_ARTISTS + enrichment vs seed)..."
+in_image python scripts/validate_graph_db.py "/data/${DB_NAME}.incoming" \
+  --seed-counts "/data/${DB_NAME}.seed-counts.json" \
+  --min-artists "$MIN_ARTISTS" \
+  || fail "validation failed — keeping current DB, NOT swapping"
+
+# --- 5. Atomic swap (same filesystem) ----------------------------------------
+# Clear the prior generation's WAL/SHM so a stale journal can't shadow the new
+# inode, then rename (atomic on the same FS). The API opens read-only per request
+# from app.state.db_path, so the next request picks up the new inode — no restart.
+log "Swapping in the new DB (clearing stale -wal/-shm, then rename)"
+rm -f "${PROD_DB}-wal" "${PROD_DB}-shm"
+mv -f "$INCOMING_DB" "$PROD_DB" || fail "atomic swap failed"
+
+# Best-effort freshness signal (seeds the 'DB mtime > 36h' alarm follow-up).
+aws cloudwatch put-metric-data --namespace WXYC/SemanticIndex \
+  --metric-name GraphRebuildSuccess --value 1 --unit Count 2>/dev/null || true
+
+log "Rebuild complete. $PROD_DB mtime: $(date -u -r "$PROD_DB" +%FT%TZ 2>/dev/null || stat -c %y "$PROD_DB")"


### PR DESCRIPTION
Last of three chained PRs for WXYC/semantic-index#347. **Base is `si-rebuild-infra` (#350)** — review/merge #349 then #350 first; this diff is only the conductor layer. Plan: `plans/si-out-of-process-rebuild/plan.md`.

Closes #347

## What this PR adds (the orchestration half)

`scripts/ec2-build-conductor.sh` — the single nightly driver on the serving host. It snapshots the live DB (consistent `sqlite .backup`) and records its enrichment counts, uploads the seed to S3, launches the Fargate build and waits for it, downloads and validates the artifact (fail-closed), then clears stale `-wal`/`-shm` and `os.replace`s it into the live path. The per-request read-only open (`api/database.py`) picks up the new inode on the next request, so there is **no API restart**. Any failure leaves the currently serving DB untouched and exits non-zero.

`deploy/semantic-index-build.{service,timer}` — install the conductor as a oneshot systemd service fired nightly at 08:50 UTC (`Persistent=true` to catch up a missed run).

## Addressed in review

The build is waited on by **polling `describe-tasks` for `STOPPED` with a configurable ceiling** (`BUILD_WAIT_CEILING_SECS`, default 2700s), not a single `aws ecs wait tasks-stopped` — that waiter is fixed at 100x6s = 600s (10 min) and would abort a longer build mid-flight without swapping. `TimeoutStartSec` is set to 3600s to sit comfortably above the ceiling plus the snapshot/upload/download/validate I/O on the ~1.5 GB DB.

## Cutover (operator, after this merges)

1. Deploy the stack (#350) and apply the three out-of-band steps (`infra/README.md`).
2. Dry-run the Fargate task by hand; validate the artifact without swapping (first full `[mem]` profile past `after _load_from_pg`).
3. Install the conductor + timer; let it run the round-trip for >=2 nights (mtime advances, enrichment preserved).
4. Set `SYNC_ENABLED=false` and recreate the API container.
5. Confirm over >=2 further nights that mtime keeps advancing and canary #50 stops firing on the 09:00 window.

Validated with `shellcheck` (clean). Part 3 of 3.