### PR TITLE
feat(api): return source total_plays on library-artists/neighbors/batch (#369)

### DIFF
--- a/docs/graph-api.md
+++ b/docs/graph-api.md
@@ -43,10 +43,12 @@ POST /graph/library-artists/neighbors/batch
 
 { "results": {
     "4210": [ {"artist_id": 5121, "weight": 4.83} ],
-    "887":  [] } }
+    "887":  [] },
+  "source_plays": { "4210": 312 } }
 ```
 
 - **Shape** — each requested id maps to a list of `SimilarArtist` items (`{artist_id, weight}`, the wxyc-shared DTO verbatim), weight-descending. Every requested id is present in `results`; an unknown, unmapped, or [homonym](glossary.md#homonym) id maps to an empty list rather than being omitted, so the caller can tell "asked, none" from "never asked". Duplicate ids collapse.
+- **`source_plays`** (WXYC/Backend-Service#1702) — each mapped source artist's own all-time WXYC play count (`artist.total_plays`), keyed by the same requested library-artist-id strings as `results`. Present **only** for ids that mapped to a graph artist; an unknown, unmapped, or [homonym](glossary.md#homonym) id is absent from the map (distinct from `results`, which carries it with an empty list). Additive and backward-compatible — consumers reading only `results` are unaffected. Feeds the Backend concerts "On Tour" station play-affinity shelf (WXYC/Backend-Service#1626).
 - **`heat`** (optional, 0.0–1.0, default 0.5) — the same discovery dial as the neighbors endpoints: cool ranks by well-worn co-occurrence, hot by surprising enrichment edges. One heat per request keeps a response's weights mutually comparable. The production consumer omits it; the iOS debug dial (WXYC/wxyc-ios-64#534) passes it for live preview.
 - **`weight`** is the raw affinity composite and is **list-relative** — type-max normalized per source artist, so weights are comparable *within* one list, not *across* lists. Rank and cap relative to a list's own maximum; never compare a weight from one list against a weight from another.
 - **Cap and overflow** — at most 100 ids per request (`limit` 1–100, default 20); 101+ ids returns a structured `422`, never a silent truncation, because the nightly caller is unattended and a dropped id would be silent data loss. Empty input returns `200` with empty `results`.

--- a/semantic_index/api/routes.py
+++ b/semantic_index/api/routes.py
@@ -525,13 +525,18 @@ def get_library_neighbors_batch(
     # A pre-#358 served DB has no such column yet — degrade to "nothing mapped"
     # (empty lists) rather than 500, per the endpoint's deploy-order contract.
     code_placeholders = ",".join("?" * len(requested))
+    source_plays: dict[str, int] = {}
     try:
         code_rows = db.execute(
-            f"SELECT id, wxyc_library_code_id FROM artist "  # noqa: S608
+            f"SELECT id, wxyc_library_code_id, total_plays FROM artist "  # noqa: S608
             f"WHERE wxyc_library_code_id IN ({code_placeholders})",
             requested,
         ).fetchall()
         code_to_graph: dict[int, int] = {r["wxyc_library_code_id"]: r["id"] for r in code_rows}
+        # Station play-affinity signal (#1702): the source artist's own all-time
+        # play count, keyed like `results` but present only for mapped ids.
+        # total_plays is NOT NULL DEFAULT 0, so the value is always an int.
+        source_plays = {str(r["wxyc_library_code_id"]): r["total_plays"] for r in code_rows}
     except sqlite3.OperationalError:
         code_to_graph = {}
 
@@ -569,7 +574,7 @@ def get_library_neighbors_batch(
                     break
         results[str(code_id)] = neighbors
 
-    return LibraryNeighborsBatchResponse(results=results)
+    return LibraryNeighborsBatchResponse(results=results, source_plays=source_plays)
 
 
 class DiscogsNeighborsBatchRequest(BaseModel):

--- a/semantic_index/api/schemas.py
+++ b/semantic_index/api/schemas.py
@@ -108,9 +108,18 @@ class LibraryNeighborsBatchResponse(BaseModel):
     items (``{artist_id, weight}``), weight-descending. Unknown, unmapped, and
     ambiguous (homonym) ids are present with an empty list rather than omitted,
     so the consumer can tell "asked, no neighbors" from "never asked".
+
+    ``source_plays`` is the station play-affinity signal (WXYC/Backend-Service#1702):
+    the requested source artist's own all-time WXYC play count (``artist.total_plays``),
+    keyed by the same requested library-artist-id strings as ``results``. Unlike
+    ``results``, it is present ONLY for ids that mapped to a graph artist —
+    unknown, unmapped, and ambiguous (homonym) ids are absent from the map rather
+    than carried with a zero. Additive (default ``{}``); consumers reading only
+    ``results`` are unaffected.
     """
 
     results: dict[str, list[SimilarArtist]]
+    source_plays: dict[str, int] = {}
 
 
 class DiscogsNeighborsBatchResponse(BaseModel):

--- a/tests/unit/test_api_library_neighbors.py
+++ b/tests/unit/test_api_library_neighbors.py
@@ -357,6 +357,8 @@ class TestDeployOrderDegradation:
             resp = await ac.post(ENDPOINT, json={"library_artist_ids": [1000], "limit": 5})
         assert resp.status_code == 200
         assert resp.json()["results"] == {"1000": []}
+        # The degrade branch yields no station-play signal either (#369).
+        assert resp.json()["source_plays"] == {}
 
     @pytest.mark.asyncio
     async def test_artist_detail_survives_missing_column(self, tmp_path) -> None:
@@ -372,3 +374,68 @@ class TestDeployOrderDegradation:
             resp = await ac.get(f"/graph/artists/{aid}")
         assert resp.status_code == 200
         assert resp.json()["wxyc_library_code_id"] is None
+
+
+def _build_source_plays_db(path: str) -> None:
+    """Build a fixture whose mapped source artists carry DISTINCT total_plays, so
+    a source_plays value can't pass by coincidentally matching a shared count.
+    Father John Misty (code 3000) has 812 plays, Stereolab (code 3001) has 337.
+    """
+    stats = {
+        "Father John Misty": make_artist_stats("Father John Misty", total_plays=812),
+        "Stereolab": make_artist_stats("Stereolab", total_plays=337),
+    }
+    export_sqlite(path, artist_stats=stats, pmi_edges=[], xref_edges=[], min_count=1)
+
+    conn = sqlite3.connect(path)
+    conn.execute(
+        "UPDATE artist SET wxyc_library_code_id = 3000 WHERE canonical_name = 'Father John Misty'"
+    )
+    conn.execute("UPDATE artist SET wxyc_library_code_id = 3001 WHERE canonical_name = 'Stereolab'")
+    conn.commit()
+    conn.close()
+
+
+class TestSourcePlays:
+    """source_plays carries each mapped source artist's own total_plays (#369)."""
+
+    @pytest_asyncio.fixture
+    async def sp_client(self, tmp_path) -> AsyncClient:
+        path = str(tmp_path / "source_plays.db")
+        _build_source_plays_db(path)
+        app = create_app(path)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            yield ac
+
+    @pytest.mark.asyncio
+    async def test_mapped_ids_carry_total_plays_unmapped_absent(
+        self, sp_client: AsyncClient
+    ) -> None:
+        # 3000/3001 map to graph artists; 999999 is unknown to the mapping.
+        resp = await sp_client.post(
+            ENDPOINT, json={"library_artist_ids": [3000, 3001, 999999], "limit": 20}
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        # Each mapped id carries its OWN total_plays, keyed by the request string.
+        assert body["source_plays"] == {"3000": 812, "3001": 337}
+        # Unknown id: present in results (empty list), ABSENT from source_plays —
+        # the two maps diverge on unmapped ids by design.
+        assert body["results"]["999999"] == []
+        assert "999999" not in body["source_plays"]
+
+    @pytest.mark.asyncio
+    async def test_results_shape_unchanged_by_source_plays(self, sp_client: AsyncClient) -> None:
+        # source_plays is additive: results still carries every requested id.
+        resp = await sp_client.post(
+            ENDPOINT, json={"library_artist_ids": [3000, 3001, 999999], "limit": 20}
+        )
+        assert resp.status_code == 200
+        assert set(resp.json()["results"].keys()) == {"3000", "3001", "999999"}
+
+    @pytest.mark.asyncio
+    async def test_empty_input_yields_empty_source_plays(self, sp_client: AsyncClient) -> None:
+        resp = await sp_client.post(ENDPOINT, json={"library_artist_ids": [], "limit": 20})
+        assert resp.status_code == 200
+        assert resp.json()["source_plays"] == {}


### PR DESCRIPTION
## What

Adds an additive `source_plays: dict[str, int]` field to the `POST /graph/library-artists/neighbors/batch` response, giving each requested-and-mapped source artist's `total_plays` alongside the existing neighbor `results` map.

This is the upstream compute for the On Tour "For You" **station play-affinity** tier ([WXYC/Backend-Service#1702](https://github.com/WXYC/Backend-Service/issues/1702)): the Backend `concerts-similar-artists-enrichment` job already calls this endpoint nightly for the exact in-library headliner cohort, so the station-play count rides the same call — no new endpoint, no extra query.

## How

- `schemas.py` — `source_plays: dict[str, int] = {}` on `LibraryNeighborsBatchResponse`, keyed by the same requested library-artist-id strings as `results`; present only for ids that mapped to a graph artist.
- `routes.py` — folds `total_plays` into the existing mapping `SELECT` (no extra round-trip); degrades to `{}` on the pre-#358 error path and on empty input.
- `docs/graph-api.md` — response example + field bullet updated (caught in review).
- Unit tests: mapped-ids-carry-plays, unmapped-absent, `results`-shape-unchanged, empty-input, degrade branch.

Additive and backward-compatible: `results` is byte-for-byte unchanged; the field defaults to `{}`.

## Validation

`pytest tests/unit/test_api_library_neighbors.py` → 25 passed · `ruff check`/`format` clean · `mypy semantic_index/` clean · pre-commit hook passed. High-effort review loop run to convergence.

Closes #369
