### PR TITLE
feat(api): batch neighbors endpoint keyed by Backend library artist id (On Tour R3b)

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -98,6 +98,10 @@ The process of mapping the free-text artist names DJs typed into the flowsheet (
 
 The single authoritative display name chosen for an artist, under which all of that artist's name variants are merged. Each canonical artist is one node in the graph (one row in the `artist` table).
 
+### Library artist id
+
+A Backend-Service catalog artist id — `wxyc_schema.artists.id`, the keyspace Backend and the iOS app identify artists by, and the id space of the shared `SimilarArtist.artist_id` and `Concert.headlining_artist_id` DTOs. The graph keys its own nodes by [canonical name](#canonical-name) with internal ids, so the [nightly sync](#nightly-sync) records each unambiguous artist's library artist id in the `artist.wxyc_library_code_id` column (WXYC/semantic-index#358). The batch endpoint `POST /graph/library-artists/neighbors/batch` reads that mapping in both directions to answer "artists similar to X" entirely in library-artist-id space, so the Backend concerts enrichment never translates ids itself. A [homonym](#homonym) name carries more than one catalog id and is left unmapped.
+
 ### Homonym
 
 Two or more *distinct* artists that share a name — e.g. several unrelated bands all filed as "Lake" in the [library catalog](#library-catalog) under different library codes. Because the resolver keys artists by [canonical name](#canonical-name), its first-wins name index conflates homonyms into a single graph node whose neighborhood mixes all of them. No single library code is correct for such a node, so the graph↔Backend-library-id mapping (see [docs/pipeline.md](pipeline.md)) deliberately leaves ambiguous names **unmapped** rather than guessing. Splitting conflated homonym nodes is a separate, open track (WXYC/semantic-index#360).

--- a/docs/graph-api.md
+++ b/docs/graph-api.md
@@ -22,8 +22,9 @@ app = create_app("data/wxyc_artist_graph.db")
 | `GET` | `/` | D3.js graph explorer (interactive visualization). |
 | `GET` | `/health` | Health check — returns `status`, `artist_count`, and `graph_db_age_seconds` (age in seconds of the serving DB file's mtime, or `null` if the file is briefly absent mid [atomic swap](glossary.md#atomic-swap)), or 503 if the database is unreachable. `graph_db_age_seconds` is the freshness signal the WXYC synthetic-DJ canary reads to catch SIGKILL-class silent nightly-sync failures (WXYC/semantic-index#348). |
 | `GET` | `/graph/artists/search?q=autechre&limit=10` | Case-insensitive LIKE search, ordered by total_plays descending. |
-| `GET` | `/graph/artists/{id}` | Full artist detail including external IDs (Discogs, MusicBrainz, Wikidata QID) and streaming service IDs (Spotify, Apple Music, Bandcamp) joined from the [entity](glossary.md#entity) table. Gracefully degrades on old-schema databases. |
+| `GET` | `/graph/artists/{id}` | Full artist detail including external IDs (Discogs, MusicBrainz, Wikidata QID) and streaming service IDs (Spotify, Apple Music, Bandcamp) joined from the [entity](glossary.md#entity) table, plus `wxyc_library_code_id` (the [library artist id](glossary.md#library-artist-id), or `null` when unmapped). Gracefully degrades on old-schema databases. |
 | `GET` | `/graph/artists/{id}/neighbors?type=djTransition&limit=20` | Neighbors by [edge type](glossary.md#edge-type). Types: `djTransition`, `sharedPersonnel`, `sharedStyle`, `labelFamily`, `compilation`, `crossReference`, `wikidataInfluence`. Supports optional `month` (1-12) and `dj_id` [facet](glossary.md#facet) filters for `djTransition` — computes PMI dynamically from play-level data. `min_raw_count` (default 1) filters DJ transition edges by minimum co-occurrence count; applies to `djTransition` and `affinity` edge types. |
+| `POST` | `/graph/library-artists/neighbors/batch` | Batch affinity neighbors keyed by [library artist id](glossary.md#library-artist-id) rather than graph id — for the Backend concerts "On Tour" enrichment. See [below](#library-artist-neighbors-on-tour). |
 | `GET` | `/graph/artists/{id}/explain/{target_id}` | All relationship types between two artists with weights and details. |
 | `GET` | `/graph/entities/{id}/artists` | All artists sharing an entity (alias group). Returns entity metadata and a list of artist summaries. |
 | `GET` | `/graph/facets` | Available facet values (months with data, DJ list) for filtering. Gracefully returns empty lists on databases without facet tables. |
@@ -31,6 +32,28 @@ app = create_app("data/wxyc_artist_graph.db")
 | `GET` | `/graph/artists/{id}/explain/{target_id}/narrative?month=&dj_id=` | LLM-generated natural-language explanation of the relationship between two artists (see below). Uses Claude Haiku. Cached in a sidecar SQLite DB. Returns 501 when `ANTHROPIC_API_KEY` is not set. |
 | `GET` | `/graph/artists/{id}/preview` | Audio preview URL for an artist. Multi-source fallback: iTunes lookup (by Apple Music ID) → Spotify top tracks (by Spotify ID, requires credentials) → Bandcamp (by bandcamp_id, scrapes track stream) → Deezer search (by name) → iTunes search (by name). Cached in sidecar `.preview-cache.db`. |
 | `GET` | `/graph/narrative-audit/recent?limit=50&flagged_only=false` | Most-recent narrative-audit rows from the audit sidecar (`<db>.narrative-audit-cache.db`). Returns an empty list when no audits have run yet. |
+
+## Library-artist neighbors (On Tour)
+
+`POST /graph/library-artists/neighbors/batch` answers "artists similar to X" in the [library artist id](glossary.md#library-artist-id) keyspace instead of internal graph ids, so the Backend-Service concerts enrichment (WXYC/Backend-Service#1626) can look up affinity neighbors for concert headliners without ever translating id spaces. It reads the `artist.wxyc_library_code_id` mapping the [nightly sync](glossary.md#nightly-sync) populates (WXYC/semantic-index#358).
+
+```json
+POST /graph/library-artists/neighbors/batch
+{ "library_artist_ids": [4210, 887], "limit": 20, "heat": 0.5 }
+
+{ "results": {
+    "4210": [ {"artist_id": 5121, "weight": 4.83} ],
+    "887":  [] } }
+```
+
+- **Shape** — each requested id maps to a list of `SimilarArtist` items (`{artist_id, weight}`, the wxyc-shared DTO verbatim), weight-descending. Every requested id is present in `results`; an unknown, unmapped, or [homonym](glossary.md#homonym) id maps to an empty list rather than being omitted, so the caller can tell "asked, none" from "never asked". Duplicate ids collapse.
+- **`heat`** (optional, 0.0–1.0, default 0.5) — the same discovery dial as the neighbors endpoints: cool ranks by well-worn co-occurrence, hot by surprising enrichment edges. One heat per request keeps a response's weights mutually comparable. The production consumer omits it; the iOS debug dial (WXYC/wxyc-ios-64#534) passes it for live preview.
+- **`weight`** is the raw affinity composite and is **list-relative** — type-max normalized per source artist, so weights are comparable *within* one list, not *across* lists. Rank and cap relative to a list's own maximum; never compare a weight from one list against a weight from another.
+- **Cap and overflow** — at most 100 ids per request (`limit` 1–100, default 20); 101+ ids returns a structured `422`, never a silent truncation, because the nightly caller is unattended and a dropped id would be silent data loss. Empty input returns `200` with empty `results`.
+- **Top-K refill** — neighbors are ranked once at 2× `limit`, translated to library ids, unmapped neighbors dropped, then cut to `limit`. The over-fetch keeps a list full when its top-ranked neighbors happen to be unmapped (probe: a plain top-`limit` left a fifth of lists short; 2× saturated all of them).
+- **No auth** — public, like the rest of the graph API. The worst case is a bounded local SQLite read (100 sources × 2× `limit`), never a fan-out to a rate-limited external service, and the secondary consumer is the keyless iOS debug screen.
+
+The endpoint returns empty lists for every id until #358 has deployed **and** a nightly rebuild has run; `GET /health`'s `mapped_artist_count` (~22K once populated) is the integration-day signal that separates "mapping not yet rebuilt" from "endpoint broken".
 
 ## Narratives and their quality gates
 

--- a/semantic_index/api/routes.py
+++ b/semantic_index/api/routes.py
@@ -13,9 +13,9 @@ from typing import Any
 
 import sentry_sdk
 from fastapi import APIRouter, Depends, HTTPException, Query
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
-from generated.api_models import ReconciledIdentity
+from generated.api_models import ReconciledIdentity, SimilarArtist
 from semantic_index.api.database import get_db
 from semantic_index.api.schemas import (
     ArtistDetail,
@@ -28,6 +28,7 @@ from semantic_index.api.schemas import (
     EntityArtists,
     ExplainResponse,
     FacetsResponse,
+    LibraryNeighborsBatchResponse,
     NeighborEntry,
     NeighborsResponse,
     Relationship,
@@ -457,6 +458,116 @@ def get_neighbors_batch(
     return BatchNeighborsResponse(results=results)
 
 
+class LibraryNeighborsBatchRequest(BaseModel):
+    """Request body for POST /graph/library-artists/neighbors/batch.
+
+    ``library_artist_ids`` are Backend catalog artist ids (the
+    ``SimilarArtist.artist_id`` keyspace), NOT internal graph ids. The sibling
+    /artists/neighbors/batch endpoint's ``artist_ids`` are graph ids, so the
+    distinct field name here is deliberate — it guards against the id-space
+    confusion this endpoint exists to resolve. The 100-id cap (``max_length``)
+    returns a structured 422 on overflow rather than the sibling's silent
+    truncation, which for an unattended nightly job would be silent data loss.
+    """
+
+    library_artist_ids: list[int] = Field(..., max_length=100)
+    limit: int = Field(20, ge=1, le=100)
+    heat: float = Field(0.5, ge=0.0, le=1.0)
+
+
+# Rank-then-filter over-fetch multiple. The affinity ranker returns graph
+# neighbors; an unmapped neighbor (NULL wxyc_library_code_id) drops during
+# translation, so a raw top-`limit` can come back short. Empirical probe (40
+# simulated headliners, popularity ranks 1-600, local graph): at limit=20 only
+# 19/40 lists survived to a full 20 mapped neighbors (min 16); 2x saturated
+# 40/40 at heat 0.0 / 0.5 / 1.0. Over-fetch is nearly free — affinity SQL cost
+# lives in the AFFINITY_PER_SOURCE_CAP-bounded candidate scans, not the final
+# limit — so a single pass at 2x then a hard cut to `limit`, with no refill loop.
+_LIBRARY_NEIGHBOR_OVERFETCH = 2
+
+
+@router.post("/library-artists/neighbors/batch", response_model=LibraryNeighborsBatchResponse)
+def get_library_neighbors_batch(
+    body: LibraryNeighborsBatchRequest,
+    db: sqlite3.Connection = Depends(get_db),
+) -> LibraryNeighborsBatchResponse:
+    """Batch affinity neighbors keyed by Backend catalog library-artist id.
+
+    For each requested library id: reverse-map it to a graph artist via
+    ``artist.wxyc_library_code_id`` (#358), rank affinity neighbors, translate
+    those neighbors back into library ids, drop any that are unmapped, and cut to
+    ``limit``. Every requested id appears in ``results``; unknown, unmapped, and
+    ambiguous (homonym) ids map to an empty list. Duplicate ids collapse.
+
+    Read-only over the precomputed affinity edges plus the mapping; called
+    nightly server-to-server by the Backend-Service concerts enrichment
+    (WXYC/Backend-Service#1626). Public and unauthenticated, consistent with the
+    rest of the graph API — worst case is a bounded local SQLite read.
+
+    ``weight`` is the raw affinity composite and is list-relative (type-max
+    normalized per source artist), so consumers must rank and cap within a single
+    list, not across lists (guidance on WXYC/wxyc-ios-64#493).
+    """
+    _init_metrics_flag(db)
+
+    # Dedupe, preserving first-seen order; empty input short-circuits to {}.
+    requested = list(dict.fromkeys(body.library_artist_ids))
+    if not requested:
+        return LibraryNeighborsBatchResponse(results={})
+
+    # Reverse lookup: library code id -> graph artist id. Injective (each code
+    # belongs to at most one graph artist, since canonical_name is UNIQUE),
+    # backed by the partial index idx_artist_library_code. A pre-#358 served DB
+    # has no such column yet — degrade to "nothing mapped" (empty lists) rather
+    # than 500, per the endpoint's deploy-order contract.
+    code_placeholders = ",".join("?" * len(requested))
+    try:
+        code_rows = db.execute(
+            f"SELECT id, wxyc_library_code_id FROM artist "  # noqa: S608
+            f"WHERE wxyc_library_code_id IN ({code_placeholders})",
+            requested,
+        ).fetchall()
+        code_to_graph: dict[int, int] = {r["wxyc_library_code_id"]: r["id"] for r in code_rows}
+    except sqlite3.OperationalError:
+        code_to_graph = {}
+
+    graph_ids = [code_to_graph[c] for c in requested if c in code_to_graph]
+    per_source = _neighbors_affinity_batch(
+        db, graph_ids, body.limit * _LIBRARY_NEIGHBOR_OVERFETCH, heat=body.heat
+    )
+
+    # Forward translation: neighbor graph id -> library code id, across every
+    # neighbor surfaced for every source. Neighbors absent here are unmapped and
+    # drop during the per-source cut below. The mapping filter stays in Python,
+    # NOT in the shared affinity SQL, which also serves the public explorer.
+    neighbor_gids = {entry.artist.id for entries in per_source.values() for entry in entries}
+    graph_to_code: dict[int, int] = {}
+    if neighbor_gids:
+        nbr_placeholders = ",".join("?" * len(neighbor_gids))
+        nbr_rows = db.execute(
+            f"SELECT id, wxyc_library_code_id FROM artist "  # noqa: S608
+            f"WHERE id IN ({nbr_placeholders}) AND wxyc_library_code_id IS NOT NULL",
+            list(neighbor_gids),
+        ).fetchall()
+        graph_to_code = {r["id"]: r["wxyc_library_code_id"] for r in nbr_rows}
+
+    results: dict[str, list[SimilarArtist]] = {}
+    for code_id in requested:
+        gid = code_to_graph.get(code_id)
+        neighbors: list[SimilarArtist] = []
+        if gid is not None:
+            for entry in per_source.get(gid, []):
+                mapped = graph_to_code.get(entry.artist.id)
+                if mapped is None:
+                    continue  # unmapped neighbor dropped, then over-fetch refills
+                neighbors.append(SimilarArtist(artist_id=mapped, weight=entry.weight))
+                if len(neighbors) >= body.limit:
+                    break
+        results[str(code_id)] = neighbors
+
+    return LibraryNeighborsBatchResponse(results=results)
+
+
 @router.get("/artists/{artist_id}/explain/{target_id}", response_model=ExplainResponse)
 def explain_relationship(
     artist_id: int,
@@ -521,6 +632,23 @@ def _build_reconciled_identity(row: sqlite3.Row) -> ReconciledIdentity | None:
     return ReconciledIdentity(**fields)
 
 
+def _fetch_library_code_id(db: sqlite3.Connection, artist_id: int) -> int | None:
+    """Read ``artist.wxyc_library_code_id`` defensively for the old-schema path.
+
+    The ``ArtistDetail`` fallback SELECT omits it (that branch handles lean
+    SQL-dump / pre-entity-store databases). The column lives on ``artist``, so it
+    is still readable there; a genuinely pre-#358 served DB lacks the column and
+    degrades to None rather than 500.
+    """
+    try:
+        row = db.execute(
+            "SELECT wxyc_library_code_id FROM artist WHERE id = ?", (artist_id,)
+        ).fetchone()
+    except sqlite3.OperationalError:
+        return None
+    return row["wxyc_library_code_id"] if row is not None else None
+
+
 def _get_artist_detail(db: sqlite3.Connection, artist_id: int) -> ArtistDetail:
     """Fetch full artist detail, joining entity table when available.
 
@@ -533,7 +661,7 @@ def _get_artist_detail(db: sqlite3.Connection, artist_id: int) -> ArtistDetail:
             "  a.active_first_year, a.active_last_year, a.dj_count, "
             "  a.request_ratio, a.show_count, "
             "  a.entity_id, a.discogs_artist_id, a.musicbrainz_artist_id, "
-            "  a.reconciliation_status, "
+            "  a.reconciliation_status, a.wxyc_library_code_id, "
             "  e.wikidata_qid, "
             "  e.spotify_artist_id, e.apple_music_artist_id, e.bandcamp_id "
             "FROM artist a "
@@ -562,6 +690,7 @@ def _get_artist_detail(db: sqlite3.Connection, artist_id: int) -> ArtistDetail:
             dj_count=row["dj_count"],
             request_ratio=row["request_ratio"],
             show_count=row["show_count"],
+            wxyc_library_code_id=_fetch_library_code_id(db, artist_id),
         )
 
     if row is None:
@@ -588,6 +717,7 @@ def _get_artist_detail(db: sqlite3.Connection, artist_id: int) -> ArtistDetail:
         apple_music_artist_id=row["apple_music_artist_id"],
         bandcamp_id=row["bandcamp_id"],
         reconciled_identity=reconciled_identity,
+        wxyc_library_code_id=row["wxyc_library_code_id"],
     )
 
 

--- a/semantic_index/api/schemas.py
+++ b/semantic_index/api/schemas.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from pydantic import BaseModel
 
-from generated.api_models import ReconciledIdentity
+from generated.api_models import ReconciledIdentity, SimilarArtist
 
 
 class ArtistSummary(BaseModel):
@@ -91,6 +91,26 @@ class ArtistDetail(BaseModel):
     apple_music_artist_id: str | None = None
     bandcamp_id: str | None = None
     reconciled_identity: ReconciledIdentity | None = None
+    # Backend catalog library-artist id (the SimilarArtist.artist_id keyspace),
+    # populated by the nightly sync (#358). NULL for raw/CTA-only and homonym
+    # names. Exposed additively so individual mappings are spot-checkable from a
+    # browser; the batch translation itself lives at
+    # POST /graph/library-artists/neighbors/batch.
+    wxyc_library_code_id: int | None = None
+
+
+class LibraryNeighborsBatchResponse(BaseModel):
+    """Response for POST /graph/library-artists/neighbors/batch.
+
+    Keyed by requested library artist id (rendered as a string, per JSON object
+    keys); each value is the top-K affinity neighbors translated back into the
+    same Backend catalog library-artist id keyspace as shared ``SimilarArtist``
+    items (``{artist_id, weight}``), weight-descending. Unknown, unmapped, and
+    ambiguous (homonym) ids are present with an empty list rather than omitted,
+    so the consumer can tell "asked, no neighbors" from "never asked".
+    """
+
+    results: dict[str, list[SimilarArtist]]
 
 
 class EntityArtists(BaseModel):

--- a/tests/unit/test_api_library_neighbors.py
+++ b/tests/unit/test_api_library_neighbors.py
@@ -1,0 +1,319 @@
+"""Tests for POST /graph/library-artists/neighbors/batch (On Tour R3b, #354).
+
+The endpoint answers "artists similar to X" in the Backend catalog library-artist
+id keyspace (``SimilarArtist.artist_id``), reading the ``artist.wxyc_library_code_id``
+mapping populated by the nightly sync (#358). Graph ids never leak into the
+response — every id in and out is a library code id.
+
+Fixtures assign ``wxyc_library_code_id`` with a direct UPDATE after export, since
+``export_sqlite`` (SQL-dump mode) leaves the column present-but-NULL by design.
+Library code ids are >= 1000 while graph ids autoincrement from 1, so a test can
+never pass by accidentally conflating the two keyspaces.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import tempfile
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from semantic_index.api.app import create_app
+from semantic_index.models import PmiEdge
+from semantic_index.sqlite_export import export_sqlite
+from tests.conftest import make_artist_stats
+
+ENDPOINT = "/graph/library-artists/neighbors/batch"
+
+# Autechre is the source under test. Its djTransition neighbors, in raw_count
+# order, are Stereolab (60), Broadcast (50), Boards of Canada (40), Oval (30),
+# Mouse on Mars (20), Pole (10). At heat=0.0 the affinity rank is exactly this
+# raw_count order. Stereolab and Broadcast are deliberately left UNMAPPED so the
+# top two affinity ranks drop out — the over-fetch test hinges on this.
+_CODE_MAP = {
+    "Autechre": 1000,
+    "Boards of Canada": 1002,
+    "Oval": 1003,
+    "Mouse on Mars": 1004,
+    "Pole": 1005,
+    "Cat Power": 2000,
+    "Jessica Pratt": 2001,
+}
+# Stereolab, Broadcast: intentionally absent from _CODE_MAP (unmapped / NULL).
+
+
+def _build_library_fixture_db() -> tuple[str, dict[str, int]]:
+    """Build a fixture DB and map a subset of artists to library code ids.
+
+    Returns ``(db_path, name_to_graph_id)``. Names absent from ``_CODE_MAP`` are
+    left NULL, modeling homonym/raw names #358 excludes from the mapping.
+    """
+    path = tempfile.mktemp(suffix=".db")
+    names = [
+        "Autechre",
+        "Stereolab",
+        "Broadcast",
+        "Boards of Canada",
+        "Oval",
+        "Mouse on Mars",
+        "Pole",
+        "Cat Power",
+        "Jessica Pratt",
+    ]
+    stats = {n: make_artist_stats(n, total_plays=50, genre="Electronic") for n in names}
+    pmi_edges = [
+        PmiEdge(source="Autechre", target="Stereolab", raw_count=60, pmi=6.0),
+        PmiEdge(source="Autechre", target="Broadcast", raw_count=50, pmi=5.0),
+        PmiEdge(source="Autechre", target="Boards of Canada", raw_count=40, pmi=4.0),
+        PmiEdge(source="Autechre", target="Oval", raw_count=30, pmi=3.0),
+        PmiEdge(source="Autechre", target="Mouse on Mars", raw_count=20, pmi=2.0),
+        PmiEdge(source="Autechre", target="Pole", raw_count=10, pmi=1.0),
+        PmiEdge(source="Cat Power", target="Jessica Pratt", raw_count=5, pmi=1.5),
+    ]
+    export_sqlite(path, artist_stats=stats, pmi_edges=pmi_edges, xref_edges=[], min_count=1)
+
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    name_to_graph = {
+        r["canonical_name"]: r["id"] for r in conn.execute("SELECT id, canonical_name FROM artist")
+    }
+    for name, code in _CODE_MAP.items():
+        conn.execute(
+            "UPDATE artist SET wxyc_library_code_id = ? WHERE canonical_name = ?",
+            (code, name),
+        )
+    conn.commit()
+    conn.close()
+    return path, name_to_graph
+
+
+@pytest.fixture(scope="module")
+def _fixture() -> tuple[str, dict[str, int]]:
+    return _build_library_fixture_db()
+
+
+@pytest.fixture(scope="module")
+def db_path(_fixture: tuple[str, dict[str, int]]) -> str:
+    return _fixture[0]
+
+
+@pytest.fixture(scope="module")
+def name_to_graph(_fixture: tuple[str, dict[str, int]]) -> dict[str, int]:
+    return _fixture[1]
+
+
+@pytest_asyncio.fixture
+async def client(db_path: str) -> AsyncClient:
+    app = create_app(db_path)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+class TestInputDirection:
+    """Requested library ids resolve to graph neighbors; unmapped ids → empty."""
+
+    @pytest.mark.asyncio
+    async def test_mapped_source_returns_neighbors(self, client: AsyncClient) -> None:
+        resp = await client.post(
+            ENDPOINT, json={"library_artist_ids": [2000], "limit": 20, "heat": 0.5}
+        )
+        assert resp.status_code == 200
+        results = resp.json()["results"]
+        assert "2000" in results
+        # Cat Power (2000) -> Jessica Pratt (2001), the only mapped neighbor.
+        assert [n["artist_id"] for n in results["2000"]] == [2001]
+        assert results["2000"][0]["weight"] > 0
+
+    @pytest.mark.asyncio
+    async def test_unknown_library_id_present_but_empty(self, client: AsyncClient) -> None:
+        resp = await client.post(ENDPOINT, json={"library_artist_ids": [999999], "limit": 20})
+        assert resp.status_code == 200
+        # Present in results (never dropped), but empty — unknown to the mapping.
+        assert resp.json()["results"] == {"999999": []}
+
+    @pytest.mark.asyncio
+    async def test_ambiguous_and_unmapped_ids_return_empty(self, client: AsyncClient) -> None:
+        # 4999 models a homonym code #358 excluded from the mapping (no graph
+        # artist carries it); it behaves identically to an unknown id.
+        resp = await client.post(ENDPOINT, json={"library_artist_ids": [2000, 4999], "limit": 20})
+        assert resp.status_code == 200
+        results = resp.json()["results"]
+        assert results["4999"] == []
+        assert results["2000"]  # the mapped one still resolves
+        # Every requested id is present in results.
+        assert set(results.keys()) == {"2000", "4999"}
+
+
+class TestOutputDirection:
+    """Neighbor graph ids translate to library ids; unmapped neighbors drop."""
+
+    @pytest.mark.asyncio
+    async def test_neighbors_are_library_ids_never_graph_ids(
+        self, client: AsyncClient, name_to_graph: dict[str, int]
+    ) -> None:
+        resp = await client.post(
+            ENDPOINT, json={"library_artist_ids": [1000], "limit": 20, "heat": 0.0}
+        )
+        assert resp.status_code == 200
+        got = [n["artist_id"] for n in resp.json()["results"]["1000"]]
+        # Stereolab and Broadcast are unmapped and drop out entirely; the rest
+        # translate to their library code ids in weight order.
+        assert got == [1002, 1003, 1004, 1005]
+        # The unmapped neighbors' GRAPH ids must never leak into the response.
+        assert name_to_graph["Stereolab"] not in got
+        assert name_to_graph["Broadcast"] not in got
+
+    @pytest.mark.asyncio
+    async def test_over_fetch_refills_past_unmapped_top_neighbors(
+        self, client: AsyncClient
+    ) -> None:
+        """The 2x over-fetch is what keeps a short list full after the drop.
+
+        Autechre's top-2 affinity neighbors (Stereolab, Broadcast) are unmapped.
+        With limit=3 and NO over-fetch, only rank-3 (Boards) survives the drop
+        for a length-1 list. The 2x over-fetch pulls ranks 1-6, drops the two
+        unmapped, and refills to a full 3. This is the test that fails if someone
+        simplifies the fixed 2x away.
+        """
+        resp = await client.post(
+            ENDPOINT, json={"library_artist_ids": [1000], "limit": 3, "heat": 0.0}
+        )
+        assert resp.status_code == 200
+        got = [n["artist_id"] for n in resp.json()["results"]["1000"]]
+        assert got == [1002, 1003, 1004]
+
+    @pytest.mark.asyncio
+    async def test_weights_descending(self, client: AsyncClient) -> None:
+        resp = await client.post(
+            ENDPOINT, json={"library_artist_ids": [1000], "limit": 20, "heat": 0.0}
+        )
+        weights = [n["weight"] for n in resp.json()["results"]["1000"]]
+        assert weights == sorted(weights, reverse=True)
+
+
+class TestEnvelope:
+    """Batch cap, empty input, dedup, and bound enforcement."""
+
+    @pytest.mark.asyncio
+    async def test_over_100_ids_returns_422(self, client: AsyncClient) -> None:
+        resp = await client.post(
+            ENDPOINT, json={"library_artist_ids": list(range(101)), "limit": 20}
+        )
+        assert resp.status_code == 422  # structured overflow, never silent truncation
+
+    @pytest.mark.asyncio
+    async def test_exactly_100_ids_ok(self, client: AsyncClient) -> None:
+        resp = await client.post(
+            ENDPOINT, json={"library_artist_ids": list(range(1, 101)), "limit": 5}
+        )
+        assert resp.status_code == 200
+        assert len(resp.json()["results"]) == 100
+
+    @pytest.mark.asyncio
+    async def test_empty_input_returns_empty_results(self, client: AsyncClient) -> None:
+        resp = await client.post(ENDPOINT, json={"library_artist_ids": [], "limit": 20})
+        assert resp.status_code == 200
+        assert resp.json()["results"] == {}
+
+    @pytest.mark.asyncio
+    async def test_duplicate_ids_collapse(self, client: AsyncClient) -> None:
+        resp = await client.post(
+            ENDPOINT, json={"library_artist_ids": [2000, 2000, 2000], "limit": 20}
+        )
+        assert resp.status_code == 200
+        assert list(resp.json()["results"].keys()) == ["2000"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("limit", [0, 101])
+    async def test_limit_out_of_bounds_422(self, client: AsyncClient, limit: int) -> None:
+        resp = await client.post(ENDPOINT, json={"library_artist_ids": [2000], "limit": limit})
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("heat", [-0.1, 1.1])
+    async def test_heat_out_of_bounds_422(self, client: AsyncClient, heat: float) -> None:
+        resp = await client.post(
+            ENDPOINT, json={"library_artist_ids": [2000], "limit": 20, "heat": heat}
+        )
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_heat_defaults_when_omitted(self, client: AsyncClient) -> None:
+        resp = await client.post(ENDPOINT, json={"library_artist_ids": [2000]})
+        assert resp.status_code == 200
+        assert resp.json()["results"]["2000"]  # default heat still resolves neighbors
+
+
+class TestSimilarArtistContract:
+    """Response items are the shared SimilarArtist schema, verbatim."""
+
+    @pytest.mark.asyncio
+    async def test_response_items_have_exactly_similar_artist_fields(
+        self, client: AsyncClient
+    ) -> None:
+        resp = await client.post(
+            ENDPOINT, json={"library_artist_ids": [1000], "limit": 3, "heat": 0.0}
+        )
+        neighbors = resp.json()["results"]["1000"]
+        assert neighbors  # non-empty, so the assertion below actually runs
+        for item in neighbors:
+            assert set(item.keys()) == {"artist_id", "weight"}
+            assert isinstance(item["artist_id"], int)
+            assert isinstance(item["weight"], int | float)
+
+    def test_generated_similar_artist_field_names(self) -> None:
+        # Pins the contract here so drift fails in this repo, not in the
+        # Backend-Service consumer. Fails if a regen renames/drops a field.
+        from generated.api_models import SimilarArtist
+
+        assert set(SimilarArtist.model_fields.keys()) == {"artist_id", "weight"}
+
+
+class TestArtistDetailLibraryCodeId:
+    """ArtistDetail exposes wxyc_library_code_id for browser spot-checks."""
+
+    @pytest.mark.asyncio
+    async def test_mapped_artist_detail_reports_code_id(
+        self, client: AsyncClient, name_to_graph: dict[str, int]
+    ) -> None:
+        resp = await client.get(f"/graph/artists/{name_to_graph['Autechre']}")
+        assert resp.status_code == 200
+        assert resp.json()["wxyc_library_code_id"] == 1000
+
+    @pytest.mark.asyncio
+    async def test_unmapped_artist_detail_reports_null(
+        self, client: AsyncClient, name_to_graph: dict[str, int]
+    ) -> None:
+        resp = await client.get(f"/graph/artists/{name_to_graph['Stereolab']}")
+        assert resp.status_code == 200
+        assert resp.json()["wxyc_library_code_id"] is None
+
+
+class TestDeployOrderDegradation:
+    """A pre-#358 served DB has no wxyc_library_code_id column yet."""
+
+    @pytest.mark.asyncio
+    async def test_missing_column_returns_empty_not_500(self, tmp_path) -> None:
+        path = str(tmp_path / "old_schema.db")
+        export_sqlite(
+            path,
+            artist_stats={"Autechre": make_artist_stats("Autechre")},
+            pmi_edges=[],
+            xref_edges=[],
+            min_count=1,
+        )
+        conn = sqlite3.connect(path)
+        conn.execute("DROP INDEX IF EXISTS idx_artist_library_code")
+        conn.execute("ALTER TABLE artist DROP COLUMN wxyc_library_code_id")
+        conn.commit()
+        conn.close()
+
+        app = create_app(path)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.post(ENDPOINT, json={"library_artist_ids": [1000], "limit": 5})
+        assert resp.status_code == 200
+        assert resp.json()["results"] == {"1000": []}

--- a/tests/unit/test_api_library_neighbors.py
+++ b/tests/unit/test_api_library_neighbors.py
@@ -14,7 +14,6 @@ never pass by accidentally conflating the two keyspaces.
 from __future__ import annotations
 
 import sqlite3
-import tempfile
 
 import pytest
 import pytest_asyncio
@@ -22,6 +21,7 @@ from httpx import ASGITransport, AsyncClient
 
 from semantic_index.api.app import create_app
 from semantic_index.models import PmiEdge
+from semantic_index.pipeline_db import PipelineDB
 from semantic_index.sqlite_export import export_sqlite
 from tests.conftest import make_artist_stats
 
@@ -44,13 +44,12 @@ _CODE_MAP = {
 # Stereolab, Broadcast: intentionally absent from _CODE_MAP (unmapped / NULL).
 
 
-def _build_library_fixture_db() -> tuple[str, dict[str, int]]:
+def _build_library_fixture_db(path: str) -> tuple[str, dict[str, int]]:
     """Build a fixture DB and map a subset of artists to library code ids.
 
     Returns ``(db_path, name_to_graph_id)``. Names absent from ``_CODE_MAP`` are
     left NULL, modeling homonym/raw names #358 excludes from the mapping.
     """
-    path = tempfile.mktemp(suffix=".db")
     names = [
         "Autechre",
         "Stereolab",
@@ -90,8 +89,9 @@ def _build_library_fixture_db() -> tuple[str, dict[str, int]]:
 
 
 @pytest.fixture(scope="module")
-def _fixture() -> tuple[str, dict[str, int]]:
-    return _build_library_fixture_db()
+def _fixture(tmp_path_factory: pytest.TempPathFactory) -> tuple[str, dict[str, int]]:
+    path = str(tmp_path_factory.mktemp("library_neighbors") / "graph.db")
+    return _build_library_fixture_db(path)
 
 
 @pytest.fixture(scope="module")
@@ -272,6 +272,21 @@ class TestSimilarArtistContract:
         assert set(SimilarArtist.model_fields.keys()) == {"artist_id", "weight"}
 
 
+def _build_entity_primary_path_db(path: str) -> int:
+    """Build a pipeline-DB fixture whose entity table makes ``_get_artist_detail``
+    take its PRIMARY (entity-JOIN) branch — the path production's served DB uses —
+    with ``wxyc_library_code_id`` set, so the primary read is covered. The SQL-dump
+    fixtures above have no entity table and always fall back to
+    ``_fetch_library_code_id`` instead. Returns Autechre's graph id.
+    """
+    db = PipelineDB(path)
+    db.initialize()
+    db.upsert_artist("Autechre", genre="Electronic", wxyc_library_code_id=1000)
+    aid = db._conn.execute("SELECT id FROM artist WHERE canonical_name = 'Autechre'").fetchone()[0]
+    db.close()
+    return int(aid)
+
+
 class TestArtistDetailLibraryCodeId:
     """ArtistDetail exposes wxyc_library_code_id for browser spot-checks."""
 
@@ -291,6 +306,42 @@ class TestArtistDetailLibraryCodeId:
         assert resp.status_code == 200
         assert resp.json()["wxyc_library_code_id"] is None
 
+    @pytest.mark.asyncio
+    async def test_primary_path_reports_code_id(self, tmp_path) -> None:
+        """The entity-JOIN branch reads ``a.wxyc_library_code_id`` directly — the
+        production served DB has an entity table, so this, not the fallback the other
+        two tests hit, is the live read path.
+        """
+        path = str(tmp_path / "entity_primary.db")
+        aid = _build_entity_primary_path_db(path)
+        app = create_app(path)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get(f"/graph/artists/{aid}")
+        assert resp.status_code == 200
+        assert resp.json()["wxyc_library_code_id"] == 1000
+
+
+def _build_pre_358_db(path: str) -> int:
+    """Export a fixture DB, then drop the #358 column and its index to model a served
+    DB that predates the mapping. Returns Autechre's graph id.
+    """
+    export_sqlite(
+        path,
+        artist_stats={"Autechre": make_artist_stats("Autechre")},
+        pmi_edges=[],
+        xref_edges=[],
+        min_count=1,
+    )
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    aid = conn.execute("SELECT id FROM artist WHERE canonical_name = 'Autechre'").fetchone()["id"]
+    conn.execute("DROP INDEX IF EXISTS idx_artist_library_code")
+    conn.execute("ALTER TABLE artist DROP COLUMN wxyc_library_code_id")
+    conn.commit()
+    conn.close()
+    return int(aid)
+
 
 class TestDeployOrderDegradation:
     """A pre-#358 served DB has no wxyc_library_code_id column yet."""
@@ -298,18 +349,7 @@ class TestDeployOrderDegradation:
     @pytest.mark.asyncio
     async def test_missing_column_returns_empty_not_500(self, tmp_path) -> None:
         path = str(tmp_path / "old_schema.db")
-        export_sqlite(
-            path,
-            artist_stats={"Autechre": make_artist_stats("Autechre")},
-            pmi_edges=[],
-            xref_edges=[],
-            min_count=1,
-        )
-        conn = sqlite3.connect(path)
-        conn.execute("DROP INDEX IF EXISTS idx_artist_library_code")
-        conn.execute("ALTER TABLE artist DROP COLUMN wxyc_library_code_id")
-        conn.commit()
-        conn.close()
+        _build_pre_358_db(path)
 
         app = create_app(path)
         transport = ASGITransport(app=app)
@@ -317,3 +357,18 @@ class TestDeployOrderDegradation:
             resp = await ac.post(ENDPOINT, json={"library_artist_ids": [1000], "limit": 5})
         assert resp.status_code == 200
         assert resp.json()["results"] == {"1000": []}
+
+    @pytest.mark.asyncio
+    async def test_artist_detail_survives_missing_column(self, tmp_path) -> None:
+        """GET /graph/artists/{id} degrades wxyc_library_code_id to null rather than
+        500 when the served DB predates #358 — the _fetch_library_code_id guard.
+        """
+        path = str(tmp_path / "old_schema.db")
+        aid = _build_pre_358_db(path)
+
+        app = create_app(path)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get(f"/graph/artists/{aid}")
+        assert resp.status_code == 200
+        assert resp.json()["wxyc_library_code_id"] is None


### PR DESCRIPTION
## Summary

Adds `POST /graph/library-artists/neighbors/batch` — the On Tour R3b endpoint that returns affinity neighbors keyed by Backend catalog **library artist id** (the `SimilarArtist.artist_id` / `Concert.headlining_artist_id` keyspace) instead of internal graph ids, so the Backend-Service concerts enrichment (WXYC/Backend-Service#1626) can look up similar artists for concert headliners without ever translating id spaces.

> **Stacked on #363** (the `api_models.py` regen that adds `SimilarArtist`). This PR's diff is feature-only; `generated/api_models.py` belongs to #363. The base retargets to `main` automatically when #363 merges — I'll then rebase to drop the carried regen commit.

## What changed (feature-only, ~500 lines)

- **Endpoint** (`routes.py`) — reverse-maps each requested library id to a graph artist via `artist.wxyc_library_code_id` (#358), ranks affinity through the shared `_neighbors_affinity_batch`, translates neighbors back into library ids, drops unmapped ones, cuts to `limit`. Over-fetches at **2× limit** in a single pass so a list stays full when its top-ranked neighbors are unmapped (probe: a plain top-`limit` left a fifth of lists short; 2× saturated all of them). The mapping filter stays in Python, not the shared affinity SQL (which also serves the public explorer).
- **Contract** — response items are the wxyc-shared `SimilarArtist` schema (`{artist_id, weight}`) verbatim, so the consumer persists and re-emits with zero field mapping. Every requested id is present in `results`; unknown / unmapped / homonym ids map to an empty list; duplicates collapse. Cap 100 ids (structured **422** on overflow, never silent truncation); `limit` 1–100 (default 20); optional `heat` 0–1 (default 0.5). Public, no auth. `weight` is the raw affinity composite and is **list-relative** (type-max normalized per source artist).
- **`ArtistDetail`** (`schemas.py`, `routes.py`) — additively exposes `wxyc_library_code_id` on `GET /graph/artists/{id}` (`null` when unmapped) for browser spot-checks.
- **Deploy-order safety** — the endpoint and the detail field degrade to empty / `null` rather than 500 on a pre-#358 served DB; `GET /health` `mapped_artist_count` distinguishes "mapping not yet rebuilt" from "endpoint broken".
- **Tests** — `tests/unit/test_api_library_neighbors.py`: both translation directions, the 2× over-fetch refill (the test that fails if the multiple is removed), the request envelope, the `SimilarArtist` field-name pin, the `ArtistDetail` field, and the pre-#358 degradation path.
- **Docs** — `docs/graph-api.md` endpoint section (shape, heat, weight list-relativity, cap/422, empty-list semantics, no-auth rationale); `docs/glossary.md` *library artist id* entry.

## Testing

`ruff check .` clean · `ruff format --check .` clean · `mypy semantic_index/` clean · **1172 passed**, 13 deselected. All default-marker, `AsyncClient` over a fixture DB per the `test_api_routes.py` convention, WXYC example artists in fixtures.

## Related

- Closes #354
- Prerequisite (stacked on): #363 — regenerates `api_models.py` to add `SimilarArtist`
- Consumer: WXYC/Backend-Service#1626 (nightly concerts enrichment)
- Mapping: #358 (merged) · Contract: WXYC/wxyc-shared#222 · iOS debug dial: WXYC/wxyc-ios-64#534 · Homonym-node split: #360
