### PR TITLE
fix(docs): satisfy ruff format in the graph-api.md Python block

### DIFF
--- a/docs/graph-api.md
+++ b/docs/graph-api.md
@@ -12,6 +12,7 @@ Or programmatically:
 
 ```python
 from semantic_index.api.app import create_app
+
 app = create_app("data/wxyc_artist_graph.db")
 ```
 


### PR DESCRIPTION
## What was failing

The `lint` job runs `ruff check .` followed by `ruff format --check .`. The second command fails at `docs/graph-api.md:15`:

```
unformatted: File would be reformatted
  --> docs/graph-api.md:15:1
   |
14 | from semantic_index.api.app import create_app
15 +
16 | app = create_app("data/wxyc_artist_graph.db")
   |

1 file would be reformatted, 142 files already formatted
```

The Python code block under "Or programmatically" puts the `create_app(...)` call immediately after the import, and the formatter wants a blank line between the import block and the first statement.

## Why it was already red on main

This is pre-existing drift on `main`, not something any open branch introduced. Two things combined to hide it.

Ruff only began formatting Python code blocks inside Markdown in the 0.16 series, and `.github/workflows/ci.yml` installs ruff unpinned (`pip install ruff`). The runner moved from 0.15.x to 0.16.2 on its own and started checking a file that had never previously been in scope. Locally, ruff 0.15.2 reports `124 files already formatted` and sees nothing wrong; 0.16.2 reports 142 files and flags this one.

The same workflow sets `paths-ignore: ['**/*.md', 'docs/**']` on both its `push` and `pull_request` triggers, so the PR that added this code block never ran `lint`, and no subsequent build of `main` ran it either. `main` looked green the whole time. The failure only becomes visible on a PR that touches a non-doc file, because that PR triggers the workflow and `ruff format --check .` then walks the entire tree, docs included. Every such PR inherits a red `lint` job for a defect it did not cause, most recently #373.

## What changed

One added blank line in `docs/graph-api.md`. No prose, no code, no behavior. The formatter was run scoped to the single offending file rather than repo-wide, so the diff is exactly one line.

Verified against ruff 0.16.2, the version CI resolved: `ruff check .` and `ruff format --check .` both pass, and the format check now reports the same 142 files the failing CI run counted. `mypy semantic_index/` also passes.

## Note on checks for this PR

This PR touches only `docs/graph-api.md`, which `paths-ignore` excludes, so the CI workflow will not run here and the check list will be empty. That is the same configuration gap that let the drift land in the first place. The fix is verified locally against the exact CI commands and the exact ruff version the failing run resolved; the real confirmation is that #373 goes green once rebased onto `main` with this merged.

Two follow-ups are worth considering separately, and are deliberately out of scope here to keep this PR to one line: pinning ruff in `ci.yml` so a transparent upstream upgrade cannot turn `main` red without a commit, and narrowing `paths-ignore` so that `lint` still runs on doc-only changes now that ruff formats Markdown code blocks.