### PR TITLE
feat(api): add graph_db_age_seconds to /health

### DIFF
--- a/docs/graph-api.md
+++ b/docs/graph-api.md
@@ -18,7 +18,7 @@ app = create_app("data/wxyc_artist_graph.db")
 | Method | Path | Description |
 |--------|------|-------------|
 | `GET` | `/` | D3.js graph explorer (interactive visualization). |
-| `GET` | `/health` | Health check — returns artist count or 503 if database is unreachable. |
+| `GET` | `/health` | Health check — returns `status`, `artist_count`, and `graph_db_age_seconds` (age in seconds of the serving DB file's mtime, or `null` if the file is briefly absent mid atomic-swap), or 503 if the database is unreachable. `graph_db_age_seconds` is the freshness signal the WXYC synthetic-DJ canary reads to catch SIGKILL-class silent nightly-sync failures (WXYC/semantic-index#348). |
 | `GET` | `/graph/artists/search?q=autechre&limit=10` | Case-insensitive LIKE search, ordered by total_plays descending. |
 | `GET` | `/graph/artists/{id}` | Full artist detail including external IDs (Discogs, MusicBrainz, Wikidata QID) and streaming service IDs (Spotify, Apple Music, Bandcamp) joined from the entity table. Gracefully degrades on old-schema databases. |
 | `GET` | `/graph/artists/{id}/neighbors?type=djTransition&limit=20` | Neighbors by edge type. Types: `djTransition`, `sharedPersonnel`, `sharedStyle`, `labelFamily`, `compilation`, `crossReference`, `wikidataInfluence`. Supports optional `month` (1-12) and `dj_id` facet filters for `djTransition` — computes PMI dynamically from play-level data. `min_raw_count` (default 1) filters DJ transition edges by minimum co-occurrence count; applies to `djTransition` and `affinity` edge types. |

--- a/semantic_index/api/app.py
+++ b/semantic_index/api/app.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import sqlite3
+import time
 from pathlib import Path
 
 from fastapi import FastAPI
@@ -74,17 +76,37 @@ def create_app(
     # synthetic-DJ canary parses (see WXYC/wxyc-canary). Readiness, which
     # is shape-compatible with the shared router, *is* delegated below.
     # Tracked: WXYC/wxyc-fastapi#19 (extra-fields hook for liveness).
+    def _graph_db_age_seconds() -> float | None:
+        """Age, in seconds, of the serving graph DB file (from its mtime).
+
+        This is the freshness signal the WXYC synthetic-DJ canary reads to
+        catch SIGKILL-class silent nightly-sync failures, where the scheduler
+        fires but the rebuild is OOM-killed before the atomic swap lands — so
+        the DB file's mtime never advances (see WXYC/semantic-index#348 and
+        #329). A single ``os.stat`` of ``db_path`` is cheap enough to compute
+        on every ``/health`` hit. Returns ``None`` if the file is briefly
+        absent (e.g. mid atomic-swap) so ``/health`` never raises on it.
+        """
+        try:
+            mtime = os.stat(db_path).st_mtime
+        except OSError:
+            return None
+        return max(0.0, time.time() - mtime)
+
     @app.get("/health", include_in_schema=False)
     def health() -> JSONResponse:
         """Health check — verifies the SQLite database is readable."""
+        age = _graph_db_age_seconds()
         try:
             conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
             count = conn.execute("SELECT COUNT(*) FROM artist").fetchone()[0]
             conn.close()
-            return JSONResponse({"status": "healthy", "artist_count": count})
+            return JSONResponse(
+                {"status": "healthy", "artist_count": count, "graph_db_age_seconds": age}
+            )
         except Exception as exc:
             return JSONResponse(
-                {"status": "unhealthy", "detail": str(exc)},
+                {"status": "unhealthy", "detail": str(exc), "graph_db_age_seconds": age},
                 status_code=503,
             )
 

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -1,5 +1,7 @@
 """Tests for the Graph API scaffolding."""
 
+import os
+import time
 from pathlib import Path
 from unittest.mock import patch
 
@@ -91,6 +93,43 @@ class TestHealthEndpoint:
         assert response.status_code == 503
         data = response.json()
         assert data["status"] == "unhealthy"
+
+    def test_health_reports_graph_db_age_seconds(self, client: TestClient, test_db: Path):
+        """The freshness field reflects the serving DB file's mtime.
+
+        The wxyc-canary freshness check (WXYC/wxyc-canary#53) reads this to
+        catch SIGKILL-class silent nightly-sync failures (#348/#329).
+        """
+        # Pin the DB mtime to a known point ~2 hours ago.
+        two_hours_ago = time.time() - 7200
+        os.utime(test_db, (two_hours_ago, two_hours_ago))
+
+        response = client.get("/health")
+        assert response.status_code == 200
+        data = response.json()
+        age = data["graph_db_age_seconds"]
+        assert isinstance(age, (int, float))
+        # Allow generous slack for clock granularity / test execution time.
+        assert 7100 <= age <= 7300
+
+    def test_health_age_is_small_for_fresh_db(self, client: TestClient, test_db: Path):
+        """A just-written DB reports a near-zero age."""
+        os.utime(test_db, None)  # set mtime to now
+        response = client.get("/health")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["graph_db_age_seconds"] >= 0
+        assert data["graph_db_age_seconds"] < 60
+
+    def test_health_age_degrades_gracefully_when_db_missing(self, client_missing_db: TestClient):
+        """A missing DB (e.g. mid-swap) must not 500; age is reported as null."""
+        response = client_missing_db.get("/health")
+        # The unhealthy path already returns 503; it must still carry the
+        # freshness field so the canary can distinguish stale from absent.
+        assert response.status_code == 503
+        data = response.json()
+        assert data["status"] == "unhealthy"
+        assert data["graph_db_age_seconds"] is None
 
 
 class TestReadinessEndpoint:


### PR DESCRIPTION
## Summary

Adds a `graph_db_age_seconds` field to the `/health` endpoint: the age, in seconds, of the serving graph DB file, computed from a single `os.stat` of the DB path at request time. The endpoint already returns `artist_count`; this slots in alongside it.

This is the cheap half of the freshness monitor from WXYC/semantic-index#348 (option 3). The nightly sync can fail completely silently: an OOM/SIGKILL delivered by the kernel bypasses Python's exception machinery, so the scheduler's `except BaseException` handler never runs, nothing reaches Sentry, and the DB file's mtime never advances. That produced a 22-day undetected stale-graph window. Surfacing the serving-host DB freshness on `/health` lets an external assertion (the synthetic-DJ canary) treat the swap landing — the only trustworthy success signal — as the success condition, independent of whether the scheduler attempted to run or threw.

## Behavior

- Included on both the healthy (200) and unhealthy (503) responses, so a canary can distinguish *stale* from *absent*.
- Degrades to `null` when the DB file is briefly missing (e.g. mid atomic-swap) — `os.stat` raising `OSError` is caught so `/health` never 500s on it.
- Keyed on serving-host DB freshness, so it satisfies the issue's architecture-agnostic criterion and needs no rework when the off-host rebuild (#347) lands.

## Tests

Three new unit tests in `tests/unit/test_api.py` (TDD, no Postgres needed): the field is present and approximately correct against a pinned mtime; a freshly-touched DB reports near-zero age; a missing DB degrades to `null` on the 503 path.

## Scope note

This PR is only the endpoint field plus its tests and a doc note. The monitor itself — the new canary freshness check, its distinct alarm wiring (kept separate from wxyc-canary's flapping aggregate `CheckFailure`), and the content floor pairing freshness with `artist_count` — lives in WXYC/wxyc-canary#53, which this unblocks.

Closes #348.