### PR TITLE
feat(api): Discogs-id-keyed batch neighbors endpoint (#367)

### DIFF
--- a/semantic_index/api/routes.py
+++ b/semantic_index/api/routes.py
@@ -24,6 +24,7 @@ from semantic_index.api.schemas import (
     BatchNeighborsResponse,
     CommunitiesResponse,
     CommunityDetail,
+    DiscogsNeighborsBatchResponse,
     DjSummary,
     EntityArtists,
     ExplainResponse,
@@ -569,6 +570,125 @@ def get_library_neighbors_batch(
         results[str(code_id)] = neighbors
 
     return LibraryNeighborsBatchResponse(results=results)
+
+
+class DiscogsNeighborsBatchRequest(BaseModel):
+    """Request body for POST /graph/discogs-artists/neighbors/batch (#367).
+
+    ``discogs_artist_ids`` are EXTERNAL Discogs artist ids — the key a non-library
+    concert headliner is looked up by (WXYC/Backend-Service#1614's LML-minted
+    ids), distinct from the sibling endpoints' ``library_artist_ids`` (catalog
+    codes) and ``artist_ids`` (internal graph ids). The distinct field name is
+    deliberate: it names the input keyspace and guards against the id-space
+    confusion this family of endpoints exists to resolve. The 100-id cap
+    (``max_length``) returns a structured 422 on overflow rather than silent
+    truncation, which for an unattended nightly job would be silent data loss.
+    """
+
+    discogs_artist_ids: list[int] = Field(..., max_length=100)
+    limit: int = Field(20, ge=1, le=100)
+    heat: float = Field(0.5, ge=0.0, le=1.0)
+
+
+@router.post("/discogs-artists/neighbors/batch", response_model=DiscogsNeighborsBatchResponse)
+def get_discogs_neighbors_batch(
+    body: DiscogsNeighborsBatchRequest,
+    db: sqlite3.Connection = Depends(get_db),
+) -> DiscogsNeighborsBatchResponse:
+    """Batch affinity neighbors keyed by an EXTERNAL Discogs artist id.
+
+    Sibling of :func:`get_library_neighbors_batch` (#354) for concert headliners
+    that are NOT in the WXYC library — Discogs-only touring artists resolved via
+    ``concerts.headlining_discogs_artist_id`` (WXYC/Backend-Service#1614) that have
+    no catalog code to ask under. For each requested Discogs id: reverse-map it to
+    a graph artist via ``artist.discogs_artist_id``, rank affinity neighbors,
+    translate those neighbors back into library ids (``wxyc_library_code_id``),
+    drop any that are unmapped, and cut to ``limit``. Every requested id appears in
+    ``results``; unknown, unmapped, and ambiguous ids map to an empty list.
+    Duplicate ids collapse. The NEIGHBORS returned are library code ids — the same
+    keyspace #354 returns and the same one iOS intersects against listener likes;
+    only the lookup KEY changed.
+
+    The one real divergence from #354: ``idx_artist_discogs`` is a PLAIN partial
+    index, not UNIQUE like ``idx_artist_library_code``, so a Discogs id can be
+    borne by >=2 graph nodes (homonym-collapse). The reverse lookup therefore keeps
+    only ids that resolve to EXACTLY ONE node (``GROUP BY … HAVING COUNT(*) = 1``)
+    and drops the ambiguous ones to ``[]`` rather than collapse to an arbitrary
+    winner — the schema can't guarantee injectivity here the way #365 does for
+    library codes, so this query enforces it.
+
+    Read-only, public, unauthenticated — consistent with the rest of the graph API;
+    worst case is a bounded local SQLite read. Called nightly server-to-server by
+    the Backend-Service concerts enrichment's Discogs lane (WXYC/Backend-Service#1701).
+    ``weight`` is the raw affinity composite and is list-relative, so consumers
+    must rank and cap within a single list, not across lists.
+    """
+    _init_metrics_flag(db)
+
+    # Dedupe, preserving first-seen order; empty input short-circuits to {}.
+    requested = list(dict.fromkeys(body.discogs_artist_ids))
+    if not requested:
+        return DiscogsNeighborsBatchResponse(results={})
+
+    # Reverse lookup: Discogs id -> graph artist id. NOT injective by schema —
+    # idx_artist_discogs is a plain (non-UNIQUE) partial index, unlike the library
+    # sibling's #365 UNIQUE index — so a homonym-collapsed Discogs id can sit on
+    # >=2 graph nodes. GROUP BY … HAVING COUNT(*) = 1 keeps only the unambiguous
+    # ones; an id on >=2 nodes falls out of the map and lands as an empty list
+    # below, never an arbitrary node's neighbors. A served DB that predates the
+    # discogs column would degrade to "nothing mapped" here rather than 500.
+    placeholders = ",".join("?" * len(requested))
+    try:
+        source_rows = db.execute(
+            f"SELECT discogs_artist_id, id FROM artist "  # noqa: S608
+            f"WHERE discogs_artist_id IN ({placeholders}) "
+            f"GROUP BY discogs_artist_id HAVING COUNT(*) = 1",
+            requested,
+        ).fetchall()
+        discogs_to_graph: dict[int, int] = {r["discogs_artist_id"]: r["id"] for r in source_rows}
+    except sqlite3.OperationalError:
+        discogs_to_graph = {}
+
+    graph_ids = [discogs_to_graph[d] for d in requested if d in discogs_to_graph]
+    per_source = _neighbors_affinity_batch(
+        db, graph_ids, body.limit * _LIBRARY_NEIGHBOR_OVERFETCH, heat=body.heat
+    )
+
+    # Forward translation: neighbor graph id -> library code id, dropping unmapped
+    # neighbors (the over-fetch refills past them). Unlike the library sibling, the
+    # source lookup above succeeds on a pre-#358 served DB (discogs_artist_id is an
+    # old column), so this translation query is the one that would hit a missing
+    # wxyc_library_code_id column — wrap it too, degrading every neighbor to
+    # "unmapped" (empty lists) rather than 500.
+    neighbor_gids = {entry.artist.id for entries in per_source.values() for entry in entries}
+    graph_to_code: dict[int, int] = {}
+    if neighbor_gids:
+        nbr_placeholders = ",".join("?" * len(neighbor_gids))
+        try:
+            nbr_rows = db.execute(
+                f"SELECT id, wxyc_library_code_id FROM artist "  # noqa: S608
+                f"WHERE id IN ({nbr_placeholders}) AND wxyc_library_code_id IS NOT NULL",
+                list(neighbor_gids),
+            ).fetchall()
+            graph_to_code = {r["id"]: r["wxyc_library_code_id"] for r in nbr_rows}
+        except sqlite3.OperationalError:
+            graph_to_code = {}
+
+    results: dict[str, list[SimilarArtist]] = {}
+    for discogs_id in requested:
+        gid = discogs_to_graph.get(discogs_id)
+        neighbors: list[SimilarArtist] = []
+        if gid is not None:
+            for entry in per_source.get(gid, []):
+                mapped = graph_to_code.get(entry.artist.id)
+                if mapped is None:
+                    continue  # unmapped neighbor dropped, then over-fetch refills
+                neighbors.append(SimilarArtist(artist_id=mapped, weight=entry.weight))
+                if len(neighbors) >= body.limit:
+                    break
+        results[str(discogs_id)] = neighbors
+
+    return DiscogsNeighborsBatchResponse(results=results)
 
 
 @router.get("/artists/{artist_id}/explain/{target_id}", response_model=ExplainResponse)

--- a/semantic_index/api/schemas.py
+++ b/semantic_index/api/schemas.py
@@ -113,6 +113,22 @@ class LibraryNeighborsBatchResponse(BaseModel):
     results: dict[str, list[SimilarArtist]]
 
 
+class DiscogsNeighborsBatchResponse(BaseModel):
+    """Response for POST /graph/discogs-artists/neighbors/batch (#367).
+
+    Same shape and neighbor keyspace as ``LibraryNeighborsBatchResponse`` — the
+    values are top-K affinity neighbors in the Backend catalog library-artist id
+    keyspace (``SimilarArtist`` ``{artist_id, weight}``), weight-descending. Only
+    the request KEY differs: here it is an external Discogs artist id. Keyed by
+    the requested Discogs id (rendered as a string). Unknown, unmapped, and
+    ambiguous (a Discogs id borne by >=2 graph nodes) ids are present with an
+    empty list rather than omitted, so the consumer can tell "asked, no
+    neighbors" from "never asked".
+    """
+
+    results: dict[str, list[SimilarArtist]]
+
+
 class EntityArtists(BaseModel):
     """Response for GET /graph/entities/{id}/artists — all artists sharing an entity."""
 

--- a/semantic_index/sqlite_export.py
+++ b/semantic_index/sqlite_export.py
@@ -47,6 +47,11 @@ CREATE TABLE IF NOT EXISTS artist (
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_artist_library_code ON artist(wxyc_library_code_id) WHERE wxyc_library_code_id IS NOT NULL;
 
+-- Non-UNIQUE (homonym-collapse can share a Discogs id across nodes) partial index
+-- backing the reverse lookup in POST /graph/discogs-artists/neighbors/batch (#367).
+-- Mirrors idx_artist_discogs in pipeline_db.py so the served export is indexed too.
+CREATE INDEX IF NOT EXISTS idx_artist_discogs ON artist(discogs_artist_id) WHERE discogs_artist_id IS NOT NULL;
+
 CREATE TABLE IF NOT EXISTS dj_transition (
     source_id INTEGER NOT NULL REFERENCES artist(id),
     target_id INTEGER NOT NULL REFERENCES artist(id),

--- a/tests/unit/test_api_discogs_neighbors.py
+++ b/tests/unit/test_api_discogs_neighbors.py
@@ -82,9 +82,15 @@ def _build_discogs_fixture_db(path: str) -> tuple[str, dict[str, int]]:
         PmiEdge(source="Autechre", target="Mouse on Mars", raw_count=20, pmi=2.0),
         PmiEdge(source="Autechre", target="Pole", raw_count=10, pmi=1.0),
         PmiEdge(source="Cat Power", target="Jessica Pratt", raw_count=5, pmi=1.5),
-        # Homonym One WOULD map to Boards of Canada (1002) if the endpoint picked
-        # an arbitrary node for the ambiguous Discogs id 900009 — it must not.
+        # Both nodes sharing the ambiguous Discogs id 900009 carry a DISTINCT mapped
+        # neighbor (Homonym One -> Boards of Canada 1002, Homonym Two -> Oval 1003),
+        # so a naive "pick one node" impl returns a non-empty list whichever node it
+        # lands on — only the correct ambiguity DROP yields []. Giving Homonym Two a
+        # neighbor is load-bearing: without it, the rowid-order dict-overwrite would
+        # land on the edgeless Homonym Two and return [] anyway, letting a regression
+        # that deletes the `GROUP BY ... HAVING COUNT(*) = 1` guard pass unnoticed.
         PmiEdge(source="Homonym One", target="Boards of Canada", raw_count=15, pmi=2.5),
+        PmiEdge(source="Homonym Two", target="Oval", raw_count=15, pmi=2.5),
     ]
     export_sqlite(path, artist_stats=stats, pmi_edges=pmi_edges, xref_edges=[], min_count=1)
 
@@ -160,9 +166,10 @@ class TestAmbiguousDiscogsId:
 
     @pytest.mark.asyncio
     async def test_ambiguous_discogs_id_returns_empty(self, client: AsyncClient) -> None:
-        # 900009 is carried by both Homonym One and Homonym Two. Homonym One has a
-        # mapped neighbor (Boards of Canada, 1002), so a naive "pick one node" impl
-        # would return [1002]. The contract requires [] — ambiguity is unresolvable.
+        # 900009 is carried by both Homonym One and Homonym Two, each with a distinct
+        # mapped neighbor, so a naive "pick one node" impl would return [1002] or
+        # [1003] whichever node it lands on. The contract requires [] — ambiguity is
+        # unresolvable, so the id is dropped rather than collapsed to a winner.
         resp = await client.post(ENDPOINT, json={"discogs_artist_ids": [900009], "limit": 20})
         assert resp.status_code == 200
         results = resp.json()["results"]
@@ -324,6 +331,31 @@ def _build_pre_358_db(path: str) -> None:
     conn.close()
 
 
+def _build_pre_discogs_column_db(path: str) -> None:
+    """Export a fixture, then drop the discogs_artist_id column + its index to model a
+    served DB so old it predates the Discogs reverse-lookup KEY itself. The SOURCE
+    lookup can't run, so every requested id degrades to empty — exercising the FIRST
+    OperationalError guard (the reverse discogs query), which ``_build_pre_358_db``
+    leaves untouched because it keeps discogs_artist_id and only drops the mapping.
+    """
+    stats = {
+        "Autechre": make_artist_stats("Autechre", genre="Electronic"),
+        "Boards of Canada": make_artist_stats("Boards of Canada", genre="Electronic"),
+    }
+    export_sqlite(
+        path,
+        artist_stats=stats,
+        pmi_edges=[PmiEdge(source="Autechre", target="Boards of Canada", raw_count=40, pmi=4.0)],
+        xref_edges=[],
+        min_count=1,
+    )
+    conn = sqlite3.connect(path)
+    conn.execute("DROP INDEX IF EXISTS idx_artist_discogs")
+    conn.execute("ALTER TABLE artist DROP COLUMN discogs_artist_id")
+    conn.commit()
+    conn.close()
+
+
 class TestDeployOrderDegradation:
     """A pre-#358 served DB has no wxyc_library_code_id column to translate into."""
 
@@ -338,5 +370,19 @@ class TestDeployOrderDegradation:
             resp = await ac.post(ENDPOINT, json={"discogs_artist_ids": [900000], "limit": 5})
         # Source resolves via discogs_artist_id, but neighbor translation cannot
         # run without wxyc_library_code_id — degrade to empty, never 500.
+        assert resp.status_code == 200
+        assert resp.json()["results"] == {"900000": []}
+
+    @pytest.mark.asyncio
+    async def test_missing_discogs_column_returns_empty_not_500(self, tmp_path) -> None:
+        path = str(tmp_path / "pre_discogs.db")
+        _build_pre_discogs_column_db(path)
+
+        app = create_app(path)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.post(ENDPOINT, json={"discogs_artist_ids": [900000], "limit": 5})
+        # The reverse discogs_artist_id lookup can't run on a DB without the column;
+        # the source-query OperationalError guard degrades it to empty, never 500.
         assert resp.status_code == 200
         assert resp.json()["results"] == {"900000": []}

--- a/tests/unit/test_api_discogs_neighbors.py
+++ b/tests/unit/test_api_discogs_neighbors.py
@@ -1,0 +1,342 @@
+"""Tests for POST /graph/discogs-artists/neighbors/batch (On Tour, #367).
+
+Sibling of ``test_api_library_neighbors`` (#354): the SOURCE headliner is keyed by
+its external ``artist.discogs_artist_id`` instead of the library code, but the
+NEIGHBORS returned are still in the Backend catalog library-artist id keyspace
+(``SimilarArtist.artist_id``, the ``wxyc_library_code_id`` mapping). So a fixture
+sets ``discogs_artist_id`` on the sources and ``wxyc_library_code_id`` on the
+neighbors, via direct UPDATE after ``export_sqlite`` (SQL-dump mode leaves both
+columns present-but-NULL by design).
+
+The one real divergence from the library sibling: ``idx_artist_discogs`` is a
+PLAIN partial index, not UNIQUE like ``idx_artist_library_code``. Homonym-collapse
+can therefore put >=2 graph nodes on one Discogs id, and the endpoint must DROP
+such an id (return ``[]``), NOT collapse to an arbitrary winner. ``Homonym One`` /
+``Homonym Two`` share Discogs id 900009 to pin that contract.
+
+Keyspaces never collide by accident: Discogs source ids are >= 900000, library
+code ids >= 1000, graph ids autoincrement from 1.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from semantic_index.api.app import create_app
+from semantic_index.models import PmiEdge
+from semantic_index.sqlite_export import export_sqlite
+from tests.conftest import make_artist_stats
+
+ENDPOINT = "/graph/discogs-artists/neighbors/batch"
+
+# Autechre (Discogs 900000) is the source under test. Its djTransition neighbors,
+# in raw_count order, are Stereolab (60), Broadcast (50), Boards of Canada (40),
+# Oval (30), Mouse on Mars (20), Pole (10). At heat=0.0 the affinity rank is
+# exactly this raw_count order. Stereolab and Broadcast are deliberately left
+# UNMAPPED (no library code) so the top two affinity ranks drop out — the
+# over-fetch test hinges on this.
+_DISCOGS_MAP = {
+    "Autechre": 900000,
+    "Cat Power": 900001,
+    "Homonym One": 900009,
+    "Homonym Two": 900009,  # SAME id as Homonym One → ambiguous, must return []
+}
+_CODE_MAP = {
+    "Boards of Canada": 1002,
+    "Oval": 1003,
+    "Mouse on Mars": 1004,
+    "Pole": 1005,
+    "Jessica Pratt": 2001,
+}
+# Stereolab, Broadcast: intentionally in neither map (unmapped neighbors / NULL).
+
+
+def _build_discogs_fixture_db(path: str) -> tuple[str, dict[str, int]]:
+    """Build a fixture DB, keying sources by Discogs id and neighbors by code id.
+
+    Returns ``(db_path, name_to_graph_id)``.
+    """
+    names = [
+        "Autechre",
+        "Stereolab",
+        "Broadcast",
+        "Boards of Canada",
+        "Oval",
+        "Mouse on Mars",
+        "Pole",
+        "Cat Power",
+        "Jessica Pratt",
+        "Homonym One",
+        "Homonym Two",
+    ]
+    stats = {n: make_artist_stats(n, total_plays=50, genre="Electronic") for n in names}
+    pmi_edges = [
+        PmiEdge(source="Autechre", target="Stereolab", raw_count=60, pmi=6.0),
+        PmiEdge(source="Autechre", target="Broadcast", raw_count=50, pmi=5.0),
+        PmiEdge(source="Autechre", target="Boards of Canada", raw_count=40, pmi=4.0),
+        PmiEdge(source="Autechre", target="Oval", raw_count=30, pmi=3.0),
+        PmiEdge(source="Autechre", target="Mouse on Mars", raw_count=20, pmi=2.0),
+        PmiEdge(source="Autechre", target="Pole", raw_count=10, pmi=1.0),
+        PmiEdge(source="Cat Power", target="Jessica Pratt", raw_count=5, pmi=1.5),
+        # Homonym One WOULD map to Boards of Canada (1002) if the endpoint picked
+        # an arbitrary node for the ambiguous Discogs id 900009 — it must not.
+        PmiEdge(source="Homonym One", target="Boards of Canada", raw_count=15, pmi=2.5),
+    ]
+    export_sqlite(path, artist_stats=stats, pmi_edges=pmi_edges, xref_edges=[], min_count=1)
+
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    name_to_graph = {
+        r["canonical_name"]: r["id"] for r in conn.execute("SELECT id, canonical_name FROM artist")
+    }
+    for name, discogs_id in _DISCOGS_MAP.items():
+        conn.execute(
+            "UPDATE artist SET discogs_artist_id = ? WHERE canonical_name = ?",
+            (discogs_id, name),
+        )
+    for name, code in _CODE_MAP.items():
+        conn.execute(
+            "UPDATE artist SET wxyc_library_code_id = ? WHERE canonical_name = ?",
+            (code, name),
+        )
+    conn.commit()
+    conn.close()
+    return path, name_to_graph
+
+
+@pytest.fixture(scope="module")
+def _fixture(tmp_path_factory: pytest.TempPathFactory) -> tuple[str, dict[str, int]]:
+    path = str(tmp_path_factory.mktemp("discogs_neighbors") / "graph.db")
+    return _build_discogs_fixture_db(path)
+
+
+@pytest.fixture(scope="module")
+def db_path(_fixture: tuple[str, dict[str, int]]) -> str:
+    return _fixture[0]
+
+
+@pytest.fixture(scope="module")
+def name_to_graph(_fixture: tuple[str, dict[str, int]]) -> dict[str, int]:
+    return _fixture[1]
+
+
+@pytest_asyncio.fixture
+async def client(db_path: str) -> AsyncClient:
+    app = create_app(db_path)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+class TestInputDirection:
+    """Requested Discogs ids resolve to graph neighbors; unknown ids → empty."""
+
+    @pytest.mark.asyncio
+    async def test_mapped_source_returns_neighbors(self, client: AsyncClient) -> None:
+        resp = await client.post(
+            ENDPOINT, json={"discogs_artist_ids": [900001], "limit": 20, "heat": 0.5}
+        )
+        assert resp.status_code == 200
+        results = resp.json()["results"]
+        assert "900001" in results
+        # Cat Power (Discogs 900001) -> Jessica Pratt (code 2001), the only mapped neighbor.
+        assert [n["artist_id"] for n in results["900001"]] == [2001]
+        assert results["900001"][0]["weight"] > 0
+
+    @pytest.mark.asyncio
+    async def test_unknown_discogs_id_present_but_empty(self, client: AsyncClient) -> None:
+        resp = await client.post(ENDPOINT, json={"discogs_artist_ids": [999999], "limit": 20})
+        assert resp.status_code == 200
+        # Present in results (never dropped), but empty — no graph node carries it.
+        assert resp.json()["results"] == {"999999": []}
+
+
+class TestAmbiguousDiscogsId:
+    """A Discogs id borne by >=2 graph nodes is dropped, not collapsed."""
+
+    @pytest.mark.asyncio
+    async def test_ambiguous_discogs_id_returns_empty(self, client: AsyncClient) -> None:
+        # 900009 is carried by both Homonym One and Homonym Two. Homonym One has a
+        # mapped neighbor (Boards of Canada, 1002), so a naive "pick one node" impl
+        # would return [1002]. The contract requires [] — ambiguity is unresolvable.
+        resp = await client.post(ENDPOINT, json={"discogs_artist_ids": [900009], "limit": 20})
+        assert resp.status_code == 200
+        results = resp.json()["results"]
+        assert results == {"900009": []}
+
+    @pytest.mark.asyncio
+    async def test_ambiguous_id_does_not_poison_sibling_ids(self, client: AsyncClient) -> None:
+        # An ambiguous id in the batch must not affect the unambiguous ones.
+        resp = await client.post(
+            ENDPOINT, json={"discogs_artist_ids": [900009, 900001], "limit": 20}
+        )
+        assert resp.status_code == 200
+        results = resp.json()["results"]
+        assert results["900009"] == []
+        assert [n["artist_id"] for n in results["900001"]] == [2001]
+        assert set(results.keys()) == {"900009", "900001"}
+
+
+class TestOutputDirection:
+    """Neighbor graph ids translate to library ids; unmapped neighbors drop."""
+
+    @pytest.mark.asyncio
+    async def test_neighbors_are_library_ids_never_graph_ids(
+        self, client: AsyncClient, name_to_graph: dict[str, int]
+    ) -> None:
+        resp = await client.post(
+            ENDPOINT, json={"discogs_artist_ids": [900000], "limit": 20, "heat": 0.0}
+        )
+        assert resp.status_code == 200
+        got = [n["artist_id"] for n in resp.json()["results"]["900000"]]
+        # Stereolab and Broadcast are unmapped and drop out entirely; the rest
+        # translate to their library code ids in weight order.
+        assert got == [1002, 1003, 1004, 1005]
+        # The unmapped neighbors' GRAPH ids must never leak into the response.
+        assert name_to_graph["Stereolab"] not in got
+        assert name_to_graph["Broadcast"] not in got
+        # Nor may the SOURCE's own Discogs id ever appear as a neighbor id.
+        assert 900000 not in got
+
+    @pytest.mark.asyncio
+    async def test_over_fetch_refills_past_unmapped_top_neighbors(
+        self, client: AsyncClient
+    ) -> None:
+        """The 2x over-fetch keeps a short list full after the unmapped-top drop.
+
+        Autechre's top-2 affinity neighbors (Stereolab, Broadcast) are unmapped.
+        With limit=3 and NO over-fetch, only rank-3 (Boards) survives for a
+        length-1 list. The 2x over-fetch pulls ranks 1-6, drops the two unmapped,
+        and refills to a full 3. Fails if someone simplifies the fixed 2x away.
+        """
+        resp = await client.post(
+            ENDPOINT, json={"discogs_artist_ids": [900000], "limit": 3, "heat": 0.0}
+        )
+        assert resp.status_code == 200
+        got = [n["artist_id"] for n in resp.json()["results"]["900000"]]
+        assert got == [1002, 1003, 1004]
+
+    @pytest.mark.asyncio
+    async def test_weights_descending(self, client: AsyncClient) -> None:
+        resp = await client.post(
+            ENDPOINT, json={"discogs_artist_ids": [900000], "limit": 20, "heat": 0.0}
+        )
+        weights = [n["weight"] for n in resp.json()["results"]["900000"]]
+        assert weights == sorted(weights, reverse=True)
+
+
+class TestEnvelope:
+    """Batch cap, empty input, dedup, and bound enforcement."""
+
+    @pytest.mark.asyncio
+    async def test_over_100_ids_returns_422(self, client: AsyncClient) -> None:
+        resp = await client.post(
+            ENDPOINT, json={"discogs_artist_ids": list(range(101)), "limit": 20}
+        )
+        assert resp.status_code == 422  # structured overflow, never silent truncation
+
+    @pytest.mark.asyncio
+    async def test_exactly_100_ids_ok(self, client: AsyncClient) -> None:
+        resp = await client.post(
+            ENDPOINT, json={"discogs_artist_ids": list(range(1, 101)), "limit": 5}
+        )
+        assert resp.status_code == 200
+        assert len(resp.json()["results"]) == 100
+
+    @pytest.mark.asyncio
+    async def test_empty_input_returns_empty_results(self, client: AsyncClient) -> None:
+        resp = await client.post(ENDPOINT, json={"discogs_artist_ids": [], "limit": 20})
+        assert resp.status_code == 200
+        assert resp.json()["results"] == {}
+
+    @pytest.mark.asyncio
+    async def test_duplicate_ids_collapse(self, client: AsyncClient) -> None:
+        resp = await client.post(
+            ENDPOINT, json={"discogs_artist_ids": [900001, 900001, 900001], "limit": 20}
+        )
+        assert resp.status_code == 200
+        assert list(resp.json()["results"].keys()) == ["900001"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("limit", [0, 101])
+    async def test_limit_out_of_bounds_422(self, client: AsyncClient, limit: int) -> None:
+        resp = await client.post(ENDPOINT, json={"discogs_artist_ids": [900001], "limit": limit})
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("heat", [-0.1, 1.1])
+    async def test_heat_out_of_bounds_422(self, client: AsyncClient, heat: float) -> None:
+        resp = await client.post(
+            ENDPOINT, json={"discogs_artist_ids": [900001], "limit": 20, "heat": heat}
+        )
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_heat_defaults_when_omitted(self, client: AsyncClient) -> None:
+        resp = await client.post(ENDPOINT, json={"discogs_artist_ids": [900001]})
+        assert resp.status_code == 200
+        assert resp.json()["results"]["900001"]  # default heat still resolves neighbors
+
+
+class TestSimilarArtistContract:
+    """Response items are the shared SimilarArtist schema, verbatim."""
+
+    @pytest.mark.asyncio
+    async def test_response_items_have_exactly_similar_artist_fields(
+        self, client: AsyncClient
+    ) -> None:
+        resp = await client.post(
+            ENDPOINT, json={"discogs_artist_ids": [900000], "limit": 3, "heat": 0.0}
+        )
+        neighbors = resp.json()["results"]["900000"]
+        assert neighbors  # non-empty, so the assertion below actually runs
+        for item in neighbors:
+            assert set(item.keys()) == {"artist_id", "weight"}
+            assert isinstance(item["artist_id"], int)
+            assert isinstance(item["weight"], int | float)
+
+
+def _build_pre_358_db(path: str) -> None:
+    """Export a fixture with a Discogs-keyed source, then drop the #358 mapping
+    column + index to model a served DB that predates library-code translation.
+    The source Discogs lookup still resolves, but no neighbor can be translated.
+    """
+    stats = {
+        "Autechre": make_artist_stats("Autechre", genre="Electronic"),
+        "Boards of Canada": make_artist_stats("Boards of Canada", genre="Electronic"),
+    }
+    export_sqlite(
+        path,
+        artist_stats=stats,
+        pmi_edges=[PmiEdge(source="Autechre", target="Boards of Canada", raw_count=40, pmi=4.0)],
+        xref_edges=[],
+        min_count=1,
+    )
+    conn = sqlite3.connect(path)
+    conn.execute("UPDATE artist SET discogs_artist_id = 900000 WHERE canonical_name = 'Autechre'")
+    conn.execute("DROP INDEX IF EXISTS idx_artist_library_code")
+    conn.execute("ALTER TABLE artist DROP COLUMN wxyc_library_code_id")
+    conn.commit()
+    conn.close()
+
+
+class TestDeployOrderDegradation:
+    """A pre-#358 served DB has no wxyc_library_code_id column to translate into."""
+
+    @pytest.mark.asyncio
+    async def test_missing_mapping_column_returns_empty_not_500(self, tmp_path) -> None:
+        path = str(tmp_path / "old_schema.db")
+        _build_pre_358_db(path)
+
+        app = create_app(path)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.post(ENDPOINT, json={"discogs_artist_ids": [900000], "limit": 5})
+        # Source resolves via discogs_artist_id, but neighbor translation cannot
+        # run without wxyc_library_code_id — degrade to empty, never 500.
+        assert resp.status_code == 200
+        assert resp.json()["results"] == {"900000": []}


### PR DESCRIPTION
## What

Adds `POST /graph/discogs-artists/neighbors/batch` — a sibling of the library-id endpoint (#354 / #364) that looks a concert headliner up by its **external Discogs artist id** instead of a WXYC catalog code, and returns affinity neighbors in the **same catalog library-artist id keyspace** #354 returns.

This unblocks the On Tour "For You" Similar tier for headliners that aren't in the WXYC library — Discogs-only touring artists resolved via `concerts.headlining_discogs_artist_id` (WXYC/Backend-Service#1614) that have no `wxyc_library_code_id` to ask under, so today they structurally get `similar_artists: null`.

## How

For each requested Discogs id: reverse-map to a graph artist via `artist.discogs_artist_id`, rank affinity neighbors, translate the neighbors back into library code ids (`wxyc_library_code_id`), drop the unmapped, cut to `limit`. The whole translate-drop-cut-overfetch path, the batch cap (100 → 422), dedupe, empty-input short-circuit, and `heat` default (0.5) are reused verbatim from `get_library_neighbors_batch`. Only the lookup **key** changed — the neighbors stay catalog ids, the same keyspace iOS intersects against listener likes, so nothing on the neighbor side or on iOS moves.

## The one real divergence from #354

`idx_artist_discogs` is a **plain** (non-UNIQUE) partial index, unlike the #365 UNIQUE `idx_artist_library_code`. Homonym-collapse can therefore put ≥2 graph nodes on one Discogs id. The reverse lookup keeps only ids that resolve to **exactly one** node (`GROUP BY discogs_artist_id HAVING COUNT(*) = 1`) and drops the ambiguous ones to `[]` — never an arbitrary node's neighbors. The schema can't guarantee injectivity here the way it does for library codes, so the query enforces it. `TestAmbiguousDiscogsId` pins this: two nodes share Discogs `900009`, one carries a real mapped neighbor, and the endpoint still returns `[]`.

## Notes

- **Forward-translation guard.** Unlike #354 (where a pre-#358 DB fails the *source* lookup first and never reaches translation), the Discogs source lookup succeeds on a pre-#358 served DB because `discogs_artist_id` is an old column. So the neighbor-translation query is wrapped in its own `OperationalError` guard — a served DB missing `wxyc_library_code_id` degrades to empty lists, never a 500. Covered by `TestDeployOrderDegradation`.
- **Export index (minor, additive).** The served SQLite export `_SCHEMA` only carried `idx_artist_library_code`; this adds the symmetric non-UNIQUE `idx_artist_discogs` partial index (the build DB in `pipeline_db.py` already has it) so the reverse lookup is indexed on the served DB. Idempotent `IF NOT EXISTS`, picked up on the next nightly rebuild; the query degrades to a bounded scan on an older served DB in the meantime. This is a small deviation from the ticket's "no schema change" note, called out here for the reviewer.
- Reuses the shared `SimilarArtist` (`{artist_id, weight}`) contract verbatim — no `generated/api_models.py` regen, no new response shape in the cross-repo SSOT.

## Testing

`tests/unit/test_api_discogs_neighbors.py` (18 cases, TDD): input/output direction, ambiguity drop (+ no cross-id poisoning), over-fetch refill past unmapped top neighbors, weights descending, the full envelope (cap/empty/dedupe/limit+heat bounds/heat default), the `SimilarArtist` field contract, and pre-#358 degradation. Full local run green: `ruff check .`, `ruff format --check .`, `mypy semantic_index/`, `pytest tests/` (1198 passed, 13 pg-deselected).

Closes #367.

## Related

- WXYC/Backend-Service#1701 (consumer; this is its blocking dependency — the Discogs enrichment lane)
- #354 / #364 (the library-id sibling this mirrors)
- #358 / #365 (the `wxyc_library_code_id` mapping + UNIQUE index the neighbor translation relies on)
- WXYC/Backend-Service#1614 (LML Discogs-id headliner resolve — source of the non-library headliner Discogs ids)
