### PR TITLE
fix(infra): set PYTHONPATH=/app on the nightly build task

### DIFF
--- a/infra/build-job.yaml
+++ b/infra/build-job.yaml
@@ -181,6 +181,13 @@ Resources:
           # Reuse the serving image; override CMD to run the build wrapper.
           Command: ["python", "scripts/run_build_job.py"]
           Environment:
+            # The image installs deps but not the semantic_index package into
+            # site-packages (source is COPYed to /app after `pip install`); the
+            # API works because it runs with CWD=/app on sys.path. Running
+            # `python scripts/run_build_job.py` puts /app/scripts (not /app) on
+            # the path, so import semantic_index needs /app explicitly.
+            - Name: PYTHONPATH
+              Value: /app
             - Name: DB_PATH
               Value: /data/wxyc_artist_graph.db
             - Name: SEED_S3_URI


### PR DESCRIPTION
Follow-up hotfix to the out-of-process rebuild (#347), found during the operator cutover dry-run.

## Bug
The `semantic-index` image runs `pip install ".[api,build]"` **before** `COPY semantic_index/`, so the `semantic_index` package is never installed into site-packages — it lives at `/app/semantic_index` and is only importable because the API runs with CWD `/app` on `sys.path`. The Fargate build task runs `python scripts/run_build_job.py`, which puts `/app/scripts` (not `/app`) on `sys.path`, so `import semantic_index` raised `ModuleNotFoundError` and the task exited 1 before doing any work. (`validate_graph_db.py` is stdlib-only, so the conductor's in-image validate/seed-count calls were unaffected — which is why only the build task failed.)

## Fix
Set `PYTHONPATH=/app` in the task definition's container environment — matches how the image already treats `/app` as the import root. Infra-only; no image rebuild.

## Verified end-to-end
After deploying this (task-def revision `:2`), a manual `aws ecs run-task` dry-run built the full graph against the RDS private endpoint and uploaded a swap-ready artifact (no prod swap). First full `[mem]` profile ever observed:

- peak **3544 MiB** (at facet_export) → 8 GiB is right, **4 GiB would be marginal** (do not dial down)
- `after _load_from_pg` = 1115 MiB → confirms the in-process OOM mechanism (>1 GiB cap)
- runtime **988 s (16.5 min)** → confirms the conductor's poll-loop ceiling is required (a plain `aws ecs wait` caps at 10 min and aborted)
- validation gate **passed**: 138,743 artists; enrichment preserved (shared_style/compilation/wikidata_influence/audio_profile/acoustic_similarity == seed) and correctly top-50-pruned (shared_personnel 2.55M→888K, label_family 2.59M→891K, both above the ÷10 floor)

The live stack already has this fix (deployed manually during cutover); this PR brings `main` in sync so a future `deploy.sh` doesn't revert it.